### PR TITLE
Proxy Support

### DIFF
--- a/calabash-cucumber/bin/calabash-ios-setup.rb
+++ b/calabash-cucumber/bin/calabash-ios-setup.rb
@@ -97,6 +97,15 @@ def calabash_download(args)
   download_calabash(File.expand_path("."))
 end
 
+def has_proxy?
+  ENV['http_proxy'] ? true : false
+end
+
+def proxy
+  url_parts = URI.split(ENV['http_proxy'])
+  [url_parts[2], url_parts[3]]
+end
+
 def download_calabash(project_path)
   file = 'calabash.framework'
   ##Download calabash.framework
@@ -109,7 +118,13 @@ def download_calabash(project_path)
 
       uri = URI.parse "http://cloud.github.com/downloads/calabash/calabash-ios/#{zip_file}"
       success = false
-      Net::HTTP.start(uri.host, uri.port) do |http|
+      if has_proxy?
+        proxy_url = proxy
+        connection = Net::HTTP::Proxy(proxy_url[0], proxy_url[1])
+      else
+        connection = Net::HTTP
+      end
+      connection.start(uri.host, uri.port) do |http|
         request = Net::HTTP::Get.new uri.request_uri
 
         http.request request do |response|


### PR DESCRIPTION
Hi,

We have to use the internet through a proxy, so all traffic has to go through it. I have changed the calabash-ios-setup.rb to support it through the $http_proxy shell variable so the download of the calabash framework automatically goes through any http proxy.

Matt
