### PR TITLE
issue 151: general clean up of text field input and disabled keyboard_enter_text for iOS 7

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -93,8 +93,11 @@ module Calabash
       end
 
       def keyboard_enter_text(text)
+        # check for iOS 7 - ATM this will send the app into an infinite loop
+        if ENV['OS']=='ios7' || @calabash_launcher && @calabash_launcher.ios_major_version == "7"
+          pending "'keyboard_enter_text' is not available for iOS 7 (yet)"
+        end
         fail("No visible keyboard") if element_does_not_exist("view:'UIKBKeyplaneView'")
-
         text.each_char do |ch|
           begin
             keyboard_enter_char(ch, false)

--- a/calabash-cucumber/lib/calabash-cucumber/operations.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/operations.rb
@@ -82,6 +82,12 @@ module Calabash
         text_fields_modified
       end
 
+      def clear_text(uiquery)
+        views_modified = map(uiquery, :setText, '')
+        screenshot_and_raise "could not find text field #{uiquery}" if views_modified.empty?
+        views_modified
+      end
+
 
       def set_user_pref(key, val)
         res = http({:method => :post, :path => 'userprefs'},


### PR DESCRIPTION
### POTENTIAL BREAKING CHANGES: the predefined steps for text fields:
1. no longer call set_text - they call keyboard_enter_text
2. they first try to touch the text field indicated by the arguments
   and wait for the keyboard before they try to enter text
### IMPORTANT

`keyboard_enter_text` now throws a `pending` exception on iOS 7 because using it on that OS causes the app to enter an infinite loop
### Motivation

https://github.com/calabash/calabash-ios/issues/151

the `set_text` function is marked as deprecated, but it is still used in many predefined steps.  the motivation behind the deprecation is sound:  we want people to migrate to `keyboard_enter_text`.  however, there are still times when you want to clear the text from a text field or text view.  to meet this need, i added `clear_text`.  

since we want people to stop using `set_text`, i rewrote the predefined steps to use `keyboard_enter_text` and `clear_text`.  the predefined steps will also touch now touch the correct text field and wait for the keyboard, which will obviate the need to write additional steps like:

```
Then I touch the "password" text field
# for keyboard animation
Then I wait 
```

before a step like:

```
Then I enter "pa$$w0rd" into text field number 2
```

tested on briar-ios-example 0.0.8 - https://github.com/jmoody/briar-ios-example/tree/0.0.8 
