### PR TITLE
Added quotes to file paramter in call to system() 

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -399,7 +399,7 @@ EOF
 
         file_name = "#{file_name}_#{os}_#{device}.base64"
         system("/usr/bin/plutil -convert binary1 -o _recording_binary.plist _recording.plist")
-        system("openssl base64 -in _recording_binary.plist -out #{file_name}")
+        system("openssl base64 -in _recording_binary.plist -out '#{file_name}'")
         system("rm _recording.plist _recording_binary.plist")
         file_name
       end


### PR DESCRIPTION
Added single quotes around filename parameter in system call for base64 encoding. This addresses https://github.com/calabash/calabash-ios/issues/167
