### PR TITLE
Run rake-build-server last in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ script:
   - script/ci/travis/install-gem-ci.rb
   - script/ci/travis/rspec-ci.rb
   - script/ci/travis/unit-ci.rb
-  - script/ci/travis/rake-build-server-ci.rb
   - script/ci/travis/cucumber-ci.rb --tags ~@no_ci
+  - script/ci/travis/rake-build-server-ci.rb
 
 rvm:
   - 1.9.3

--- a/script/ci/travis/local-run-as-travis.rb
+++ b/script/ci/travis/local-run-as-travis.rb
@@ -39,13 +39,13 @@ Dir.chdir working_dir do
   do_system('script/ci/travis/unit-ci.rb',
             {:env_vars => env_vars})
 
-  do_system('script/ci/travis/rake-build-server-ci.rb',
-            {:env_vars => env_vars})
-
   do_system('script/ci/travis/cucumber-ci.rb --tags ~@no_ci',
             {:env_vars => env_vars})
 
   do_system('script/ci/travis/cucumber-dylib-ci.rb',
+            {:env_vars => env_vars})
+
+  do_system('script/ci/travis/rake-build-server-ci.rb',
             {:env_vars => env_vars})
 
 end


### PR DESCRIPTION
There is an order of operations conflict. The objc required libs required by the gem need to be present in order for the gem to be installed.

ATM the server make dylibs step cannot pass because it requires xcspecs to be injected into the Xcode.app
bundle.

The build-server tasks deletes the stub (fake) libraries installed in a previous CI build step which caused the next CI step to fail because the calabash-ios gem could not be fully installed.
