### PR TITLE
Fixed the linked_with_calabash method to properly find the right binary linked with calabash.

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -738,6 +738,11 @@ EOF
         end
       end
 
+      def shutdown_test_server
+        # Compat with Calabash Android
+        stop_test_server
+      end
+
       def default_device
         @calabash_launcher && @calabash_launcher.device
       end

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -131,7 +131,21 @@ class Calabash::Cucumber::Launcher
   end
 
   def detect_connected_device?
+    if ENV['DETECT_CONNECTED_DEVICE'] == '1'
+      return true
+    end
+
+    if ENV['BUNDLE_ID'].nil? && ENV['DETECT_CONNECTED_DEVICE'].nil?
+      return false
+    end
+    if ENV['BUNDLE_ID'] && ENV['DETECT_CONNECTED_DEVICE'].nil?
+      return true
+    end
+    if ENV['DETECT_CONNECTED_DEVICE']
       return ENV['DETECT_CONNECTED_DEVICE'] != '0'
+    end
+
+    return false
   end
 
   def default_launch_method

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -1,6 +1,6 @@
 module Calabash
   module Cucumber
-    VERSION = '0.9.163.pre3.2'
+    VERSION = '0.9.163.pre4.1'
     FRAMEWORK_VERSION = '0.9.163.pre3'
   end
 end


### PR DESCRIPTION
otool doesnt really work on the directory, it has to be on a file-by-file bases. This will greatly improve the issues of finding the path for APP_BUNDLE_PATH.
