### PR TITLE
WIP instructions how _not_ to import predefined steps

### DIFF
--- a/calabash-cucumber/features-skeleton/support/env.rb
+++ b/calabash-cucumber/features-skeleton/support/env.rb
@@ -1,20 +1,7 @@
-# WIP - needs better text and testing
-#
-# @see https://github.com/calabash/calabash-ios/issues/458
-
-# This will import the calabash pre-defined steps.
-#
-# Once you have some experience with Calabash and Cucumber, we recommend that
-# not use pre-defined steps.  Instead, you should write Steps that are specific
-# to your application.
-#
-# Imports calabash-ios pre-defined steps.
+# Requiring this file will import Calabash and the Calabash predefined Steps.
 require 'calabash-cucumber/cucumber'
 
-# If you don't want to use the pre-defined steps,
-# delete the 'require' above and uncomment the
-# requires below.
-
-# Imports calabash-ios without pre-defined steps.
+# To use Calabash without the predefined Calabash Steps, uncomment these
+# two lines and delete the require above.
 # require 'calabash-cucumber/wait_helpers'
 # require 'calabash-cucumber/operations'


### PR DESCRIPTION
## Motivation

First pass at explain how to _not_ import predefined steps.  

See https://github.com/calabash/calabash-ios/issues/458
