### PR TITLE
handling of optional arguments in IBase methods should be clearer

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/ibase.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/ibase.rb
@@ -54,17 +54,20 @@ class Calabash::IBase
   #
   # Note it is assumed that the target page is a Calabash::IBase (or acts accordingly)
   def transition(transition_options={})
-    uiquery = transition_options[:tap]
-    action = transition_options[:action]
-    page_arg = transition_options[:page]
-    should_await = transition_options.has_key?(:await) ? transition_options[:await] : true
+    default_opts = {:await => true}
+    merged_transitions_opts = default_opts.merge(transition_options)
+
+    uiquery = merged_transitions_opts[:tap]
+    action = merged_transitions_opts[:action]
+    page_arg = merged_transitions_opts[:page]
+    should_await = merged_transitions_opts[:await]
 
     if action.nil? && uiquery.nil?
-      raise "Called transition without providing a gesture (:tap or :action) #{transition_options}"
+      raise MissingArgument "Called transition without providing a gesture (:tap or :action) #{transition_options}"
     end
 
     if uiquery
-      tap_options = transition_options[:tap_options] || {}
+      tap_options = merged_transitions_opts[:tap_options] || {}
       touch(uiquery, tap_options)
     else
       action.call()
@@ -74,9 +77,9 @@ class Calabash::IBase
     page_obj ||= self
 
     if should_await
-      wait_opts = transition_options[:wait_options] || {}
+      wait_opts = merged_transitions_opts[:wait_options] || {}
       if page_obj == self
-        unless wait_opts.has_key?(:await_animation) && !wait_opts[:await_animation]
+        if wait_opts[:await_animation]
           sleep(transition_duration)
         end
       else

--- a/calabash-cucumber/lib/calabash-cucumber/ibase.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/ibase.rb
@@ -29,7 +29,7 @@ class Calabash::IBase
 
   def await(wait_opts={})
     wait_for_elements_exist([trait], wait_opts)
-    unless wait_opts.has_key?(:await_animation) && !wait_opts[:await_animation]
+    if wait_opts[:await_animation]
       sleep(transition_duration)
     end
     self

--- a/calabash-cucumber/lib/calabash-cucumber/ibase.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/ibase.rb
@@ -12,8 +12,11 @@ class Calabash::IBase
   end
 
   def trait
-    raise "You should define a trait method or a title method" unless respond_to?(:title)
-    "navigationItemView marked:'#{self.title}'"
+    if respond_to?(:title)
+      "navigationItemView marked:'#{self.title}'"
+    else
+      raise NotImplementedError, "Subclasses must implement a 'trait' or 'title' method"
+    end
   end
 
   def current_page?

--- a/calabash-cucumber/lib/calabash-cucumber/ibase.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/ibase.rb
@@ -63,7 +63,7 @@ class Calabash::IBase
     should_await = merged_transitions_opts[:await]
 
     if action.nil? && uiquery.nil?
-      raise MissingArgument "Called transition without providing a gesture (:tap or :action) #{transition_options}"
+      raise(ArgumentError, "Called transition without providing a gesture (:tap or :action) #{transition_options}")
     end
 
     if uiquery


### PR DESCRIPTION
## Motivation

While writing the docs for the IBase class, I saw that there were a number of cases where the code was unclear.  

### `trait` control is unclear

This is a straight refactor with no behavior change.

### await and transition option handling

These might be breaking changes.  The code as written is very confusing.   I *think* I understand the intent...

## todo

- [ ] @krukow needs review
- [ ] needs rspec tests