### PR TITLE
Allow path with spaces to be passed to 'calabash-ios setup' command

### DIFF
--- a/calabash-cucumber/bin/calabash-ios-setup.rb
+++ b/calabash-cucumber/bin/calabash-ios-setup.rb
@@ -93,7 +93,7 @@ def download_calabash(project_path)
       zip_file = File.join(@framework_dir,"calabash.framework.zip")
 
       if File.exist?(zip_file)
-        if not system("unzip -C -K -o -q -d #{project_path} #{zip_file} -x __MACOSX/* calabash.framework/.DS_Store")
+        if not system("unzip -C -K -o -q -d '#{project_path}' '#{zip_file}' -x __MACOSX/* calabash.framework/.DS_Store")
           msg("Error") do
             puts "Unable to unzip file: #{zip_file}"
             puts "You must install manually."


### PR DESCRIPTION
In the command for unzipping calabash.framework into the project path, I've enclosed the project_path parameter in quotes in case a path with spaces is passed to the 'calabash-ios setup' command.  (I also puts quotes around the zip_file parameter in case the path to calabash.framework ever has a space in it for some reason).
