### PR TITLE
Pin dependency to sim_launcher to 0.4.13

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -58,8 +58,8 @@ Gem::Specification.new do |s|
   s.add_dependency('json', '~> 1.8')
   s.add_dependency('edn', '~> 1.0.6')
   s.add_dependency('CFPropertyList','~> 2.2.8')
-  # Pinned because 0.4.12 _requires_ ios-sim installed with brew.
-  s.add_dependency('sim_launcher', '0.4.11')
+  # Avoid 0.5 release because it does not contain ios-sim binary.
+  s.add_dependency('sim_launcher', '~> 0.4.13')
   s.add_dependency('slowhandcuke', '~> 0.0.3')
   s.add_dependency('geocoder', '~>1.1.8')
   s.add_dependency('httpclient', '~> 2.3.3')


### PR DESCRIPTION
sim_launcher 0.4.12 removed the bundled ios-sim because it was broken in Xcode 6 environments.  Unfortunately, this requires calabash users to install ios-sim or see runtime exceptions even if they are not directly using ios-sim.

This is a temporary fix.  We will either remove the sim_launcher dependency (planned) or monkey patch.

Woot!  Thanks @moredip for releasing 0.4.13 to help us work around this issue.
