### PR TITLE
version class needs to be more flexible

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -5,12 +5,12 @@ module Calabash
 
     # @!visibility public
     # The Calabash iOS gem version.
-    VERSION = '0.10.0.pre3'
+    VERSION = '0.10.0.pre4'
 
     # @!visibility public
     # The minimum required version of the calabash.framework or, for Xamarin
     # users, the Calabash component.
-    MIN_SERVER_VERSION = '0.10.0.pre3'
+    MIN_SERVER_VERSION = '0.10.0.pre4'
 
     # @!visibility private
     def self.const_missing(const_name)


### PR DESCRIPTION
## motivation

The simulator configuration in Xcode 6 / iOS 8 is radically different.  In order to provide support, I have to do a lot of version checking.

This PR fills in some obvious gaps in the Calabash::Cucumber::Version class.
