### PR TITLE
Moved launcher inside calabash_jvm folder.

### DIFF
--- a/calabash-jvm/project.clj
+++ b/calabash-jvm/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.firesofmay/calabash-jvm "0.0.5"
+(defproject calabash-jvm "0.0.5"
   :description "JVM client for calabash-ios-server for automated iOS functional testing"
   :url "https://github.com/calabash/calabash-ios"
   :repositories {"sonatype"

--- a/calabash-jvm/src/calabash_jvm/launcher.clj
+++ b/calabash-jvm/src/calabash_jvm/launcher.clj
@@ -2,6 +2,7 @@
       :author "Mayank Jain <mayank@helpshift.com>"}
   calabash-jvm.launcher
   (:require [me.raynes.conch :refer [programs with-programs let-programs]]
+            [calabash-jvm.env :as calenv]
             [clojure.data.json :as json]))
 
 ;;; Required for fresh-start-simulator & getting device details.
@@ -22,7 +23,7 @@
 (defn get-device-details-all
   "Returns a map of details"
   []
-  (json/read-json (curl (str calabash-jvm.env/*endpoint* "/version"))))
+  (json/read-json (curl (str calenv/*endpoint* "/version"))))
 
 (defn get-device-details-app-id
   "Returns app-id"


### PR DESCRIPTION
There were some issues with requiring launcher.clj namespace. I've fixed that in this commit. Will test changes before I push them.
