### PR TITLE
Fixed Issue #194 bug that caused some character not to be typable when they were in the first-alternate or second-alternate keyplane

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -72,15 +72,20 @@ module Calabash
           known = KEYPLANE_NAMES.values
 
           found = false
-          ["shift", "more"].each do |key|
+          keyplane_selection_keys = ["shift", "more"]
+          keyplane_selection_keys.each do |key|
             plane = props["#{key}-alternate"]
-            if (known.member?(plane) and
-                not visited.member?(plane))
+            if (known.member?(plane) and  
+            not visited.member?(plane))
               keyboard_enter_char(key.capitalize, false)
               found = search_keyplanes_and_enter_char(chr, visited)
               return true if found
-              #not found => go back
-              keyboard_enter_char(key.capitalize, false)
+              #not found => try with other keyplane selection key
+              keyplane_selection_keys.delete(key)
+              other_key = keyplane_selection_keys.last
+              keyboard_enter_char(other_key.capitalize, false)
+              found = search_keyplanes_and_enter_char(chr, visited)
+              return true if found
             end
           end
           return false


### PR DESCRIPTION
The search_keyplanes_and_enter_char() method in keyboard_helpers.rb was
unable to reach all typable characters due to a bug that caused it to
select the "shift" key repeatedly instead of using the "more" key
followed by the "shift" key to reach the second-alternate keyplane
where the characters are located.
