### PR TITLE
changes the text field touch predefined step to search for text fields by 'placeholder' and by 'marked'

### DIFF
--- a/calabash-cucumber/features/step_definitions/calabash_steps.rb
+++ b/calabash-cucumber/features/step_definitions/calabash_steps.rb
@@ -53,7 +53,15 @@ Then /^I (?:press|touch) (?:input|text) field number (\d+)$/ do |index|
 end
 
 Then /^I (?:press|touch) the "([^\"]*)" (?:input|text) field$/ do |name|
-  touch("textField placeholder:'#{name}'")
+  placeholder_query = "textField placeholder:'#{name}'"
+  marked_query = "textField marked:'#{name}'"
+  if !query(placeholder_query).empty?
+    touch(placeholder_query)
+  elsif !query(marked_query).empty?
+    touch(marked_query)
+  else
+    screenshot_and_raise "could not find text field with placeholder '#{name}' or marked as '#{name}'"
+  end
   sleep(STEP_PAUSE)
 end
 


### PR DESCRIPTION
it is a  simple change and is backward compatible.

can be tested using:

https://github.com/jmoody/briar/tree/0.0.6
https://github.com/jmoody/briar-ios-example/tree/0.0.6

the relevant feature file in the ios example is:   Briar/features/calabash_pull_request_116.feature

test is currently failing pending the change
