### PR TITLE
replaced 'device_orientation' with 'status_bar_orientation' for detecting orientation of device when rotating, translating touch coordinates, and swiping.

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/ios7_operations.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/ios7_operations.rb
@@ -27,7 +27,7 @@ module Calabash
       end
 
       def normalize_rect_for_orientation(rect)
-        orientation = device_orientation().to_sym
+        orientation = status_bar_orientation().to_sym
         launcher = Calabash::Cucumber::Launcher.launcher
         screen_size = launcher.device.screen_size
         case orientation

--- a/calabash-cucumber/lib/calabash-cucumber/operations.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/operations.rb
@@ -38,7 +38,7 @@ module Calabash
       end
 
       def home_direction
-        device_orientation().to_sym
+        status_bar_orientation.to_sym
       end
 
       def assert_home_direction(expected)

--- a/changelog/0.9.161.md
+++ b/changelog/0.9.161.md
@@ -3,5 +3,14 @@
 * (pull 224) fixes bug in 'send app to background' predefined step
   - thanks @ThersaP Thersa Peters 
   - https://github.com/calabash/calabash-ios/pull/224
+
+* (pull 26) adds a LPSliderOperation to ease the pain of interacting with UISliders
+  - https://github.com/calabash/calabash-ios-server/pull/26
   
-  
+* (pull 226) Allow path with spaces to be passed to 'calabash-ios setup' command
+  - thanks @cdstone 
+  - https://github.com/calabash/calabash-ios/pull/226
+
+* (pull 230) replaced 'device_orientation' with 'status_bar_orientation' detecting orientation of device  
+  - https://github.com/calabash/calabash-ios/pull/230
+


### PR DESCRIPTION
### motivation

the `device_orientation` function returns `{face up, face down, up, down, left, right, unknown}`.

this is confusing to users because:
1. `face up` and `face down` are only returned if testing on a device and if the device has not been previously rotated by calabash.
2. `unknown` is only returned if testing on the simulator and if the simulator has not been previously rotated by calabash.

in contrast, the `status_bar_orientation` only returns `{up, down, left, right}`
### testing

**_NB:**_ cannot test swiping on iOS Simulator because of an [Apple bug in the simulator](http://stackoverflow.com/questions/18792965/uiautomations-draginsidewithoptions-has-no-effect-on-ios7-simulator).

testing revealed an unrelated bug in iOS 7 swiping.

tested using briar gem and Briar-cal 
- 0.1.1 branch -- https://github.com/jmoody/briar 
- 0.1.2 branch -- https://github.com/jmoody/briar-ios-example  

testing against an app without a status bar:  https://github.com/jmoody/calabash-no-status-bar

use the `@rotation` tag to test
- `bundle exec cucumber -p launch -p iphone  --tags @rotation`
- `bundle exec cucumber -p launch -p ipad    --tags @rotation`
#### devices and simulators
- [x] iOS 6 iPhone 4S
- [ ] iOS 7 iPhone 5C `swiping broken`
- [x] iOS 5.1 iPad 1
- [ ] iOS 7.0 iPad 4  `swiping broken`
- [x] all simulator combinations
- [x] UIA launching (when supported)
- [x] manually launching (when supported)
#### other tests
- [x] on an app with no status bar
### KNOWN ISSUES

on iOS 7 swiping is broken for any orientation other than portrait with the home button down.  

this is an unrelated bug that was discovered during testing. 

https://github.com/calabash/calabash-ios/issues/230
