### PR TITLE
Entering text should use native keyboard and placeholders

### DIFF
--- a/calabash-cucumber/features/step_definitions/calabash_steps.rb
+++ b/calabash-cucumber/features/step_definitions/calabash_steps.rb
@@ -103,7 +103,7 @@ end
 
 Then /^I enter "([^\"]*)" into the "([^\"]*)" field$/ do |text_to_type, field_name|
   touch("textField placeholder:'#{field_name}'")
-  wait_for_keyboard()
+  wait_for_keyboard
   keyboard_enter_text text_to_type
   sleep(STEP_PAUSE)
 end
@@ -119,7 +119,7 @@ end
 
 Then /^I use the native keyboard to enter "([^\"]*)" into the "([^\"]*)" (?:text|input) field$/ do |text_to_type, field_name|
   touch("textField placeholder:'#{field_name}'")
-  await_keyboard
+  wait_for_keyboard
   keyboard_enter_text(text_to_type)
   sleep(STEP_PAUSE)
 end
@@ -134,7 +134,7 @@ Then /^I enter "([^\"]*)" into (?:input|text) field number (\d+)$/ do |text_to_t
   index = index.to_i
   screenshot_and_raise "Index should be positive (was: #{index})" if (index<=0)
   touch("textField index:#{index-1}",index)
-  await_keyboard
+  wait_for_keyboard
   keyboard_enter_text text_to_type
   sleep(STEP_PAUSE)
 end
@@ -143,7 +143,7 @@ Then /^I use the native keyboard to enter "([^\"]*)" into (?:input|text) field n
   index = index.to_i
   screenshot_and_raise "Index should be positive (was: #{index})" if (index<=0)
   touch("textField index:#{index-1}")
-  await_keyboard
+  wait_for_keyboard
   keyboard_enter_text(text_to_type)
   sleep(STEP_PAUSE)
 end


### PR DESCRIPTION
Steps defined in `calabash_steps.rb` do not match those described in [wiki](https://github.com/calabash/calabash-ios/wiki/02-Predefined-steps#wiki-entering-text). Also, we should use the native keyboard (since set_text is deprecated?) and fetch the text fields by placeholder (whereas in some places textfields were queried by `marked:`).
