### PR TITLE
fix for 'Playback not found: touch_done_ios7_iphone.base64' when testing against iOS 5 + 6 targets with 'OS=ios7'

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -393,9 +393,14 @@ EOF
         recording = recording_name_for(recording_name, os, device)
         data = load_recording(recording, rec_dir)
 
-        if data.nil? and os=="ios6"
-          recording = recording_name_for(recording_name, "ios5", device)
+        version_counter = os[-1,1].to_i
+        loop do
+          version_counter = version_counter - 1
+          break if version_counter < 5
+          loop_os = "ios#{version_counter}"
+          recording = recording_name_for(recording_name, loop_os, device)
           data = load_recording(recording, rec_dir)
+          break if !data.nil?
         end
 
         if data.nil? and device=='ipad'


### PR DESCRIPTION
**NB: this does _not_ fix playback on iOS 7.**

**problem description**

in order to test _at all_ on iOS 7, you need to set `OS=ios7`.  

when you are testing against iOS 5 or 6 targets, you should not have to change the `OS` variable.  this is the way it has worked for iOS 5 and 6 (and maybe 4).  

before this fix, `load_playback_data` attempted to load the wrong playback file.

for example, when running against a iOS 6 target with `OS=ios7` the `keyboard_enter_text "some text"` fails with this message:

`RuntimeError: Playback not found: touch_done_ios7_iphone.base64`

`load_playback_data` now tries to load an iOS 7 playback file (there are none), then an iOS 6 file, and finally falls back to an iOS 5 file. 
