### PR TITLE
should not test the default accessibility plist contents

### DIFF
--- a/calabash-cucumber/spec/simulator_accessibility_spec.rb
+++ b/calabash-cucumber/spec/simulator_accessibility_spec.rb
@@ -117,14 +117,22 @@ describe 'simulator accessibility tool' do
       it 'should be able to enable accessibility for the latest sdk' do
         repopulate_sim_app_support_for_sdk(@latest_sdk)
 
-        plist = File.join(simulator_app_support_dir, "#{@latest_sdk}", 'Library/Preferences/com.apple.Accessibility.plist')
-        hash = accessibility_properties_hash()
-        expect(plist_read(hash[:access_enabled], plist)).to be == 'true'
-        expect(plist_read(hash[:app_access_enabled], plist)).to be == 'true'
-        expect(plist_read(hash[:automation_enabled], plist)).to be == 'true'
-        expect(plist_read(hash[:inspector_showing], plist)).to be == 'false'
-        expect(plist_key_exists?(hash[:inspector_full_size], plist)).to be == false
-        expect(plist_key_exists?(hash[:inspector_frame], plist)).to be == false
+        # i am not sure we need these tests
+        # the are checking the state of the 'clean' accessibility plist
+        # which is subject to change
+        # plist = File.join(simulator_app_support_dir, "#{@latest_sdk}", 'Library/Preferences/com.apple.Accessibility.plist')
+        # hash = accessibility_properties_hash()
+
+        # expect(plist_read(hash[:access_enabled], plist)).to be == 'true'
+        # expect(plist_read(hash[:app_access_enabled], plist)).to be == 'true'
+
+        # flickers depending on the state - not a crucial test
+        # expect(plist_read(hash[:automation_enabled], plist)).to be == 'true'
+        # expect(plist_read(hash[:inspector_showing], plist)).to be == 'false'
+        # expect(plist_key_exists?(hash[:inspector_full_size], plist)).to be == false
+
+        # flickers depending on the state - not a crucial test
+        # expect(plist_key_exists?(hash[:inspector_frame], plist)).to be == false
 
         dir = File.join(simulator_app_support_dir, "#{@latest_sdk}")
         enable_accessibility_in_sdk_dir(dir)


### PR DESCRIPTION
these were bad tests because the contents of the plist were subject to
change (by Apple), were not stable from run to run, and were not
germane to the topic at hand: testing if we could enable accessibility.
