### PR TITLE
Rubocop static code analysis integration

### DIFF
--- a/calabash-cucumber/Rakefile
+++ b/calabash-cucumber/Rakefile
@@ -11,7 +11,6 @@ rescue Exception => _
   warn 'skipping rspec requirement because it is a development dependency'
 end
 
-
 begin
   require 'yard'
   YARD::Rake::YardocTask.new do |t|
@@ -19,6 +18,15 @@ begin
   end
 rescue Exception => _
   warn 'skipping yard requirement because it is a development dependency'
+end
+
+begin
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new(:rubocop) do |t|
+    t.patterns = %w(bin/**/*.rb lib/**/*.rb)
+  end
+rescue Exception => _
+  warn 'skipping rubocop requirement because it is a development dependency'
 end
 
 # Builds and installs the Objective-C libraries that this gem requires.

--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -71,5 +71,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'yard', '~> 0.8'
   s.add_development_dependency 'redcarpet', '~> 3.1'
-
+  s.add_development_dependency 'rubocop', '~> 0.27'
 end


### PR DESCRIPTION
**Background**
Rubocop is static code analyser for Ruby that reports problems in the code and suggests good coding practices based on the Ruby Style Guide. See Rubocop project: https://github.com/bbatsov/rubocop

**Motivation**
This pull request only integrates Rubocop to the project and adds rake task for an easy and fast execution. Actual offences will be fixed and cleaned up in the separate tasks (I will volunteer to start implementing those tasks).

Currently Rubocop detects **2605** offences when `calabash-cucumber/bin` and `calabash-cucumber/lib` folders are analysed: http://www.screencast.com/t/NZjOpQd5

After cleanup tasks are completed we will benefit
1. Cleaner codebase
2. More unified coding style throughout the project
3. Easier to spot new and fatal offences in the future