### PR TITLE
adds scroll_to_row_with_mark to provide 'core' support for new server operation :scrollToRowWithMark

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -190,6 +190,31 @@ module Calabash
         views_touched
       end
 
+
+      def scroll_to_row_with_mark(row_id, options={:query => 'tableView',
+                                                   :scroll_position => :middle,
+                                                   :animate => true})
+        uiquery = options[:query] || 'tableView'
+
+        args = []
+        if options.has_key?(:scroll_position)
+          args << options[:scroll_position]
+        else
+          args << 'middle'
+        end
+        if options.has_key?(:animate)
+          args << options[:animate]
+        end
+
+        views_touched=map(uiquery, :scrollToRowWithMark, row_id, *args)
+
+        if views_touched.empty? or views_touched.member? '<VOID>'
+          msg = options[:failed_message] || "Unable to scroll: '#{uiquery}' to: #{options}"
+          screenshot_and_raise msg
+        end
+        views_touched
+      end
+
       def pinch(in_out, options={})
         file = "pinch_in"
         if in_out.to_sym==:out


### PR DESCRIPTION
allows testers to scroll to a row with 'mark'

supports searching for cells by:
- accessibilityIdentifier (iOS 5+)
- accessibilityLabel
- subviews in the cell's contentView that match:
- accessibilityIdentifier (iOS 5+)
- accessibilityLabel
- text (UILabel and UITextView)

see https://github.com/calabash/calabash-ios-server/pull/18
see https://github.com/calabash/calabash-ios/issues/128
see https://github.com/calabash/calabash-ios-server/pull/17
