### PR TITLE
Update cucumber dependency to 1.3.17

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9'
 
-  s.add_dependency('cucumber', '~> 1.3.0')
+  s.add_dependency('cucumber', '~> 1.3.17')
   s.add_dependency('calabash-common', '~> 0.0.1')
   s.add_dependency('json', '~> 1.8')
   s.add_dependency('edn', '~> 1.0.6')


### PR DESCRIPTION
Some android users are trying to use cucumber 2.0 which is still in beta.

We will support cucumber 2.0, but it is a huge rewrite and we will have to change our default hooks.

@TobiasRoikjer 
