### PR TITLE
fixes ruby < 2.0 compatibility problems in 0.9.163

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
@@ -138,7 +138,6 @@ module Calabash
       end
 
 
-
       # prints a deprecated message that includes the line number
       #   +version+ string indicating when the feature was deprecated
       #   +msg+ deprecation message (possibly suggesting alternatives)
@@ -154,13 +153,20 @@ module Calabash
 
         unless no_deprecation_warnings?
 
-          stack = Kernel.caller(0, 6)[1..-1].join("\n")
+
+          if RUBY_VERSION < '2.0'
+            stack = Kernel.caller()[1..6].join("\n")
+          else
+            stack = Kernel.caller(0, 6)[1..-1].join("\n")
+          end
+
           msg = "deprecated '#{version}' - '#{msg}'\n#{stack}"
 
           if type.eql?(:pending)
             pending(msg)
           else
             # todo deprecated function does not output on a new line when called within cucumber
+            # todo should the _deprecated function be colored?
             begin
               warn "\033[34m\nWARN: #{msg}\033[0m"
             rescue

--- a/calabash-cucumber/lib/calabash-cucumber/uia.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/uia.rb
@@ -6,7 +6,7 @@ module Calabash
     module UIA
 
       def uia(command,options={})
-        res = http({:method => :post, :path => 'uia'}, {command:command}.merge(options))
+        res = http({:method => :post, :path => 'uia'}, {:command => command}.merge(options))
         res = JSON.parse(res)
         if res['outcome'] != 'SUCCESS'
           raise "uia action failed because: #{res['reason']}\n#{res['details']}"
@@ -51,7 +51,7 @@ module Calabash
       end
 
       def uia_double_tap_mark(mark)
-        uia_double_tap(:view, marked:mark)
+        uia_double_tap(:view, {:marked => mark})
       end
 
       def uia_double_tap_offset(offset)


### PR DESCRIPTION
## motivation

0.9.163 contained several ruby compatibility problems.
1. ruby 1.8.\* hash syntax problems in uia (issue https://github.com/calabash/calabash-ios/issues/281)
2. ruby < 2.0 Kernel.caller argument problem (issue https://github.com/calabash/calabash-ios/issues/279)
## Testing
### Briar
- [briar 0.1.3.b5](https://github.com/jmoody/briar/tree/0.1.3.b5)
- [briar-ios-example 1.1.5-morekeyboard](https://github.com/jmoody/briar-ios-example/tree/1.1.5-morekeyboard)
- ruby 2.0 
- ruby 1.9 - several runs on various combinations
#### `NO_LAUNCH=1` ==> Manually Launching ==> UIA _not_ available
- [x] iPhone 4S iOS 6 
- [x] iPad 1 iOS 5.1.1 (some flickering tests around split/undocked keyboards + orientations)
- [x] iPhone Simulator iOS 6.1
- [x] iPad Simulator iOS 6.1
#### `NO_LAUNCH=0` ==> Launching with Instruments ==>  ==> UIA available
- [x] iPhone 4S iOS 6 
- [ ] iPhone 5C iOS 7.0.2
- [x] iPad 4 iOS 7.0.3
- [ ] iPhone Simulator iOS 7
- [ ] iPad Simulator iOS 7
#### `NO_LAUNCH=0` ==> Launching with Sim Launcher     ==> UIA _not_ available
- [ ] iPhone Simulator iOS 6.1
- [ ] iPad Simulator iOS 6.1
### Smoke Tests (--tags @smoke_test)
- [x] ruby 2.0
- [x] ruby 1.9
- [x] ruby 1.8 - had to use rest-client 1.25 because of https://github.com/calabash/calabash-ios/issues/280
### XTC submit

[LPSimpleExample](https://github.com/jmoody/calabash-ios-example)
- [x] ruby 2.0 (5S)
- [x] ruby 1.9 (5S)
- [x] ruby 1.8 (iphone family) - had to use rest-client 1.25 because of https://github.com/calabash/calabash-ios/issues/280
