### PR TITLE
Return :preferences if device cannot be detected

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -608,6 +608,10 @@ class Calabash::Cucumber::Launcher
           break
         end
       end
+
+      # Device could not be found; kick the problem down the road.
+      return :preferences if target_device.nil?
+
       # Preferences strategy works for iOS < 8.0, but not for iOS >= 8.0.
       if target_device.version < RunLoop::Version.new('8.0')
         :preferences

--- a/calabash-cucumber/spec/launcher_spec.rb
+++ b/calabash-cucumber/spec/launcher_spec.rb
@@ -33,6 +33,12 @@ describe 'Calabash Launcher' do
         actual = launcher.default_uia_strategy(launch_args, sim_control)
         expect(actual).to be == :preferences
       end
+
+      it 'not found' do
+        launch_args = { :device_target => 'a udid of a device that does not exist' }
+        actual = launcher.default_uia_strategy(launch_args, sim_control)
+        expect(actual).to be == :preferences
+      end
     end
 
     it 'returns :host when target is an iOS device running iOS >= 8.0' do


### PR DESCRIPTION
When the device target cannot be found, this method was raising an error. 

Ex.  

```
$ DEVICE_TARGET=<udid of a device that is not connected> be cucumber
undefined method `version' for nil:NilClass (NoMethodError)
 /Users/moody/git/calabash-ios/calabash-cucumber/lib/calabash-cucumber/launcher.rb:612:in `default_uia_strategy'
 /Users/moody/git/calabash-ios/calabash-cucumber/lib/calabash-cucumber/launcher.rb:566:in `relaunch'
 /Users/moody/git/briar-ios-example/Briar/features/support/01_launch.rb:21:in `Before'

```

Unknown targets (devices or sims) should be detected either before or after this method.
