### PR TITLE
Moves Version class out of version.rb

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber.rb
+++ b/calabash-cucumber/lib/calabash-cucumber.rb
@@ -8,6 +8,7 @@ require 'calabash-cucumber/version'
 require 'calabash-cucumber/date_picker'
 require 'calabash-cucumber/ipad_1x_2x'
 require 'calabash-cucumber/utils/logging'
+require 'calabash-cucumber/deprecated'
 
 # stubs for documentation
 

--- a/calabash-cucumber/lib/calabash-cucumber/deprecated.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/deprecated.rb
@@ -1,0 +1,22 @@
+require 'run_loop'
+
+module Calabash
+  module Cucumber
+
+    # A model of a release version that can be used to compare two version.
+    #
+    # Calabash tries very hard to comply with Semantic Versioning rules. However,
+    # the semantic versioning spec is incompatible with RubyGem's patterns for
+    # pre-release gems.
+    #
+    # > "But returning to the practical: No release version of SemVer is compatible with Rubygems." - _David Kellum_
+    #
+    # Calabash version numbers will be in the form `<major>.<minor>.<patch>[.pre<N>]`.
+    #
+    # @see http://semver.org/
+    # @see http://gravitext.com/2012/07/22/versioning.html
+    class Version < RunLoop::Version
+
+    end
+  end
+end

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -1,5 +1,4 @@
 require 'calabash-cucumber/utils/logging'
-require 'run_loop/version'
 
 module Calabash
   module Cucumber
@@ -20,22 +19,6 @@ module Calabash
         return nil
       end
       raise(NameError, "uninitialized constant Calabash::Cucumber::#{const_name}")
-    end
-
-    # A model of a release version that can be used to compare two version.
-    #
-    # Calabash tries very hard to comply with Semantic Versioning rules. However,
-    # the semantic versioning spec is incompatible with RubyGem's patterns for
-    # pre-release gems.
-    #
-    # > "But returning to the practical: No release version of SemVer is compatible with Rubygems." - _David Kellum_
-    #
-    # Calabash version numbers will be in the form `<major>.<minor>.<patch>[.pre<N>]`.
-    #
-    # @see http://semver.org/
-    # @see http://gravitext.com/2012/07/22/versioning.html
-    class Version < RunLoop::Version
-
     end
   end
 end


### PR DESCRIPTION
The gemspec reads lib/version.rb at install time.  Version.rb require'd run_loop/version which meant that run-loop needed to be installed _before_ the gemspec could be resolved and the gem installed.

I decided to create a `deprecated.rb` for APIs to live in before they are removed.  There are large number of deprecations coming soon.
- [ ] @krukow Have a look.  No rush.  We will need to resolve this before the next release.
