### PR TITLE
Update run-loop dependency to ~> 1.0.8

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |s|
   # match the xamarin-test-cloud dependency
   s.add_dependency('bundler', '~> 1.3')
   s.add_dependency('awesome_print', '~> 1.2.0')
-  s.add_dependency('run_loop', '~> 1.0.3')
+  s.add_dependency('run_loop', '~> 1.0.8')
 
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
- iOS 8 on-device testing requires instruments kill fixes.
- CoreSimulator testing requires reset simulator fixes.
