### PR TITLE
Replace run-loop calls with local equivalents in CI tests

### DIFF
--- a/script/ci/travis/ci-helpers.rb
+++ b/script/ci/travis/ci-helpers.rb
@@ -63,6 +63,15 @@ def travis_ci?
   ENV['TRAVIS']
 end
 
+def xcode_version
+  `xcrun xcodebuild -version`.split(/\s/)[1]
+end
+
+def xcode_version_gte_6?
+  version_parts = xcode_version.split('.')
+  version_parts.first.to_i >= 6
+end
+
 def update_rubygems
   do_system('gem update --system',
             {:pass_msg => 'updated rubygems',

--- a/script/ci/travis/cucumber-ci.rb
+++ b/script/ci/travis/cucumber-ci.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 require 'erb'
-require 'run_loop'
 require 'yaml'
 
 require File.expand_path(File.join(File.dirname(__FILE__), 'ci-helpers'))
@@ -105,8 +104,7 @@ Dir.chdir(working_directory) do
   end
 
   # Travis CI on Xcode 5.1.1 has a hard time with 64 bit simulators.
-  xcode_tools = RunLoop::XCTools.new
-  if travis_ci? and not xcode_tools.xcode_version_gte_6?
+  if travis_ci? and not xcode_version_gte_6?
     profiles[:air] = simulator_profiles[:air_mid]
     profiles[:iphone5s] = simulator_profiles[:iphone5s_mid]
   end

--- a/script/ci/travis/cucumber-dylib-ci.rb
+++ b/script/ci/travis/cucumber-dylib-ci.rb
@@ -1,10 +1,9 @@
 #!/usr/bin/env ruby
 require 'fileutils'
-require 'run_loop'
 
 require File.expand_path(File.join(File.dirname(__FILE__), 'ci-helpers'))
 
-if RunLoop::XCTools.new.xcode_version_gte_6?
+if xcode_version_gte_6?
   log_warn "Xcode >= 6 detected; skipping dylib because they don't run on Xcode 6"
   log_pass 'Exiting dylib tests with 0 because support for dylibs is experimental'
   exit 0

--- a/script/ci/travis/rake-build-server-ci.rb
+++ b/script/ci/travis/rake-build-server-ci.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'run_loop'
 require File.expand_path(File.join(File.dirname(__FILE__), 'ci-helpers'))
 
 working_directory = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'calabash-cucumber'))
@@ -19,10 +18,8 @@ Dir.chdir working_directory do
               'CALABASH_SERVER_PATH' => server_dir
         }
 
-  xcode_tools = RunLoop::XCTools.new
-
   # Xcode 6 supports dylib targets.
-  if xcode_tools.xcode_version_gte_6?
+  if xcode_version_gte_6?
     do_system('rake build_server',
               {:env_vars => env_vars,
                :pass_msg => 'built the framework, frank lib, and dylibs',
@@ -47,7 +44,7 @@ Dir.chdir working_directory do
   end
 
   # Xcode 6 supports dylib targets.
-  if xcode_tools.xcode_version_gte_6?
+  if xcode_version_gte_6?
     ['dylibs/libCalabashDyn.dylib', 'dylibs/libCalabashDynSim.dylib'].each do |lib|
       do_system("[ -e #{lib} ]",
                 {:pass_msg => "installed #{lib}",


### PR DESCRIPTION
It is dangerous to require run-loop in the CI tests because run-loop is installed and uninstalled repeatedly during the tests.
