### PR TITLE
Support Calabash Lite mode which uses pure UIAutomation

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
   s.add_dependency('httpclient', '~> 2.3.3')
   s.add_dependency('bundler', '~> 1.1')
   s.add_dependency('awesome_print')
-  s.add_dependency('run_loop', '>= 1.0.0.pre4')
+  s.add_dependency('run_loop', '>= 1.0.0.pre5')
 
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -1051,6 +1051,12 @@ module Calabash
       end
 
       # @!visibility private
+      def run_loop
+        l = Calabash::Cucumber::Launcher.launcher_if_used
+        l && l.run_loop
+      end
+
+      # @!visibility private
       def query_action_with_options(action, uiquery, options)
         uiquery, options = extract_query_and_options(uiquery, options)
         views_touched = launcher.actions.send(action, options)

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -555,17 +555,7 @@ class Calabash::Cucumber::Launcher
 
     if run_with_instruments?(args)
 
-      uia_strategy = ENV['UIA_STRATEGY'] || 'http'
-      case uia_strategy
-        when 'http'
-          args[:script] = :run_loop_fast_uia
-        when 'run_loop'
-          args[:script] = :run_loop_host
-        else
-          candidates = ['http', 'run_loop']
-          raise ArgumentError, "expected '#{uia_strategy}' to be one of #{candidates}"
-      end
-
+      uia_strategy = args[:uia_strategy] || :preferences
       self.run_loop = new_run_loop(args)
       self.actions= Calabash::Cucumber::InstrumentsActions.new
     else
@@ -575,11 +565,13 @@ class Calabash::Cucumber::Launcher
       self.simulator_launcher.relaunch(app_path, sdk_version(), args)
     end
     self.launch_args = args
-    ensure_connectivity
 
-    # skip compatibility check if injecting dylib
-    unless args.fetch(:inject_dylib, false)
-      check_server_gem_compatibility
+    unless args[:calabash_lite]
+      ensure_connectivity
+      # skip compatibility check if injecting dylib
+      unless args.fetch(:inject_dylib, false)
+        check_server_gem_compatibility
+      end
     end
   end
 
@@ -963,4 +955,3 @@ class Calabash::Cucumber::Launcher
   end
 
 end
-


### PR DESCRIPTION
Calabash Lite is a mode of operation where we can execute automated tests without needing the Calabash server. Only a smaller subset of operations are supported.

To use, call `relaunch` or `start_test_server_in_background` with data similar to: 

```
{calabash_lite: true, app:'com.example.app', device_target:'device'}
```

The option `uia_strategy` is also supported and passed on to run_loop (see https://github.com/calabash/run_loop/pull/18).
