### PR TITLE
require yard and rspec only during dev

### DIFF
--- a/calabash-cucumber/Rakefile
+++ b/calabash-cucumber/Rakefile
@@ -3,13 +3,22 @@ require 'fileutils'
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new
-task :test => :spec
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new
+  task :test => :spec
+rescue Exception => _
+  warn 'skipping rspec requirement because it is a development dependency'
+end
 
-require 'yard'
-YARD::Rake::YardocTask.new do |t|
-  # see .yardopts for options
+
+begin
+  require 'yard'
+  YARD::Rake::YardocTask.new do |t|
+    # see .yardopts for options
+  end
+rescue Exception => _
+  warn 'skipping yard requirement because it is a development dependency'
 end
 
 # REQUIRES that the calabash-ios-server source code is located


### PR DESCRIPTION
## motivation

Some tools, like briar, use `bundle exec` at _runtime_ to call various calabash gem take tasks.  Specifically, briar calls `$ rake build_server` as part of its automated workflow.

We don't want to require these tools include `rspec` and `yard` as runtime dependencies.

This pull requests wraps the `rspec` and `yard` require statements in a begin/rescue block that emits a warning when these gems are not part of the bundle.
