### PR TITLE
fixup `rake build_server` task

### DIFF
--- a/calabash-cucumber/Rakefile
+++ b/calabash-cucumber/Rakefile
@@ -128,6 +128,7 @@ EOF
   end
 end
 
-
+desc 'alias for build_server; deprecated since 0.10.0'
 task :install_server => [:build_server]
+desc 'alias for build_server; deprecated since 0.10.0'
 task :release_server => [:build_server]


### PR DESCRIPTION
Nightly CI was failing against the master toolchain because the dylibs step was failing.

I grouped the 'build' and 'install' phases together instead of building all the libraries and then installing all the libraries.

The build_server task was pretty crufty, so I spruced things up a bit and updated the documentation.

5ecd21d is a big whitespace change so the final diff is hard to read.
