### PR TITLE
renamed the rake tasks for building the server to be compatible with Bundler::GemHelper install/build/release

### DIFF
--- a/calabash-cucumber/Rakefile
+++ b/calabash-cucumber/Rakefile
@@ -56,7 +56,9 @@ EOF
 
 end
 
-task :build => [:build_server]
-task :install => [:build_server]
-task :release => [:build_server]
+task :build_server => [:build_server]
+task :install_server => [:build_server]
+task :release_server => [:build_server]
+
+
 


### PR DESCRIPTION
it is often convenient (or necessary) to build calabash-cucumber gem locally.

using the Bundler::GemHelper you would:

`rake install`

however, the `Rakefile` overrides the `install` task with `build_server` which is not ideal.

will probably break some build scripts.
