### PR TITLE
Turn JSON parse exception into meaningful error

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/uia.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/uia.rb
@@ -26,7 +26,13 @@ module Calabash
         case run_loop[:uia_strategy]
           when :preferences
             res = http({:method => :post, :path => 'uia'}, {:command => command}.merge(options))
-            res = JSON.parse(res)
+
+            begin
+              res = JSON.parse(res)
+            rescue TypeError, JSON::ParserError => _
+              raise "Could not parse response '#{res}'; the app has probably crashed"
+            end
+
             if res['outcome'] != 'SUCCESS'
               raise "uia action failed because: #{res['reason']}\n#{res['details']}"
             end

--- a/calabash-cucumber/spec/uia_spec.rb
+++ b/calabash-cucumber/spec/uia_spec.rb
@@ -3,6 +3,7 @@ module Calabash
     module UIA
       class TestObject
         include Calabash::Cucumber::UIA
+        include Calabash::Cucumber::HTTPHelpers
       end
     end
   end
@@ -67,6 +68,18 @@ describe Calabash::Cucumber::UIA do
         mocked_value = {'status' => 'error', 'index' =>0}
         expect(test_obj).to receive(:uia_handle_command).and_return(mocked_value)
         expect { test_obj.uia_type_string 'foo' }.to raise_error
+      end
+    end
+  end
+
+  describe 'uia' do
+    describe 'raises an error' do
+      it 'when http returns nil - simulates an app crash' do
+        launcher = Calabash::Cucumber::Launcher.new
+        launcher.run_loop = {:uia_strategy => :preferences}
+        expect(Calabash::Cucumber::Launcher).to receive(:launcher_if_used).and_return(launcher)
+        expect(test_obj).to receive(:http).and_return('')
+        expect { test_obj.uia('command') }.to raise_error
       end
     end
   end


### PR DESCRIPTION
The current JSON exception does not convey that the app or server has crashed.

The current "JSON::ParserError: A JSON text must at least contain two octets!" is misleading.
