### PR TITLE
Added DETECT_CONNECTED_DEVICE environment variable to launcher

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -105,7 +105,7 @@ class Calabash::Cucumber::Launcher
   end
 
   def detect_connected_device?
-      return ENV['DETECT_CONNECTED_DEVICE'] != 'false'
+      return ENV['DETECT_CONNECTED_DEVICE'] != '0'
   end
 
   def default_launch_method


### PR DESCRIPTION
Some Ruby implementation like JRuby has trouble executing a process in the `Timeout::timeout()`. JRuby won't throw the exception and hangs until the process returns.

In Calabash launcher, it detects the connected devices by executing the external process: `udidetect`. udidetect hangs when there are no devices connected. Calabsh launcher executes udidetect in a Timeout and when it
times out, calabash kills the `udidetect` process.

In Jruby, because of a JRuby bug, this causes the process to wait until the launched process exits. TimeoutError is never fired.

This commit introduces an environment variable `DETECT_CONNECTED_DEVICE` which can be used to turn on/off device detection. By default device detection is on.
