### PR TITLE
0.9.x add git versioning information

### DIFF
--- a/calabash-cucumber/Rakefile
+++ b/calabash-cucumber/Rakefile
@@ -22,17 +22,26 @@ EOF
     end
 
     FileUtils.cd(dir) do
+      
+      pwd = FileUtils.pwd
+      cmd = "#{pwd}/calabash/gitversioning-before.sh #{pwd}/calabash/LPGitVersionDefines.h"
+      puts cmd
+      `#{cmd}`
+      
       puts 'Building Server'
       cmd = 'xcodebuild build -project calabash.xcodeproj -target Framework -configuration Debug -sdk iphonesimulator7.0'
       puts cmd
       puts `#{cmd}`
 
+      cmd = "#{pwd}/calabash/gitversioning-after.sh #{pwd}/calabash/LPGitVersionDefines.h"
+      puts cmd
+      `#{cmd}`
+      
       unless File.exist?(FRAMEWORK)
         raise 'Unable to build framework'
       end
 
       puts "Zipping down framework"
-
 
       zip_cmd = "zip -q -r #{ZIP_FILE} #{FRAMEWORK}"
       puts zip_cmd


### PR DESCRIPTION
companion to server pull request https://github.com/calabash/calabash-ios-server/pull/25

modifies rake task `:build_server` to call server versioning scripts before and after `xcodebuild` call.

```
> server_version
{
   <snip>      
   "git branch" => "0.9.x-add-git-versioning-information",
   "git revision" => "e1abd85",
   <snip>
}
```
#### Motivation

the `server_version` route does not provide enough information about what version of the server is installed on an .ipa.
- when developing features for the server where you might testing and developing several feature branches at once over several days
- when you are presented with a stand-alone ipa and you what to know exactly what features are available in the installed framework
