### PR TITLE
marks 'done' method as deprecated @ the doc level [skip ci]

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -394,7 +394,8 @@ module Calabash
         end
       end
 
-      # touches the keyboard action key
+      # @deprecated 0.10.0 replaced with `tap_keyboard_action_key`
+      # @see #tap_keyboard_action_key
       #
       # Touches the keyboard action key.
       #

--- a/changelog/0.10.0.md
+++ b/changelog/0.10.0.md
@@ -77,7 +77,8 @@ See https://github.com/calabash/calabash-ios/wiki/Deprecated
 
 * since 0.10.0 `Calabash::Cucumber::Device.udid` - no replacement
 * since 0.10.0 `tap` - replaced with `tap_mark`
-* since 0.10.0 in `Calabash::Cucumber::Launcher` `reset_app_jail` has been replaced with `reset_app_sandbox`. This method has been deprecated, but does not issue a warning (yet).
+* since 0.10.0 in `Calabash::Cucumber::Launcher` `reset_app_jail` has been replaced with `reset_app_sandbox`. This method has been deprecated, but does not issue a warning.
+* since 0.10.0 `done` - replaced with `tap_keyboard_action_key`. This method has been deprecated, but does not issue a warning.
 
 ### Other
 


### PR DESCRIPTION
## motivation

For the purposes of documentation, the 'done' method has been marked deprecated.

No runtime warning is generated.
