### PR TITLE
call to `strings` in gem/server compatibility should work on paths with spaces

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -624,7 +624,7 @@ class Calabash::Cucumber::Launcher
 
     server_version = nil
     exe_paths.each do |path|
-      server_version_string = `strings #{path} | grep -E 'CALABASH VERSION'`.chomp!
+      server_version_string = `strings "#{path}" | grep -E 'CALABASH VERSION'`.chomp!
       if server_version_string
         server_version = server_version_string.split(' ').last
         break


### PR DESCRIPTION
The app I test has a space in the name so the resulting APP_BUNDLE_PATH looks like "/users/sqeaky/wherever/xcode/leaves/app/App Name.app". The space causes strings to see this as two filenames "/users/sqeaky/wherever/xcode/leaves/app/App" and "Name.app". Wrapping that in quotes makes strings interpret this as one argument and allows it to work correctly.

This was tested on Mac OS X 10.8 with XCode 5.1.1 and produced no warnings or error messages.
