### PR TITLE
Add code to look for the derived-data subdir based on the Xcode workspace name

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launch/simulator_helper.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launch/simulator_helper.rb
@@ -29,7 +29,7 @@ module Calabash
 
       def self.derived_data_dir_for_project
         dir = project_dir
-
+        xcode_workspace_name = ''
         info_plist = Dir.glob(DEFAULT_DERIVED_DATA_INFO).find { |plist_file|
           begin
             plist = CFPropertyList::List.new(:file => plist_file)
@@ -37,6 +37,9 @@ module Calabash
             ws_dir = File.dirname(hash['WorkspacePath']).downcase
             p_dir = dir.downcase
             ws_dir == p_dir
+            if (p_dir.include? ws_dir)
+              xcode_workspace_name = ws_dir.split('/').last
+            end
           rescue
             false
           end
@@ -60,6 +63,13 @@ module Calabash
             File.basename(xc_proj).start_with?(xcode_proj_name)
           end
 
+          if (build_dirs.count == 0 && !xcode_workspace_name.empty?)
+            # check for directory named "workspace-{deriveddirectoryrandomcharacters}"
+            build_dirs = Dir.glob("#{DERIVED_DATA}/*").find_all do |xc_proj|
+              File.basename(xc_proj).downcase.start_with?(xcode_workspace_name)
+            end
+          end
+          
           if (build_dirs.count == 0)
             msg = ["Unable to find your built app."]
             msg << "This means that Calabash can't automatically launch iOS simulator."


### PR DESCRIPTION
The Xcode xcodeproject.xcodeproj file within a repo's tree (or underneath a workspace) may not match names. And the directory that is built within derived, if within a workspace, will match the workspace name (workspace-randomchars) not the project name.

This patch is for when we are trying to launch the simulator. We note the Xcode workspace name. And when looping through subdirectories at the root of the deriveddata folder, if we cannot match based on the xcode project name, then we try to match based on the workspace name.

Note the need to constantly downcase comparison because OSX can have capitalized FS.
