### PR TITLE
Fix "calabash-ios setup <path>"

### DIFF
--- a/calabash-cucumber/bin/calabash-ios-setup.rb
+++ b/calabash-cucumber/bin/calabash-ios-setup.rb
@@ -187,14 +187,11 @@ def setup_project(project_name, project_path, path)
     end
   end
 
-
-  file = download_calabash(project_path)
+  download_calabash(project_path)
 
   msg("Info") do
     puts "Setting up project file for calabash-ios."
   end
-
-
 
   ##Backup
   msg("Info") do


### PR DESCRIPTION
This should fix issue #104

I confirmed that it does fix the issue I had, and also checked that the setup still works fine with no path supplied. In both cases the XCode target was set up correctly and the HTTP server notice appeared in the logs.
