### PR TITLE
should depend on 0.4.11 sim launcher

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency('json')
   s.add_dependency('edn')
   s.add_dependency('CFPropertyList')
-  s.add_dependency('sim_launcher', '~> 0.4.10')
+  s.add_dependency('sim_launcher', '~> 0.4.11')
   s.add_dependency('slowhandcuke')
   s.add_dependency('geocoder', '~>1.1.8')
   s.add_dependency('httpclient', '~> 2.3.3')


### PR DESCRIPTION
includes `xcode-select -p fix`

https://github.com/moredip/Sim-Launcher/pull/31
- [ ] @jamieforrest or @pavelbalintef - can you review this change?  It is impossible for me reproduce.  It should be testable using the current pre-release - 0.9.169.pre*.  
