### PR TITLE
iOS 7 touches work in orientation 'up' and rotate function works when orientation is 'face up' or 'face down'

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/ios7_operations.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/ios7_operations.rb
@@ -27,7 +27,7 @@ module Calabash
       end
 
       def normalize_rect_for_orientation(rect)
-        orientation = device_orientation.to_sym
+        orientation = device_orientation(true).to_sym
         launcher = Calabash::Cucumber::Launcher.launcher
         screen_size = launcher.device.screen_size
         case orientation
@@ -39,6 +39,11 @@ module Calabash
             cx = rect['center_x']
             rect['center_x'] = screen_size[:height] - rect['center_y']
             rect['center_y'] = cx
+          when :up
+            cy = rect['center_y']
+            cx = rect['center_x']
+            rect['center_y'] = screen_size[:height] - cy
+            rect['center_x'] = screen_size[:width]  - cx
           else
             # no-op by design.
         end

--- a/changelog/0.9.159.md
+++ b/changelog/0.9.159.md
@@ -1,0 +1,22 @@
+### 0.9.159 changelog
+
+* (pull 195/24) adds support for manipulating UIDatePickers with LPDatePickerOperation
+  - calabash-cucumber:    https://github.com/calabash/calabash-ios/pull/195
+  - calabash-ios-server:  https://github.com/calabash/calabash-ios-server/pull/24
+  
+* (pull 214/issue 212) predefined step: 'wait to see a navigation bar title' now distinguishes btw navbar title and navbar buttons
+  - thanks to Stefan van den Oord @svdo
+  - https://github.com/calabash/calabash-ios/issues/212
+  - https://github.com/calabash/calabash-ios/pull/214
+  
+* (pull 213) Basic iOS7 Rotation support
+  - thanks to Dennis Riis @driis 
+  - https://github.com/calabash/calabash-ios/pull/213
+  
+* (pull 216/25) adds git revision and branch information to output of server_output
+  - https://github.com/calabash/calabash-ios-server/pull/25
+  - https://github.com/calabash/calabash-ios/pull/216
+  
+* (pull 217) in iOS 7 touches now work when the device is in the 'up' orientation and the rotate function now works when the device is 'face up' or 'face down'
+  - https://github.com/calabash/calabash-ios/pull/216
+  


### PR DESCRIPTION
#### fixes iOS 7 touches when device orientation is 'up'

extends the work by @driis by adding support for touching things when the device home button is in the 'up' position.  see https://github.com/calabash/calabash-ios/pull/213 for more details.
#### fixes rotation when device orientation is 'face up' or 'face down'

the `device_orientation(force=false)` function now checks to see if the device 'face up' or 'face down'.

typically, a device is `'face up'` or `'face down'` when laying on a table.  when the device is upright, the device orientation is one of: `{up | down | left | right}.`

if `device_orientation(true)` is called and `'face up'` or `'face down'` is detected, the system will attempt to rotate the device to the `'down'` orientation.

the `rotate` function capitalizes on this change by forcing a `'down'` orientation if 'face up' or 'face down' is detected. 
#### testing

tested using briar gem and Briar-cal on the 0.0.9 branches
- https://github.com/jmoody/briar  
- https://github.com/jmoody/briar-ios-example 

use the @rotation tag to test just rotations
- bundle exec cucumber -p launch -p iphone  --tags @rotation
- bundle exec cucumber -p launch -p ipad    --tags @rotation
##### simulator
- [x] be cucumber -p launch -p iphone --tags @rotation
- [x] be cucumber -p launch -p ipad --tags @rotation
##### iOS 6 iPhone 4S
- [x] be cucumber -p neptune_launch --tags @rotation
- [x] be cucumber -p neptune        --tags @rotation
##### iOS 5 iPad 1 (launching instruments not supported)
- [x] be cucumber -p pluto   --tags @rotation
#### known issues

while testing, we discovered two bugs in UIAutomation.

the two problems are very similar but are two seperate issues.

in both cases, the 'Cancel' navigation bar button cannot be touched in some device + orientation combinations.
##### on "compose email" views UIAutomation cannot touch 'Cancel' button in 'left' or 'right' orientation

seen on iOS 6 and iOS 7 devices and simulators in the `left` and `right` orientations

to reproduce
1. build Briar-cal > 0.0.9 for any device
2. launch a calabash console for the device
3. `> start_test_server_in_background`
4. should see the 'First View'
5. `> rotate_home_button_to 'left'`
6. `> uia_tap_mark('show email')`
7. `> uia_tap_mark('Cancel')`

expected: to tap the Cancel button
found: TypeError: exception class/object expected
###### notes

the extended error from the `uia_tap_mark` is:

```
{"status"=>"error", "value"=>"VerboseError: tap point is not within the bounds of the screen
```

`uia_query` can find the Cancel button

```
> uia_query(:view, marked:'Cancel') ==>

[
    [0] {
             "name" => "Cancel",
             "rect" => {
                 "x" => 16,
                 "y" => 24,
            "height" => 24,
             "width" => 54
        },
        "hit-point" => {
            "x" => 36,
            "y" => 437
        },
               "el" => {},
            "label" => "Cancel"
    }
]
```
##### on "compose email" view UIAutomation cannot touch 'Cancel' button in 'up' orientation on iPad

seen on iOS 7 iPad simulator in the `up` orientation

to reproduce
1. build Briar-cal > 0.0.9 for iPad
2. launch a calabash console for the iPad
3. `> start_test_server_in_background`
4. should see the 'First View'
5. `> rotate_home_button_to 'up'`
6. `> uia_tap_mark('show email')`
7. `> uia_tap_mark('Cancel')`

expected: the `uia_tap_mark` to touch the Cancel button
found: the `uia_tap_mark` touches the email body (causing the keyboard to show)
