### PR TITLE
allow specifying target UDID in environment variable

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -68,6 +68,7 @@ class Calabash::Cucumber::Launcher
 
     if device_target?
       default_args = {:app => ENV['BUNDLE_ID']}
+      default_args[:udid] = ENV['UDID_TARGET'] if ENV['UDID_TARGET']
       self.run_loop = RunLoop.run(default_args.merge(args))
     else
 


### PR DESCRIPTION
We have an environment where we have multiple devices connected to the same machine. This allows targeting of a specific device.
