### PR TITLE
Device class attribute `udid` should be deprecated

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -23,6 +23,9 @@ module Calabash
       attr_reader :iphone_app_emulated_on_ipad
       attr_reader :iphone_4in
 
+      # @deprecated 0.10.0 no replacement
+      # @!attribute [rw] udid
+      # @return [String] The udid of this device.
       attr_accessor :udid
 
       def initialize (endpoint, version_data)
@@ -104,6 +107,17 @@ module Calabash
         @server_version
       end
 
+      # @deprecated 0.10.0 no replacement
+      def udid
+        _deprecated('0.10.0', 'no replacement', :warn)
+        @udid
+      end
+
+      # @deprecated 0.10.0 no replacement
+      def udid=(value)
+        _deprecated('0.10.0', 'no replacement', :warn)
+        @udid = value
+      end
     end
   end
 end

--- a/changelog/0.10.0.md
+++ b/changelog/0.10.0.md
@@ -41,6 +41,8 @@ See https://github.com/calabash/calabash-ios/wiki/Deprecated
 
 ##### NEW
 
+* since 0.10.0 `Calabash::Cucumber::Device.udid` - no replacement
+
 ### Other
 
 #### rspec testing for testing Calabash iOS gem


### PR DESCRIPTION
## Motivation

This attribute is not used by any part of the gem and it is not possible to get the device udid from the arguments passed to the initializer.
## todo
- [ ] @krukow needs review
