### PR TITLE
Then I touch right and down from "..." predefined step has trailing whitespace

### DIFF
--- a/calabash-cucumber/features/step_definitions/calabash_steps.rb
+++ b/calabash-cucumber/features/step_definitions/calabash_steps.rb
@@ -17,7 +17,7 @@ Then /^I (?:press|touch) "([^\"]*)"$/ do |name|
   sleep(STEP_PAUSE)
 end
 
-Then /^I (?:press|touch) (\d+)% right and (\d+)% down from "([^\"]*)" $/ do |x,y,name|
+Then /^I (?:press|touch) (\d+)% right and (\d+)% down from "([^\"]*)"$/ do |x,y,name|
   raise "This step is not yet implemented on iOS"
 end
 


### PR DESCRIPTION
This space would prevent the step from matching
