### PR TITLE
should use the latest sim-launcher version

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('json')
   s.add_dependency('edn')
   s.add_dependency('CFPropertyList')
-  s.add_dependency('sim_launcher', '~> 0.4.9')
+  s.add_dependency('sim_launcher', '~> 0.4.10')
   s.add_dependency('slowhandcuke')
   s.add_dependency('geocoder', '~>1.1.8')
   s.add_dependency('httpclient', '~> 2.3.3')


### PR DESCRIPTION
## motivation

We create a lot of SimLauncher.Launcher instances.  The sim_launcher gem was putting:

```
Using installed ios-sim at /usr/local/bin/ios-sim
```

Which was confusing users when trying to launch with instruments; "Why am I using ios-sim when I am launching with instruments?"

https://github.com/moredip/Sim-Launcher/pull/30
