### PR TITLE
'calabash-ios console' command now tries find local .irbrc before falling back to the .irbrc in the calabash-cucumber/scripts directory

### DIFF
--- a/calabash-cucumber/bin/calabash-ios-build.rb
+++ b/calabash-cucumber/bin/calabash-ios-build.rb
@@ -47,6 +47,11 @@ end
 def console
   path = ENV['CALABASH_IRBRC']
   unless path
+    if File.exist?('.irbrc')
+      path = File.expand_path('.irbrc')
+    end
+  end
+  unless path
     path = File.expand_path(File.join(@script_dir,".irbrc"))
   end
   ENV['IRBRC'] = path


### PR DESCRIPTION
i have many iOS projects using calabash.  in each one i use a custom '.irbrc' file - each project has a slightly different file. 

i really dislike having to type:  `CALABASH_IRBRC=.irbrc calabash-ios console`  when i want to drop into the irb.

the other option is to maintain a separate `irb.sh` for each project (which is my current solution), but that is just one more file to futz about with.

this is order in which the `IRBRC` is set:
1. `CALABASH_IRBRC` 
2. `./.irbrc` if it exists
3. the `.irbrc` file in the calabash-cucumber/scripts directory
