### PR TITLE
should run version.rb unit tests on ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: objective-c
+
+script:
+  - script/rspec-ci
+  - script/unit-ci
+
 rvm:
-     - "1.9.3"
-     - "2.0.0"
-     - "2.1.1"
-script: cd calabash-cucumber; bundle install; bundle exec rake spec
+  - 1.9.3
+  - 2.1.0
+  - 2.1.1
 

--- a/calabash-cucumber/.gitignore
+++ b/calabash-cucumber/.gitignore
@@ -1,6 +1,5 @@
 Markdown.pl
 .idea
-Gemfile.lock
 staticlib
 libcalabash
 
@@ -8,7 +7,6 @@ libcalabash
 pkg
 .bundle
 vendor
-pkg
 *.gem
 .ruby-version
 

--- a/calabash-cucumber/Gemfile.lock
+++ b/calabash-cucumber/Gemfile.lock
@@ -1,0 +1,81 @@
+PATH
+  remote: .
+  specs:
+    calabash-cucumber (0.10.0.pre1)
+      CFPropertyList (~> 2.2.8)
+      awesome_print
+      bundler (~> 1.1)
+      calabash-common (~> 0.0.1)
+      cucumber (~> 1.3.0)
+      edn (= 1.0.6)
+      geocoder (~> 1.1.8)
+      httpclient (~> 2.3.3)
+      json
+      run_loop (~> 0.2.1)
+      sim_launcher (~> 0.4.11)
+      slowhandcuke
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    awesome_print (1.2.0)
+    builder (3.2.2)
+    calabash-common (0.0.1)
+      cucumber (~> 1.3.0)
+    cucumber (1.3.15)
+      builder (>= 2.1.2)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 2.12)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.1)
+    diff-lcs (1.2.5)
+    edn (1.0.6)
+    geocoder (1.1.9)
+    gherkin (2.12.2)
+      multi_json (~> 1.3)
+    httpclient (2.3.4.1)
+    json (1.8.1)
+    multi_json (1.10.1)
+    multi_test (0.1.1)
+    rack (1.5.2)
+    rack-protection (1.5.3)
+      rack
+    rake (10.3.2)
+    redcarpet (3.1.2)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.2)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.2)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.2)
+    run_loop (0.2.1)
+      json
+      thor
+    sim_launcher (0.4.11)
+      sinatra
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    slowhandcuke (0.0.3)
+      cucumber
+    thor (0.19.1)
+    tilt (1.4.1)
+    yard (0.8.7.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  calabash-cucumber!
+  rake
+  redcarpet
+  rspec
+  yard (~> 0.8.7.4)

--- a/script/rspec-ci
+++ b/script/rspec-ci
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+cd calabash-cucumber
+
+RETVAL=$?
+if [ $RETVAL != 0 ]; then
+    echo "FAIL: failed to change directory to calabash-cucumber - should called as 'script/ci'"
+    exit $RETVAL
+else
+    echo "INFO: changed directory to ${PWD}"
+fi
+
+../script/shared-bundler-tasks.sh
+
+# rspec tests
+bundle exec rake spec
+RETVAL=$?
+if [ $RETVAL != 0 ]; then
+    echo "FAIL: failed rspec tests"
+    exit $RETVAL
+else
+    echo "INFO: passed rspec tests"
+fi
+
+exit $RETVAL

--- a/script/shared-bundler-tasks.sh
+++ b/script/shared-bundler-tasks.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Enable binaries to be installed.
+#
+# calabash-cucumber at /Users/travis/build/calabash/calabash-ios/calabash-cucumber did not have a valid gemspec.
+# This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
+# The validation message from Rubygems was:
+#  ["staticlib/calabash.framework.zip"] are not files
+touch calabash.framework
+zip -r calabash.framework.zip calabash.framework
+mkdir -p staticlib
+mv calabash.framework.zip staticlib/
+rm calabash.framework
+
+gem install --no-document bundler
+RETVAL=$?
+if [ $RETVAL != 0 ]; then
+    echo "FAIL: failed to install bundler"
+    exit $RETVAL
+else
+    echo "INFO: installed bundler"
+fi
+
+bundle install --deployment
+RETVAL=$?
+if [ $RETVAL != 0 ]; then
+    echo "FAIL: failed to bundle install"
+    exit $RETVAL
+else
+    echo "INFO: bundled"
+fi
+
+exit $RETVAL

--- a/script/unit-ci
+++ b/script/unit-ci
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+cd calabash-cucumber
+
+RETVAL=$?
+if [ $RETVAL != 0 ]; then
+    echo "FAIL: failed to change directory to calabash-cucumber - should called as 'script/ci'"
+    exit $RETVAL
+else
+    echo "INFO: changed directory to ${PWD}"
+fi
+
+../script/shared-bundler-tasks.sh
+
+bundle exec ruby lib/calabash-cucumber/version.rb
+RETVAL=$?
+if [ $RETVAL != 0 ]; then
+    echo "FAIL: lib/calabash-cucumber/version.rb unit tests"
+    exit $RETVAL
+else
+    echo "INFO: lib/calabash-cucumber/version.rb unit tests passed"
+fi
+
+exit $RETVAL


### PR DESCRIPTION
## motivation

What good are tests that are never run?

In version.rb there are some lonely unit tests that are waiting to converted to rspec.

This pull request adds them to the travis-ci run.

It also adds the Gemfile.lock file to git index.  Given the trouble we've had with 'edn', 'httpclient', and, 'ruby-zip' lately, I think it is a good idea to have tighter control over our gem dependencies.

The ci scripts use `$ bundle install --deployment` to ensure that gemspec does not get out of sync with the Gemfile.lock.
