### PR TITLE
rollback run_loop dependency to ~> 0.2

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |s|
   s.add_dependency('geocoder', '~>1.1.8')
   s.add_dependency('httpclient', '~> 2.3.3')
   s.add_dependency('bundler', '~> 1.1')
-  s.add_dependency('run_loop', '>= 1.0.0.pre', '< 1.1')
+  s.add_dependency('run_loop', '~> 0.2')
   s.add_dependency('awesome_print')
 
   s.add_development_dependency 'rake', '~> 10.3'


### PR DESCRIPTION
## motivation

I was overly optimistic about the readiness of run-loop 1.0.0.  We want to release 0.10.0 before Xcode 6/ iOS 8 support is finalized.
