### PR TITLE
Require rubygems in calabash-ios script

### DIFF
--- a/calabash-cucumber/bin/calabash-ios
+++ b/calabash-cucumber/bin/calabash-ios
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'rubygems'
 require 'fileutils'
 require 'cfpropertylist'
 require 'rexml/document'


### PR DESCRIPTION
This is necessary for Ruby 1.8 compatibility
