### PR TITLE
Removed an unnecessary outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ examples/LPSimpleExample.xcodeproj/xcuserdata
 examples/LPSimpleExample.xcodeproj/project.xcworkspace/xcuserdata/krukow.xcuserdatad/UserInterfaceState.xcuserstate
 Markdown.pl
 examples_development
+*.swp
+*.gem

--- a/calabash-cucumber/lib/calabash-cucumber/calabash_steps.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/calabash_steps.rb
@@ -75,7 +75,7 @@ end
 
 # alias
 Then /^I fill in "([^\"]*)" with "([^\"]*)"$/ do |text_field, text_to_type|
-  When %Q|I enter "#{text_to_type}" into the "#{text_field}" text field|
+  macro %Q|I enter "#{text_to_type}" into the "#{text_field}" text field|
 end
 
 Then /^I use the native keyboard to enter "([^\"]*)" into the "([^\"]*)" (?:text|input) field$/ do |text_to_type, field_name|

--- a/calabash-cucumber/lib/calabash-cucumber/operations.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/operations.rb
@@ -93,8 +93,6 @@ module Operations
 
   def swipe(dir,options={})
       dir = dir.to_sym
-      print "rotation: #{@current_rotation}\n"
-      print "initial dir: #{dir} \n"
       @current_rotation = @current_rotation || :down
       if @current_rotation == :left
           case dir
@@ -123,7 +121,6 @@ module Operations
           else
           end
       end
-      print "final dir: #{dir} \n"
       playback("swipe_#{dir}",options)
   end
 
@@ -364,7 +361,7 @@ module Operations
     puts "Saved screenshot: #{path}"
     path
   end
-  
+
   def map( query, method_name, *method_args )
     operation_map = {
       :method_name => method_name,


### PR DESCRIPTION
Fixed [this issue](https://github.com/calabash/calabash-ios/issues/38).
'Then' replaced with 'Macro' at calabash_steps.rb:78.
Removed prints at rotation steps.
