### PR TITLE
added method to get accessibilityIdentifier (for i18n apps)

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/operations.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/operations.rb
@@ -55,7 +55,9 @@ module Calabash
         query(uiquery, :accessibilityLabel)
       end
 
-
+      def identifier(uiquery)
+        query(uiquery, :accessibilityIdentifier)
+      end
 
       def simple_touch(label, *args)
         touch("view marked:'#{label}'", *args)


### PR DESCRIPTION
I18n apps use **accessibilityIdentifier** instead of **accessibilityLabel**. A method to query the current accessibilityIdentifiers from calabash-ios console will be awesome :-)
