### PR TITLE
Fix reset btw scenarios xcode 6

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -252,7 +252,21 @@ class Calabash::Cucumber::Launcher
 
     sim_control = opts.fetch(:sim_control, RunLoop::SimControl.new)
     if sim_control.xcode_version_gte_6?
+      default_sim = RunLoop::Core.default_simulator(sim_control.xctools)
+      udid = merged_opts[:udid] || ENV['DEVICE_TARGET'] || default_sim
 
+      target_simulator = nil
+      sim_control.simulators.each do |device|
+        if device.name == udid || device.udid == udid
+          target_simulator = device
+        end
+      end
+
+      if target_simulator.nil?
+        raise "Could not find a simulator that matches '#{udid}'"
+      end
+
+      sim_control.reset_sim_content_and_settings({:sim_udid => udid})
     else
       sdk ||= merged_opts[:sdk] || sdk_version || self.simulator_launcher.sdk_detector.latest_sdk_version
       path ||= merged_opts[:path] || self.simulator_launcher.app_bundle_or_raise(app_path)


### PR DESCRIPTION
@krukow 

I need feedback about this.  I have opted for the fastest and easiest path - use `simctl erase` to clear the simulator's content and settings.  If it is possible to reset the app sandbox in CoreSimulator, I haven't figured it out yet.
### Motivation

Fixes `reset_app_sandbox` for Xcode 6 Simulators.

Uses `simctl erase` to reset the target simulator's content and settings.

There are two other options, but both have significant technical problems.

The simulator must be quit regardless of the strategy; calling `simctl` on an 'Open' simulator can cause unexpected and displeasing behaviors.
### Option 1: Reset the simulator's content and settings.
#### Pro
1. It works and is easy to implement.
2. Deletes the NSUserDefaults.
#### Contra
1. Nukes the whole simulator.  In particular it deletes any installed media.
### Option 2: Reinstall the app
#### Pro
1. It does not nuke the whole simulator.  In particular, it does not delete any installed media.
#### Contra
1. Many calls to simctl; a new tool that might contain bugs.
2. Requires the app bundle id.  We do not require bundle ids for simulator runs.  We can extract the bundle id from the Info.plist.
3. Simctl install/reinstall does not delete the app's NSUserDefaults; we'll have to do that manually.
#### Unknown
- Is it faster to install an app with simctl or with instruments?
- Given that we have find the bundle identifier in the app bundle, is this approach faster than `simctl erase`?

```
1. Quit the simulator.
2. $ simctl shutdown "udid"                # must use udid 
3. $ simctl uninstall "udid" "com.my.app"  # requires bundle id
4. Use the bundle id to find the app's NSUserDefaults plist and delete it.
### Optional - Probably safer to let instruments do the install. 
5. $ simctl boot "udid"                    # must boot to reinstall
6. $ simctl install "udid" /path/to/App.app
7. $ simctl shutdown "udid"                # 'Booted' sims cannot be launched
```
### Option: 3 Delete the App Sandbox
##### Pro
1. This is what we actually want to do.
##### Contra
1. It doesn't work because we cannot know where the sandbox lives.
2. Requires bundle identifier to reset NSUserDefaults.
##### Discussion

In Xcode < 6, we could find the application sandbox without too much trouble and delete the 'Documents', 'Library', and 'tmp' directories.

In Xcode >= 6, the 'sandbox' does not reside in the same directory as the application bundle.  Further, there is no 'visual' mapping from the directory that contains the bundle to its sandbox.  Confused?  Here is a visual.
###### Depth 1 View

```
$ tree -d -L 1 
~/Library/Developer/CoreSimulator/Devices/626 < snip >DB8/data/Containers
├── Bundle  # App bundles are here.
├── Data    # App sandboxes are here.
└── Shared
```
###### Depth 2 View

```
$ tree -d -L 2 
~/Library/Developer/CoreSimulator/Devices/626 < snip >DB8/data/Containers
├── Bundle
│   ├── Application      # App bundles are here.
│   └── VPNPlugin
├── Data
│   ├── Application      # App sandboxes are here.
│   ├── PluginKitPlugin
│   └── VPNPlugin
└── Shared
    └── AppGroup
```
###### Depth 3 View

```
$ tree -d -L 3
~/Library/Developer/CoreSimulator/Devices/626 < snip >DB8/data/Containers
├── Bundle
│   ├── Application
│   │   └── 0BE351A1-C361-48F9-BDAD-D86B7239A5E0 # App bundle is here.
│   └── VPNPlugin
├── Data
│   ├── Application                              # Which directory is the sandbox?
│   │   ├── 1A91D858-ECD5-4830-A08F-EA1D0E3C09BB
│   │   ├── 3A53CD56-759B-495B-8803-FFE565064E8F
│   │   ├── 4A7FD99B-911C-4365-9970-8D754B907C17
│   │   ├── 55E75259-E875-4025-82CE-F7D845F3E1A5
│   │   ├── 65EDBA31-4445-4427-B3AD-1BCE721726D2
│   │   ├── 6B8EFE35-EBE9-40B0-A4F6-70262F028378
│   │   ├── 754E1ABD-B369-4F13-82D9-95BEE6EDD774
│   │   ├── A03AF826-21EB-4DCD-8DDD-2C4DC92972FF
│   │   ├── CD2F2ABB-657E-4C48-87A7-28A3399F9B0F
│   │   ├── E26F6428-77EA-46AC-8326-56CA0D400437
│   │   ├── E75425E0-43F5-4836-8ABC-8C18FEC7DB5D
│   │   └── F0F97BAC-8ACA-4093-B83F-42A79D6199E5
< snip >
```

My best guess is that the map from `Bundle/Application` to `Bundle/Data/Application` exists in a binary plist somewhere.  I could not find any such plist, despite grep'ing and visually inspecting the contents of the `data` directory.

Unless we can make a connection between the application bundle and a sandbox, we cannot use this method.
