### PR TITLE
Calabash Multi-Device Extension

### DIFF
--- a/calabash-cucumber/features/step_definitions/calabash_steps.rb
+++ b/calabash-cucumber/features/step_definitions/calabash_steps.rb
@@ -469,3 +469,20 @@ Then(/^I change the date picker date to "([^"]*)" at "([^"]*)"$/) do |date_str, 
   macro %Q|I change the date picker time to "#{time_str}"|
   macro %Q|I change the date picker date to "#{date_str}"|
 end
+
+# Multiple device support
+Then /^I use device ([a-zA-Z0-9.:\/]+)$/ do |device_number|
+  set_current_device_number(device_number)
+end
+
+Then /^on device ([a-zA-Z0-9.:\/]+) do:$/ do |device_number|
+  set_current_device_number(device_number)
+end
+
+Then /^I use default device$/ do
+  set_current_device_number(nil)
+end
+
+Then /^on default device do:$/ do
+  set_current_device_number(nil)
+end 

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -714,9 +714,18 @@ EOF
         res
       end
 
+      def set_current_device_number(current_device_number)
+         $current_device_number = current_device_number
+      end
 
       def url_for(verb)
-        url = URI.parse(ENV['DEVICE_ENDPOINT']|| "http://localhost:37265")
+        if $current_device_number.nil?
+          # used for single device tests
+          url = URI.parse(ENV["DEVICE_ENDPOINT"] || "http://localhost:37265")
+        else
+          # used for multiple device tests
+          url = URI.parse(ENV["DEVICE_ENDPOINT_#{$current_device_number}"])
+        end
         path = url.path
         if path.end_with? "/"
           path = "#{path}#{verb}"


### PR DESCRIPTION
This is an extension we have applied to test multiple (physical) devices against each other (we only do this in iOS) in a single Calabash test. To use this technique you can add the devices via USB, then build & start the Calabash Server apps on both (all) devices and finally run the tests on your host computer via Ethernet / WiFi. 

In order to use our extension, you e.g. have to add these variables to the cucumber command:

```
DEVICE_ENDPOINT_1=192.168.13.1:37265 DEVICE_ENDPOINT_2=192.168.14.1:37265 cucumber
```

And then you can extend your test by writing:

```
Then on device 1 do:
  Then I see „No connected device"
Then on device 2 do:
  Then tap „connect"
  Then wait 3 seconds
Then on device 1 do:
  Then I see „Device has connected"`
```

Hint: Instead of the command line variable `DEVICE_ENDPOINT_1` you can also choose a more descriptive name (e.g. `DEVICE_ENDPOINT_IPAD`) and write this name then also in the test (`Then on device IPAD do:`).
