### PR TITLE
resolves yarddoc undefined refs and touches up default values for optional args

### DIFF
--- a/calabash-cucumber/README_YARDOC.md
+++ b/calabash-cucumber/README_YARDOC.md
@@ -113,10 +113,12 @@ cmd (String) (defaults to: nil) — controls the return value. currently accepts
 
 #### documenting option hashes
 
+Default values can be specified by including them after the option key in `()`.
+
 ```
 # @param [Hash] opts controls the content of the query string
-# @option opts [Integer,nil] :with_tag if non-nil the query string includes tag filter
-# @option opts [Integer,nil] :with_clips_to_bounds if non-nil the query string includes clipsToBounds filter
+# @option opts [Integer,nil] :with_tag (true) if non-nil the query string includes tag filter
+# @option opts [Integer,nil] :with_clips_to_bounds (false) if non-nil the query string includes clipsToBounds filter
 ```
 
 #### multiple return values

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -447,22 +447,24 @@ module Calabash
 
       # Scrolls to a mark in a UITableView.
       #
-      # @example
-      #  # scroll to the top of the item with the given mark
-      #  scroll_to_row_with_mark(mark, {:scroll_position => :top})
-      # @example
-      #  # scroll to the bottom of the item with the given mark
-      #  scroll_to_row_with_mark(mark, {:scroll_position => :bottom})
+      # @example Scroll to the top of the item with the given mark.
+      #  scroll_to_row_with_mark('settings', {:scroll_position => :top})
       #
-      # @param [String] mark an accessibility {label | identifier} or text in
+      # @example Scroll to the bottom of the item with the given mark.
+      #  scroll_to_row_with_mark('about', {:scroll_position => :bottom})
+      #
+      # @param [String] mark an accessibility `{label | identifier}` or text in
       #  or on the row
       # @param [Hash] options controls the query and and scroll behavior
-      # @option options [String] :query the query that should be used to find
-      #  table the row is in
-      # @option options [Symbol] :scroll_position the table position to scroll
-      #  the row to - allowed values `{:middle | :top | :bottom}`
       #
-      # @option options [Boolean] :animate iff true the scrolling is animated
+      # @option options [String] :query ('tableView')
+      #  the query that should be used to location the table
+      # @option options [Symbol] :scroll_position (:middle)
+      #  the table position to scroll the row to - allowed values
+      #  `{:middle | :top | :bottom}`
+      # @option options [Boolean] :animate (true)
+      #  should the scrolling be animated
+      #
       # @raise [RuntimeError] if the scroll cannot be performed
       # @raise [RuntimeError] if the mark is nil
       # @raise [RuntimeError] if the table query finds no table view
@@ -496,30 +498,33 @@ module Calabash
       #
       # @note item and section are zero-indexed
       #
-      # @example
-      #  # scroll to item 0 in section 2 to top
+      # @example Scroll to item 0 in section 2 to top.
       #  scroll_to_collection_view_item(0, 2, {:scroll_position => :top})
       #
-      # @example
-      #  # scroll to item 5 in section 0 to bottom
+      # @example Scroll to item 5 in section 0 to bottom.
       #  scroll_to_collection_view_item(5, 0, {:scroll_position => :bottom})
       #
-      # @example
-      #  # the following are the allowed :scroll_position values
+      # @example The following are the allowed :scroll_position values.
       #  {:top | :center_vertical | :bottom | :left | :center_horizontal | :right}
       #
       # @param [Integer] item the index of the item to scroll to
       # @param [Integer] section the section of the item to scroll to
       # @param [Hash] opts options for controlling the collection view query
       #  and scroll behavior
-      # @option opts [String] :query the query that is used to identify which
-      #  collection view to scroll - defaults to `collectionView`
-      # @option opts [Symbol] :scroll_position the position in the collection
-      #  view to scroll the item to - defaults to `:top`
-      # @option opts [Boolean] :animate iff true animate the scroll
-      # @option opts [String] :failed_message a custom error message to display
-      #  if the scrolling fails; if not specified, a generic failure will be
-      #  displayed - defaults to `nil`
+      #
+      # @option opts [String] :query ('collectionView')
+      #  the query that is used to identify which collection view to scroll
+      #
+      # @option opts [Symbol] :scroll_position (top)
+      #  the position in the collection view to scroll the item to
+      #
+      # @option opts [Boolean] :animate (true)
+      #  should the scrolling be animated
+      #
+      # @option opts [String] :failed_message (nil)
+      #  a custom error message to display if the scrolling fails - if not
+      #  specified, a generic failure will be displayed
+      #
       # @raise [RuntimeException] if the scroll cannot be performed
       # @raise [RuntimeException] :query finds no collection view
       # @raise [RuntimeException] the collection view does not contain a cell at item/section
@@ -554,29 +559,30 @@ module Calabash
 
       # Scrolls to mark in a UICollectionView.
       #
-      # @example
-      #  # scroll to the top of the item with the given mark
-      #  scroll_to_collection_view_item_with_mark(mark, {:scroll_position => :top})
-      # @example
-      #  # scroll to the bottom of the item with the given mark
-      #  scroll_to_collection_view_item_with_mark(mark, {:scroll_position => :bottom})
+      # @example Scroll to the top of the item with the given mark.
+      #  scroll_to_collection_view_item_with_mark('cat', {:scroll_position => :top})
       #
-      # @example
-      #  # the following are the allowed :scroll_position values
+      # @example Scroll to the bottom of the item with the given mark.
+      #  scroll_to_collection_view_item_with_mark('dog', {:scroll_position => :bottom})
+      #
+      # @example The following are the allowed :scroll_position values.
       #  {:top | :center_vertical | :bottom | :left | :center_horizontal | :right}
       #
-      # @param [String] mark an accessibility {label | identifier} or text in
+      # @param [String] mark an accessibility `{label | identifier}` or text in
       #  or on the item
       # @param [Hash] opts options for controlling the collection view query
       #  and scroll behavior
-      # @option opts [String] :query the query that is used to identify which
-      #  collection view to scroll - defaults to `collectionView`
-      # @option opts [Symbol] :scroll_position the position in the collection
-      #  view to scroll the item to - defaults to `:top`
-      # @option opts [Boolean] :animate iff true animate the scroll
-      # @option opts [String] :failed_message a custom error message to display
-      #  if the scrolling fails; if not specified, a generic failure will be
-      #  displayed - defaults to `nil`
+      #
+      # @option opts [String] :query ('collectionView')
+      #   the query that is used to identify which collection view to scroll
+      # @option opts [Symbol] :scroll_position (:top)
+      #   the position in the collection view to scroll the item to
+      # @option opts [Boolean] :animate (true) should the scroll
+      #   be animated
+      # @option opts [String] :failed_message (nil)
+      #  a custom error message to display if the scrolling fails - if not
+      #  specified, a generic failure will be displayed
+      #
       # @raise [RuntimeException] if the scroll cannot be performed
       # @raise [RuntimeException] if the mark is nil
       # @raise [RuntimeException] :query finds no collection view

--- a/calabash-cucumber/lib/calabash-cucumber/ibase.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/ibase.rb
@@ -110,9 +110,9 @@ class Calabash::IBase
   # @param {Hash} wait_opts options hash to pass to `wait_for_element_exists`
   #   (see {Calabash::Cucumber::WaitHelpers#wait_for} and
   #   {Calabash::Cucumber::WaitHelpers::DEFAULT_OPTS}).
-  # @option wait_opts [Boolean] :await_animation iff true, will wait for
-  #  `self.transition_duration` after this page's `trait` appears - defaults to
-  #  false.
+  # @option wait_opts [Boolean] :await_animation (false)
+  #   iff true, will wait for `self.transition_duration` after this page's
+  #   `trait` appears
   # @return {IBase} self
   def await(wait_opts={})
     wait_for_elements_exist([trait], wait_opts)

--- a/calabash-cucumber/lib/calabash-cucumber/ipad_1x_2x.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/ipad_1x_2x.rb
@@ -150,9 +150,9 @@ module Calabash
       # @param [Hash] opts optional arguments to control the interaction with
       #  the 1X/2X buttons
       #
-      # @option opts [Symbol] :lang_code (defaults to :en) an Apple compatible
+      # @option opts [Symbol] :lang_code (:en) an Apple compatible
       #  language code
-      # @option opts [Symbol] :wait_after_touch (defaults to 0.4) how long to
+      # @option opts [Symbol] :wait_after_touch (0.4) how long to
       #  wait _after_ the scale button is touched
       #
       # @return [void]
@@ -216,9 +216,9 @@ module Calabash
       # @param [Hash] opts optional arguments to control the interaction with
       #  the 1X/2X buttons
       #
-      # @option opts [Symbol] :lang_code (defaults to :en) an Apple compatible
+      # @option opts [Symbol] :lang_code (:en) an Apple compatible
       #  language code
-      # @option opts [Symbol] :wait_after_touch (defaults to 0.4) how long to
+      # @option opts [Symbol] :wait_after_touch (0.4) how long to
       #  wait _after_ the scale button is touched
       #
       # @return [void]

--- a/calabash-cucumber/lib/calabash-cucumber/launch/simulator_launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launch/simulator_launcher.rb
@@ -374,21 +374,22 @@ module Calabash
         status
       end
 
-      # attempts to connect to launch the app and connect to the embedded
+      # Attempts to connect to launch the app and connect to the embedded
       # calabash server.
       #
-      # to change the number of times launching is attempted set MAX_CONNECT_RETRY
+      # @note To change the number of times launching is attempted set
+      # `MAX_CONNECT_RETRY`.
       #
-      # to change the relaunch timeout set CONNECT_TIMEOUT
+      # @note To change the relaunch timeout set `CONNECT_TIMEOUT`.
       #
       # @param [String] app_bundle_path path to the .app that should be launched
       # @param [String] sdk 6.0.3, 6.1.  if nil latest SDK will be used
-      # @param [String] device_family {iphone | ipad}
+      # @param [String] device_family `{iphone | ipad}`
       # @param [Hash] args eke! not used (see todo)
       #
       # @raise [TimeoutErr] if app cannot be launched in the simulator
-      # todo nearly a duplicate of Launcher ensure_connectivity
-      # todo args was originally intended to be the args passed to the application @ launch
+      # @todo nearly a duplicate of Launcher ensure_connectivity
+      # @todo args was originally intended to be the args passed to the application @ launch
       def ensure_connectivity(app_bundle_path, sdk, device_family, args = nil)
         begin
           # todo should get the retry could from the args
@@ -439,12 +440,13 @@ module Calabash
         end
       end
 
-      # launches the app
+      # Launches the app.
+      #
       # @param [String] app_bundle_path path to the .app that should be launched
       # @param [String] sdk 6.0.3, 6.1.  if nil latest SDK will be used
-      # @param [String] device_family {iphone | ipad}
-      # @param [Hash] args eke! not used (see todo)
-      # todo args was originally intended to be the args passed to the application @ launch
+      # @param [String] device_family `{iphone | ipad}`
+      # @param [Hash] args eke! not used
+      # @todo args was originally intended to be the args passed to the application @ launch
       def launch(app_bundle_path, sdk, device_family, args = nil)
         # cached but not used
         self.launch_args = args

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -351,7 +351,7 @@ class Calabash::Cucumber::Launcher
   # @option args {String} :app (detect the location of the bundle from project settings) app bundle path
   # @option args {String} :bundle_id if launching on device, specify this or env `BUNDLE_ID` to be the bundle identifier
   #   of the application to launch
-  # @option args {Hash} :privacy_settings preset privacy settings for the, e.g., {:photos => {:allow => true}}.
+  # @option args {Hash} :privacy_settings preset privacy settings for the, e.g., `{:photos => {:allow => true}}`.
   #    See {KNOWN_PRIVACY_SETTINGS}
   def relaunch(args={})
     #TODO stopping is currently broken, but this works anyway because instruments stop the process before relaunching

--- a/calabash-cucumber/lib/calabash-cucumber/tests_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/tests_helpers.rb
@@ -2,9 +2,9 @@ require 'calabash-cucumber/failure_helpers'
 
 module Calabash
   module Cucumber
-    module TestsHelpers #=> http
-      include Calabash::Cucumber::FailureHelpers
+    module TestsHelpers
 
+      include Calabash::Cucumber::FailureHelpers
 
       # Returns the classes of all views matching `uiquery`
       # @param {String} uiquery the query to execute
@@ -28,9 +28,10 @@ module Calabash
         not element_does_not_exist(uiquery)
       end
 
-      # Returns true if at least one element matches query "* marked:'#{expected_mark}'"
+      # Returns true if at least one element matches query `"* marked:'#{expected_mark}'"`
       # @param {String} expected_mark the mark to search for
-      # @return {Boolean} `true` if at least one element matches query "* marked:'#{expected_mark}'". `false` otherwise.
+      # @return {Boolean} `true` if at least one element matches query
+      #  `"* marked:'#{expected_mark}'". `false` otherwise.
       def view_with_mark_exists(expected_mark)
         element_exists("view marked:'#{expected_mark}'")
       end

--- a/calabash-cucumber/lib/calabash-cucumber/uia.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/uia.rb
@@ -96,7 +96,7 @@ module Calabash
       # @example Advanced example that chains calls and uses arguments
       #   uia_call [:view, marked:'New Post'], {withName:"New Post"}, :toString, {charAt:0}
       #
-      # @param {Array} args_arr array describing the query, e.g., [:button, {marked:'foo'}]
+      # @param {Array} args_arr array describing the query, e.g., `[:button, {marked:'foo'}]`
       # @param {Array} opts optional arguments specifying a chained sequence of method calls (see example)
       def uia_call(args_arr, *opts)
         uia_call_method(:queryEl, args_arr, *opts)

--- a/calabash-cucumber/lib/calabash-cucumber/utils/xctools.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/utils/xctools.rb
@@ -60,14 +60,16 @@ module Calabash
         end
       end
 
-      # does the instruments +version+ accept the -s (devices) flag?
+      # Does the instruments `version` accept the -s flag?
       #
-      #     instruments_supports_hyphen_s?('4.6.3') #=> false
-      #     instruments_supports_hyphen_s?('5.0.2') #=> true
-      #       instruments_supports_hyphen_s?('5.1') #=> true
+      # @example
+      #  instruments_supports_hyphen_s?('4.6.3') => false
+      #  instruments_supports_hyphen_s?('5.0.2') => true
+      #  instruments_supports_hyphen_s?('5.1')   => true
       #
-      # @param [String] version a major.minor.{patch} version string - defaults
-      #  to the currently active instruments binary
+      # @param [String] version (instruments(:version))
+      #   a major.minor[.patch] version string
+      #
       # @return [Boolean] true iff the version is >= 5.*
       def instruments_supports_hyphen_s?(version=instruments(:version))
         tokens = version.split('.')


### PR DESCRIPTION
## motivation

```
$ be rake yard
[warn]: In file `lib/calabash-cucumber/core.rb':555: Cannot resolve link to label from text:
[warn]: ...{label | identifier}...
[warn]: In file `lib/calabash-cucumber/core.rb':448: Cannot resolve link to label from text:
[warn]: ...{label | identifier}...
[warn]: In file `lib/calabash-cucumber/utils/xctools.rb':63: Cannot resolve link to patch from text:
[warn]: ...{patch}...
[warn]: In file `lib/calabash-cucumber/tests_helpers.rb':5: Cannot resolve link to expected_mark from text:
[warn]: ...{expected_mark}...
[warn]: In file `lib/calabash-cucumber/tests_helpers.rb':31: Cannot resolve link to expected_mark from text:
[warn]: ...{expected_mark}...
[warn]: In file `lib/calabash-cucumber/tests_helpers.rb':31: Cannot resolve link to expected_mark from text:
[warn]: ...{expected_mark}...
[warn]: In file `lib/calabash-cucumber/launcher.rb':329: Cannot resolve link to :photos from text:
[warn]: ...{:photos =&gt; {:allow =&gt; true}...
[warn]: In file `lib/calabash-cucumber/launch/simulator_launcher.rb':377: Cannot resolve link to iphone from text:
[warn]: ...{iphone | ipad}...
[warn]: In file `lib/calabash-cucumber/launch/simulator_launcher.rb':442: Cannot resolve link to iphone from text:
[warn]: ...{iphone | ipad}...
Files:          38
Modules:        26 (   11 undocumented)
Classes:        10 (    3 undocumented)
Constants:      23 (   13 undocumented)
Methods:       358 (   77 undocumented)
 75.06% documented
```

Resolved all references.  All of them were `{}` outside of backquotes.
