### PR TITLE
iphone_4in? now reports true for iPhone 5S

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -18,6 +18,7 @@ module Calabash
       attr_reader :system
       attr_reader :framework_version
       attr_reader :iphone_app_emulated_on_ipad
+      attr_reader :iphone_4in
 
       attr_accessor :udid
 
@@ -30,6 +31,7 @@ module Calabash
         @ios_version = version_data['iOS_version']
         @framework_version = version_data['version']
         @iphone_app_emulated_on_ipad = version_data['iphone_app_emulated_on_ipad']
+        @iphone_4in = version_data['4inch']
       end
 
       def simulator?
@@ -52,12 +54,13 @@ module Calabash
         device_family.eql? GESTALT_IPAD
       end
 
+      def iphone_4in?
+        @iphone_4in
+      end
+
       def iphone_5?
-        if simulator?
-          !simulator_details.scan(GESTALT_IPHONE5).empty?
-        else
-          system.split(/[\D]/).delete_if { |x| x.eql?('') }.first.eql?('5')
-        end
+        _deprecated('0.9.168', "use 'iphone_4in?' instead", :warn)
+        iphone_4in?
       end
 
       def version_hash (version_str)
@@ -85,7 +88,7 @@ module Calabash
 
       def screen_size
         return { :width => 768, :height => 1024 } if ipad?
-        return { :width => 320, :height => 568 } if iphone_5?
+        return { :width => 320, :height => 568 } if iphone_4in?
         { :width => 320, :height => 480 }
       end
 

--- a/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
@@ -72,14 +72,15 @@ module Calabash
       #
       # raises an error if the server cannot be reached
       def iphone_5?
-        _default_device_or_create().iphone_5?
+        _deprecated('0.9.168', "use 'iphone_4in?' instead", :warn)
+        iphone_4in?
       end
 
       # returns +true+ if the target device or simulator is a 4in model
       #
       # raises an error if the server cannot be reached
       def iphone_4in?
-        iphone_5?
+        _default_device_or_create().iphone_4in?
       end
 
       # returns +true+ if the OS major version is 5

--- a/changelog/0.9.168.md
+++ b/changelog/0.9.168.md
@@ -28,9 +28,10 @@ end
 ### Fixes
 
 - (issues https://github.com/calabash/calabash-ios/issues/185) - touch offset is incorrect for iphone app running on iOS 7 ipad simulator because app is always shown at 2x
+- (issues https://github.com/calabash/calabash-ios/issues/319) - iphone_5? returns false for iPhone 5S
 
 
-### Deprecated
+### Deprecated *** NEW ***
 
 These functions, methods, or cucumber steps have been deprecated and will now generate warning messages.
 
@@ -42,3 +43,4 @@ To suppress deprecated warnings set `ENV['CALABASH_NO_DEPRECATION']=1` (not reco
 * since 0.9.163 `await_keyboard` - use `wait_for_keyboard`
 * since 0.9.163 `keyboard_enter_char` second arg `should_screenshot` has been replaced by an options hash. Use the `:should_screenshot` key instead
 * since 0.9.163 `send_uia_command`  - use `uia("...javascript..", options)` instead.  This has not been formally deprecated (no warnings will be generated) yet, but it will be in a future version.
+* since 0.9.168 `iphone_5?` and `Device::iphone_5?` - use `iphone_4in?`


### PR DESCRIPTION
## motivation

`Device::iphone_5?` was returning `false` for the iPhone 5S.  Issue https://github.com/calabash/calabash-ios/issues/319

Replaces `Device::iphone_5?` with `Device::iphone_4in?`.

`Device::iphone_5?` and `Calabash::Cucumber::EnvironmentHelpers::iphone_5?` have been deprecated.
## tests
## Testing
- [briar 0.1.4.b1](https://github.com/jmoody/briar/tree/0.1.4.b1)
- [briar-ios-example master](https://github.com/jmoody/briar-ios-example)
### Briar
- tags 
  - @issue_319
- ruby versions 
  - [x] ruby 2.0
  - [x] ruby 1.9
  - [x] ruby 1.8 
- test on local sims and devices
#### XTC @issue_319

```
Apple iPad 2 (6.1.3)
Apple iPad 4th Gen (7.0.4)
Apple iPad Air (7.0.4)
Apple iPad Mini (6.1.3)
Apple iPad Mini (7.0.4)
Apple iPad Mini Retina (7.0.4)
Apple iPhone 4S (6.1.3)
Apple iPhone 4S (7.0.4)
Apple iPhone 4S (5.1.1)
Apple iPhone 5 (6.1.4)
Apple iPhone 5 (7.0.4)
Apple iPhone 5S (7.0.4)
Apple iPod touch 5th Gen (6.0.1)
Apple iPod touch 5th Gen (7.0.4)
Apple iPod touch 5th Gen (6.1.3)
```
