### PR TITLE
rollback commit 8adc10f changes to operations.rb

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/operations.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/operations.rb
@@ -5,7 +5,7 @@ require 'calabash-cucumber/keychain_helpers'
 require 'calabash-cucumber/wait_helpers'
 require 'calabash-cucumber/launcher'
 require 'net/http'
-require 'test/unit'
+require 'test/unit/assertions'
 require 'json'
 require 'set'
 require 'calabash-cucumber/version'
@@ -23,7 +23,7 @@ module Calabash
   module Cucumber
     module Operations
 
-      include Minitest::Assertions
+      include Test::Unit::Assertions
       include Calabash::Cucumber::Logging
       include Calabash::Cucumber::Core
       include Calabash::Cucumber::TestsHelpers


### PR DESCRIPTION
## motivation

Commit [8adc10](https://github.com/calabash/calabash-ios/commit/8adc10ff71ba62626d7e7ba1e54556313ccaee3d) is not ruby 1.9 compatible and causes the following error when exiting from the console:

```
irb(main):001:0> exit
/Users/moody/.rbenv/versions/2.1.2/lib/ruby/2.1.0/test/unit.rb:55:in `process_args': 
    invalid option: --readline (OptionParser::InvalidOption)
    from /Users/moody/.rbenv/versions/2.1.2/lib/ruby/2.1.0/minitest/unit.rb:1073:in _run
    from /Users/moody/.rbenv/versions/2.1.2/lib/ruby/2.1.0/minitest/unit.rb:1066:in run
```

I am was also not able to reproduce the problem that this commit was supposed to fix.

```
Warning: you should require 'minitest/autorun' instead.
Warning: or add 'gem "minitest"' before 'require "minitest/autorun"'
From:
/Users/christian/.rbenv/versions/2.1.2/lib/ruby/2.1.0/test/unit.rb:1:in require
/Users/christian/.rbenv/versions/2.1.2/lib/ruby/2.1.0/test/unit.rb:1:in <top (required)>
/Users/christian/Projects/calabash-ios/calabash-cucumber/lib/calabash-cucumber/operations.rb:9:in require
```

Regarding the failure at console exit, I think including Minitest or MiniTest (ruby 1.9 compat) somehow marks the operations.rb as a test file.  I am not really sure what is happening and could not find a fix.  Which is why I went to such lengths on the this pull request to test for the offending warning.
## to reproduce

While I was trying to fix the ruby compatibility and console problems, I realized that I could not reproduce the original problem.  I reverted operations.rb back and cooked up this example.
##### to reproduce

_Requires rbenv or enough rvm knowledge to change the local ruby version._

_Assumes you are using bundler._

```
# get the test project
git clone git://github.com/jmoody/calabash-ios-example.git
git checkout -b jmoody-demo/reproduce-minitest-autorun-warning master
git pull git@github.com:jmoody/calabash-ios-example.git demo/reproduce-minitest-autorun-warning

# run the tests against 2.1.2 and 1.9
1.  cd calabash-ios-example
2.  $ rbenv local 2.1.2
    # clean-gems.rb requires a recent version of rubygems
3.  $ gem update --system
4.  $ scripts/clean-gems.rb
5.  $ bundle
6.  $ ./run-tests.sh
    # confirm that the terminal exits without errors
7.  $ be calabash-ios console
8.  > exit
9.  rm Gemfile.lock
10. repeat from step 2 using:
    $ rbenv local 1.9.3-p484 
    $ rbenv local 2.0.0
    $ rbenv local 2.1 (optional)
```
##### expected

To see the offending warning that [8adc10](https://github.com/calabash/calabash-ios/commit/8adc10ff71ba62626d7e7ba1e54556313ccaee3d) was supposes to fix.
##### found

No warning.
##### notes

I believe the warning message that [8adc10](https://github.com/calabash/calabash-ios/commit/8adc10ff71ba62626d7e7ba1e54556313ccaee3d) was supposed to fix was caused by a bad gem setup.

Bundle users can guard against this by running:

```
# uninstall all gems not in the bundle
$ bundle clean --force
```

Mere mortals can use the `scripts/clean-gems.rb` and reinstall calabash-cucumber.

I also found this interesting link which gives an interesting insight into minutest and ruby 2.1.

http://stackoverflow.com/questions/23077637/why-do-we-need-to-install-minitest-gem-sometimes
## todo
- [x] @krukow needs review
- [x] @krukow What do you think about we adding the clean-gems.rb to the gem `scripts` directory?  Or to the calabash-ios binary commands?  Or neither?
## links

https://github.com/calabash/calabash-ios/pull/395 - related pull request
