### PR TITLE
Device iphone_5? method crashes when called on iPad devices

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -55,7 +55,7 @@ module Calabash
 
       def iphone_5?
         if simulator?
-          simulator_details.split(/[(),]/)[3].split(/ /).last.eql? GESTALT_IPHONE5
+          !simulator_details.scan(GESTALT_IPHONE5).empty?
         else
           system.split(/[\D]/).delete_if { |x| x.eql?('') }.first.eql?('5')
         end


### PR DESCRIPTION
i goofed and did not test completely.  

fixes https://github.com/calabash/calabash-ios/pull/177 for iPad simulator targets
