### PR TITLE
Don't extract Mac OS X resources from framework archive

### DIFF
--- a/calabash-cucumber/bin/calabash-ios-setup.rb
+++ b/calabash-cucumber/bin/calabash-ios-setup.rb
@@ -135,7 +135,7 @@ def download_calabash(project_path)
       end
       if success
         puts "\nDownload done: #{file}. Unzipping..."
-        if not system("unzip -C -K -o -q -d #{project_path} #{zip_file}")
+        if not system("unzip -C -K -o -q -d #{project_path} #{zip_file} -x __MACOSX/* calabash.framework/.DS_Store")
           msg("Error") do
             puts "Unable to unzip file: #{zip_file}"
             puts "You must install manually."


### PR DESCRIPTION
When running "calabash-ios download", the zip file that is downloaded contains an unneeded directory "__MACOSX" and an unneeded file ".DSStore". This patch changes the extraction process to exclude those files.
