### PR TITLE
record_end now accepts names with spaces

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -484,7 +484,7 @@ EOF
 
         file_name = "#{file_name}_#{os}_#{device}.base64"
         system("/usr/bin/plutil -convert binary1 -o _recording_binary.plist _recording.plist")
-        system("openssl base64 -in _recording_binary.plist -out #{file_name}")
+        system("openssl base64 -in _recording_binary.plist -out '#{file_name}'")
         system("rm _recording.plist _recording_binary.plist")
         file_name
       end


### PR DESCRIPTION
for example:

```
> record_end "foo bar"
"foo bar_ios6_iphone.base64"
```

fixes https://github.com/calabash/calabash-ios/issues/167 and replaces https://github.com/calabash/calabash-ios/pull/168

@gardner thanks for the pull request!   i believe it should have been made against the 0.9.x branch and not the master branch.
