### PR TITLE
should relaunch and wait for directories to be recreated

### DIFF
--- a/calabash-cucumber/bin/calabash-ios-sim.rb
+++ b/calabash-cucumber/bin/calabash-ios-sim.rb
@@ -1,4 +1,3 @@
-require 'sim_launcher'
 require 'calabash-cucumber/utils/simulator_accessibility'
 require 'calabash-cucumber/utils/logging'
 

--- a/calabash-cucumber/spec/bin/calabash_ios_sim_spec.rb
+++ b/calabash-cucumber/spec/bin/calabash_ios_sim_spec.rb
@@ -18,15 +18,7 @@ describe 'calabash ios sim cli' do
 
   it 'should be able to reset the content and settings of the simulator' do
     calabash_sim_reset
-    expect(simulator_support_sdk_dirs.count).to be == 0
-    launch_simulator
-
-    opts = {:timeout => 5, :timeout_msg => 'wait for 5s simulator to recreated directories'}
-    lib_dir = File.expand_path(File.join(simulator_app_support_dir, 'Library'))
-    wait_for(opts) do
-      simulator_support_sdk_dirs.count == 1 and File.exists?(lib_dir)
-    end
-
+    expect(simulator_support_sdk_dirs.count).to be == 1
   end
 
 end

--- a/calabash-cucumber/spec/simulator_accessibility_spec.rb
+++ b/calabash-cucumber/spec/simulator_accessibility_spec.rb
@@ -73,8 +73,6 @@ describe 'simulator accessibility tool' do
 
       before(:each) do
         reset_simulator_content_and_settings
-        actual = simulator_support_sdk_dirs
-        expect(actual.count).to be == 0
 
         @latest_sdk = @sdk_detector.latest_sdk_version
         @device_target = "iPhone Retina (4-inch) - Simulator - iOS #{@latest_sdk}"
@@ -118,11 +116,6 @@ describe 'simulator accessibility tool' do
 
       it 'should be able to enable accessibility for the latest sdk' do
         repopulate_sim_app_support_for_sdk(@latest_sdk)
-
-        # needs launch the simulator again because it seems to want to write
-        # more files on the second launch.
-        launch_simulator
-        sleep(4)
 
         plist = File.join(simulator_app_support_dir, "#{@latest_sdk}", 'Library/Preferences/com.apple.Accessibility.plist')
         hash = accessibility_properties_hash()


### PR DESCRIPTION
This is very tricky and I am not satisified with my solution.

The problem is that if you reset the content and settings on the
simulator and immediately try to launch a cucumber job via
instruments, you will find that accessibility is not enabled because
the accessibility plist will not have been created.

This is a partial solution - relaunch and wait for the accessibility
plist to be created;  ~3.0 - ~5.0 seconds.

I think the complete solution is to relaunch _each_ available
simulator and wait for _all_ accessibility plists to appear.  It will
look strange, but it will be 'safer'.
