### PR TITLE
updates the Calabash::Cucumber::Device class for Xcode 5 and iOS 7

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -72,6 +72,10 @@ module Calabash
         version_hash(ios_version)[:major_version]
       end
 
+      def ios7?
+        ios_major_version.eql?('7')
+      end
+
       def ios6?
         ios_major_version.eql?('6')
       end


### PR DESCRIPTION
- adds `ios7?` method
- fixes `iphone_5?` method for Xcode 5 simulator (device syntax changed)

this fix is compatible with Xcode 4 simulator(s) and devices.

NOT TESTED ON physical iPhone 5 - i don't have one.  if you send me one, i will do this test. :)
