### PR TITLE
fix launching with sim launcher

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -644,8 +644,7 @@ class Calabash::Cucumber::Launcher
     # for stability, quit the simulator if Xcode version is > 5.1 and the
     # target device is the simulator
     target_is_sim = simulator_target?(args)
-    xcode_gte_51 = RunLoop::Core.above_or_eql_version?('5.1', RunLoop::Core.xcode_version)
-    if target_is_sim and xcode_gte_51
+    if target_is_sim and RunLoop::XCTools.new.xcode_version_gte_51?
       self.simulator_launcher.stop
     end
 


### PR DESCRIPTION
The problem was with calls to a recently deprecated run-loop API.

This is one of the causes of the recent unstable CI builds.
