### PR TITLE
WIP Adds method to set values in DEFAULT_OPTS

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/wait_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/wait_helpers.rb
@@ -48,6 +48,24 @@ module Calabash
             :screenshot_on_error => true
       }.freeze
 
+      # Allows users to override key/value pairs in `DEFAULT_OPTS`.
+      #
+      # @param [String] key The key for the value you want to change.
+      # @param [Object] value The value for the key you want to change.
+      # @return [Hash] The `Calabash::Cucumber::WaitHelpers::DEFAULTS_OPTS hash.
+      def self.override_default_option(key, value)
+        duplicate = Calabash::Cucumber::WaitHelpers::DEFAULT_OPTS.dup
+        duplicate[key] = value
+        begin
+          out = StringIO.new
+          $stderr = out
+          Calabash::Cucumber::WaitHelpers.const_set('DEFAULT_OPTS', duplicate)
+        ensure
+          $stderr = STDERR
+        end
+        Calabash::Cucumber::WaitHelpers::DEFAULT_OPTS
+      end
+
       # Waits for a condition to be true. The condition is specified by a given block that is called repeatedly.
       # If the block returns a 'trueish' value the condition is considered true and
       # `wait_for` immediately returns.

--- a/calabash-cucumber/spec/wait_helpers_spec.rb
+++ b/calabash-cucumber/spec/wait_helpers_spec.rb
@@ -1,0 +1,12 @@
+require 'calabash-cucumber'
+
+describe Calabash::Cucumber::WaitHelpers do
+
+  describe 'overriding DEFAULT_OPTS' do
+    it '.self.override_default_option' do
+      new_timeout = 10.0
+      Calabash::Cucumber::WaitHelpers.override_default_option(:timeout, new_timeout)
+      expect(Calabash::Cucumber::WaitHelpers::DEFAULT_OPTS[:timeout]).to be == new_timeout
+    end
+  end
+end


### PR DESCRIPTION
**WIP** _DO NOT MERGE_

Fix for #488 Override DEFAULT_OPTS 

I think it would be better to unfreeze `DEFAULT_OPTS`.
### Usage

```
### support/01_launch.rb

...
require 'calabash-cucumber/wait_helpers'

Before do |scenario|
  Calabash::Cucumber::WaitHelpers.override_default_option(:timeout, 1)
  ...
end
```
