### PR TITLE
0.9.x touch_ios7 should not force an orientation when orientation is 'unknown'

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/ios7_operations.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/ios7_operations.rb
@@ -27,7 +27,7 @@ module Calabash
       end
 
       def normalize_rect_for_orientation(rect)
-        orientation = device_orientation(true).to_sym
+        orientation = device_orientation().to_sym
         launcher = Calabash::Cucumber::Launcher.launcher
         screen_size = launcher.device.screen_size
         case orientation

--- a/changelog/0.9.159.md
+++ b/changelog/0.9.159.md
@@ -20,3 +20,10 @@
 * (pull 217) in iOS 7 touches now work when the device is in the 'up' orientation and the rotate function now works when the device is 'face up' or 'face down'
   - https://github.com/calabash/calabash-ios/pull/216
   
+* (pull 220) Added DETECT_CONNECTED_DEVICE environment variable to launcher to fix a problem with JRuby timeouts
+  - thanks to @navaneeth
+  - https://github.com/calabash/calabash-ios/pull/220
+  
+* (pull 222) touch_ios7 should not force rotation to the 'down' orientation
+  - https://github.com/calabash/calabash-ios/pull/222
+  


### PR DESCRIPTION
### previous behavior

the `device_orientation()` function returns `unknown` _if and only if_
1. the command is run on the iOS Simulator
2. the simulator has not been rotated since it was launched

the `touch_ios7()` function must translate the touch coordinates for orientations other than `down`.

if the orientation was `unknown`, the `touch_ios7()` function was forcing the orientation to `down` so that the touch coordinates were guaranteed to be correct.
### the problem

this is not desirable behavior because it causes an unnatural rotation - one that the user would never do.
### new behavior

the `touch_ios()` function will now only translate touch coordinates for these orientations:
- `left`
- `right`
- `up`

if the device orientation is `unknown`, the touch coordinates will not be translated.  

this new behavior could cause problems for some users.
### potential problems

the simulator will launch in the orientation that it was last in.  

this can lead to cases were a Scenario leaves the simulator in a particular orientation - you can visually see that the simulator is rotated to the orientation - but the `device_orientation()` function returns `unknown`.

on iOS 7, subsequent steps that use `touch` will fail because the touch coordinates will not be translated.

if you find yourself in this position, the work around is simple.

call `rotate_home_button_to({up|down|left|right})` before the touch, in the `Background`, or in a `Before` hook.
### related
- [new orientation route #22](https://github.com/calabash/calabash-ios-server/pull/22)
- [@driis support for iOS 7 rotation 213](https://github.com/calabash/calabash-ios/pull/213)
- [rotation when orientation is 'face up' or 'face down' 218](https://github.com/calabash/calabash-ios/pull/218)
