### PR TITLE
Calabash-ios sim commands use SimControl

### DIFF
--- a/calabash-cucumber/bin/calabash-ios-sim.rb
+++ b/calabash-cucumber/bin/calabash-ios-sim.rb
@@ -1,20 +1,20 @@
 require 'calabash-cucumber/utils/simulator_accessibility'
 require 'calabash-cucumber/utils/logging'
+require 'run_loop'
 
 include Calabash::Cucumber::Logging
 include Calabash::Cucumber::SimulatorAccessibility
 
 def quit_sim
-  _deprecated('0.9.169', 'use Calabash::Cucumber::SimulatorAccessibility.quit_simulator', :warn)
-  quit_simulator
+  RunLoop::SimControl.new.quit_sim
 end
 
 def calabash_sim_reset
-  reset_simulator_content_and_settings
+  RunLoop::SimControl.new.reset_sim_content_and_settings
 end
 
 def calabash_sim_accessibility
-  enable_accessibility_on_simulators
+  RunLoop::SimControl.new.enable_accessibility_on_sims
 end
 
 def calabash_sim_location(args)

--- a/calabash-cucumber/spec/bin/calabash_ios_sim_spec.rb
+++ b/calabash-cucumber/spec/bin/calabash_ios_sim_spec.rb
@@ -2,19 +2,25 @@ require File.expand_path(File.join(__FILE__, '..', '..', 'spec_helper'))
 require File.expand_path(File.join(__FILE__, '..', '..', '..', 'bin', 'calabash-ios-sim'))
 require 'calabash-cucumber/utils/simulator_accessibility'
 require 'calabash-cucumber/wait_helpers'
+require 'run_loop'
 
 describe 'calabash ios sim cli' do
 
-  it 'should deprecate the sim_quit method' do
-    out = capture_stderr do
-      quit_sim
-    end
-    expect(out.string.split(' ').include?('deprecated')).to be == true
+  let(:sim_control) { RunLoop::SimControl.new }
+
+  it '#quit_sim' do
+    sim_control.launch_sim
+    quit_sim
+    expect(sim_control.sim_is_running?).to be == false
   end
 
-  it 'should be able to reset the content and settings of the simulator' do
+  it '#calabash_sim_reset' do
+    # @todo figure out how and if this can/should be tested
     calabash_sim_reset
-    expect(existing_simulator_support_sdk_dirs.count).to be == 1
   end
 
+  it '#calabash_sim_accessibility' do
+    # @todo figure out how and if this can/should be tested
+    calabash_sim_accessibility
+  end
 end


### PR DESCRIPTION
Calabash::Cucumber::SimulatorAccessibility has been replaced with RunLoop::SimControl.
