### PR TITLE
Fix wait_for* post_timeout option.

### DIFF
--- a/calabash-jvm/src/calabash_jvm/wait.clj
+++ b/calabash-jvm/src/calabash_jvm/wait.clj
@@ -53,7 +53,7 @@
                     (fn [] (if-let [res (action)]
                             res
                             (sleep!)))))
-        (when (> 0 (:post_timeout opts))
+        (when (pos? (:post_timeout opts))
           (Thread/sleep (* 1000 (:post_timeout opts)))))))
 
 (defmacro wait_for


### PR DESCRIPTION
The condition to check for post_timeout > 0 was incorrect.
Fixed it with pos? check.
