### PR TITLE
Support for app launch args.

### DIFF
--- a/calabash-cucumber/features-skeleton/step_definitions/calabash_steps.rb
+++ b/calabash-cucumber/features-skeleton/step_definitions/calabash_steps.rb
@@ -1,1 +1,5 @@
 require 'calabash-cucumber/calabash_steps'
+
+Given /^(?:an )?arguments? (?:".*"\s*)+$/ do
+  # Do nothing here. This is a placeholder step.
+end

--- a/calabash-cucumber/features-skeleton/support/launch.rb
+++ b/calabash-cucumber/features-skeleton/support/launch.rb
@@ -43,7 +43,7 @@ def reset_app_jail(sdk, app_path)
   end
 end
 
-def relaunch
+def relaunch(args)
   if ENV['NO_LAUNCH']!="1"
     sdk = ENV['SDK_VERSION'] || SimLauncher::SdkDetector.new().latest_sdk_version
     path = Calabash::Cucumber::SimulatorHelper.app_bundle_or_raise(app_path)
@@ -51,7 +51,7 @@ def relaunch
       reset_app_jail(sdk, path)
     end
 
-    Calabash::Cucumber::SimulatorHelper.relaunch(path,sdk,ENV['DEVICE'] || 'iphone')
+    Calabash::Cucumber::SimulatorHelper.relaunch(path,sdk,ENV['DEVICE'] || 'iphone', args)
   end
 end
 
@@ -66,7 +66,8 @@ def calabash_notify
 end
 
 Before do |scenario|
-  relaunch
+  args = scenario.instance_variable_get("@steps").map(&:name).grep(/^(?:an )?arguments? (?:".*"\s*)+$/){|s| s.scan(/"([^"]+)"/) }.flatten
+  relaunch(args)
   calabash_notify
 end
 

--- a/calabash-cucumber/lib/calabash-cucumber/launch/simulator_helper.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launch/simulator_helper.rb
@@ -18,10 +18,10 @@ module Calabash
 
       DEFAULT_SIM_RETRY = 2
 
-      def self.relaunch(path, sdk = nil, version = 'iphone')
+      def self.relaunch(path, sdk = nil, version = 'iphone', args = nil)
 
         app_bundle_path = app_bundle_or_raise(path)
-        ensure_connectivity(app_bundle_path, sdk, version)
+        ensure_connectivity(app_bundle_path, sdk, version, args)
 
       end
 
@@ -169,7 +169,7 @@ module Calabash
         end
       end
 
-      def self.ensure_connectivity(app_bundle_path, sdk, version)
+      def self.ensure_connectivity(app_bundle_path, sdk, version, args = nil)
         begin
           max_retry_count = (ENV['MAX_CONNECT_RETRY'] || DEFAULT_SIM_RETRY).to_i
           timeout = (ENV['CONNECT_TIMEOUT'] || DEFAULT_SIM_WAIT).to_i
@@ -183,7 +183,7 @@ module Calabash
             puts "(#{retry_count}.) Start Simulator #{sdk}, #{version}, for #{app_bundle_path}"
             begin
               Timeout::timeout(timeout, TimeoutErr) do
-                simulator = launch(app_bundle_path, sdk, version)
+                simulator = launch(app_bundle_path, sdk, version, args)
                 until connected
                   begin
                     connected = (ping_app == '405')
@@ -229,10 +229,10 @@ module Calabash
       end
 
 
-      def self.launch(app_bundle_path, sdk, version)
+      def self.launch(app_bundle_path, sdk, version, args = nil)
         simulator = SimLauncher::Simulator.new
         simulator.quit_simulator
-        simulator.launch_ios_app(app_bundle_path, sdk, version)
+        simulator.launch_ios_app(app_bundle_path, sdk, version, args)
         simulator
       end
 


### PR DESCRIPTION
Sample given step for launch arguments look like this:

```
Given an argument "-JsonUrl" "http://example.org/api/content.json"
```

Those launch arguments are needed to be passed to the simulator launcher before any of steps' execution. So, the step definition is just a place holder.

It works, but ugly.
Do you have any other idea to do this? If do, I would appreciate rejection of the pull request.

Also, this requires https://github.com/moredip/Sim-Launcher/pull/10.
