### PR TITLE
add done after native keyboard input to dismiss the keyboard

### DIFF
--- a/calabash-cucumber/features/step_definitions/calabash_steps.rb
+++ b/calabash-cucumber/features/step_definitions/calabash_steps.rb
@@ -120,6 +120,7 @@ Then /^I use the native keyboard to enter "([^\"]*)" into the "([^\"]*)" (?:text
   touch("textField placeholder:'#{field_name}'")
   await_keyboard
   keyboard_enter_text(text_to_type)
+  done
   sleep(STEP_PAUSE)
 end
 
@@ -141,6 +142,7 @@ Then /^I use the native keyboard to enter "([^\"]*)" into (?:input|text) field n
   touch("textField index:#{index-1}")
   await_keyboard
   keyboard_enter_text(text_to_type)
+  done
   sleep(STEP_PAUSE)
 end
 


### PR DESCRIPTION
Native keyboard needs to be dismissed after entering the text. 

If not dismissed and there is a button right behind the keyboard, and the next step is touching that button, Calabash will touch the location of that button. But because keyboard is still there, Calabash will actually touch another letter on the keyboard (which has a same location of the button), instead of touching the right button.

This affects all keyboard_enter_ text related step definitions, including those on 0.9.x.
