### PR TITLE
WIP - a uniform way to assert that a map call was successful

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -110,15 +110,15 @@ module Calabash
 
       def scroll(uiquery, direction)
         views_touched=map(uiquery, :scroll, direction)
-        screenshot_and_raise "could not find view to scroll: '#{uiquery}', args: #{direction}" if views_touched.empty?
+        msg = "could not find view to scroll: '#{uiquery}', args: #{direction}"
+        expect_map_results(views_touched, msg)
         views_touched
       end
 
       def scroll_to_row(uiquery, number)
         views_touched=map(uiquery, :scrollToRow, number)
-        if views_touched.empty? or views_touched.member? '<VOID>'
-          screenshot_and_raise "Unable to scroll: '#{uiquery}' to: #{number}"
-        end
+        msg = "unable to scroll: '#{uiquery}' to: #{number}"
+        expect_map_results(views_touched, msg)
         views_touched
       end
 
@@ -144,10 +144,8 @@ module Calabash
           args << options[:animate]
         end
         views_touched=map(uiquery, :scrollToRow, row.to_i, sec.to_i, *args)
-
-        if views_touched.empty? or views_touched.member? '<VOID>'
-          screenshot_and_raise "Unable to scroll: '#{uiquery}' to: #{options}"
-        end
+        msg = "unable to scroll: '#{uiquery}' to '#{options}'"
+        expect_map_results(views_touched, msg)
         views_touched
       end
 
@@ -168,11 +166,8 @@ module Calabash
         end
 
         views_touched=map(uiquery, :scrollToRowWithMark, row_id, *args)
-
-        if views_touched.empty? or views_touched.member? '<VOID>'
-          msg = options[:failed_message] || "Unable to scroll: '#{uiquery}' to: #{options}"
-          screenshot_and_raise msg
-        end
+        msg = options[:failed_message] || "Unable to scroll: '#{uiquery}' to: #{options}"
+        expect_map_results(views_touched, msg)
         views_touched
       end
 

--- a/calabash-cucumber/lib/calabash-cucumber/date_picker.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/date_picker.rb
@@ -142,11 +142,8 @@ module Calabash
         query_str = query_string_for_picker picker_id
 
         views_touched = map(query_str, :changeDatePickerDate, target_str, fmt_str, *args)
-
-        if views_touched.empty? or views_touched.member? '<VOID>'
-          screenshot_and_raise "could not change date on picker to '#{target_dt}' using query '#{query_str}' with options '#{options}'"
-        end
-
+        msg = "could not change date on picker to '#{target_dt}' using query '#{query_str}' with options '#{options}'"
+        expect_map_results(views_touched,msg)
         views_touched
       end
     end

--- a/calabash-cucumber/lib/calabash-cucumber/map.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/map.rb
@@ -23,6 +23,12 @@ module Calabash
         res
       end
 
+      def expect_map_results(views_touched, msg)
+        compact = views_touched.compact
+        if compact.empty? or compact.member? '<VOID>'
+          screenshot_and_raise msg
+        end
+      end
     end
   end
 end

--- a/calabash-cucumber/lib/calabash-cucumber/operations.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/operations.rb
@@ -74,13 +74,15 @@ module Calabash
         _deprecated('0.9.145', msg, :warn)
 
         text_fields_modified = map(uiquery, :setText, txt)
-        screenshot_and_raise "could not find text field #{uiquery}" if text_fields_modified.empty?
+        msg = "could not find text field #{uiquery}"
+        expect_map_results(text_fields_modified, msg)
         text_fields_modified
       end
 
       def clear_text(uiquery)
         views_modified = map(uiquery, :setText, '')
-        screenshot_and_raise "could not find text field #{uiquery}" if views_modified.empty?
+        msg = "could not find text field #{uiquery}" if views_modified.empty?
+        expect_map_results(views_modified, msg)
         views_modified
       end
 


### PR DESCRIPTION
needs review

i don't like that you have to construct the error message before the error occurs.

```
map.rb
+      def expect_map_results(views_touched, msg)
+        compact = views_touched.compact
+        if compact.empty? or compact.member? '<VOID>'
+          screenshot_and_raise msg
+        end
+      end
```

```
+        msg = "could not find view to scroll: '#{uiquery}', args: #{direction}"
+        expect_map_results(views_touched, msg)
```
