### PR TITLE
Bump run loop and version to 0.11.5.pre3

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |s|
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
   s.add_dependency('awesome_print', '~> 1.2.0')
-  s.add_dependency('run_loop', '~> 1.1.1.pre6')
+  s.add_dependency('run_loop', '~> 1.1.1.pre7')
 
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -3,11 +3,11 @@ module Calabash
 
     # @!visibility public
     # The Calabash iOS gem version.
-    VERSION = '0.11.5.pre4'
+    VERSION = '0.11.5.pre3'
 
     # @!visibility public
     # The minimum required version of the calabash.framework or, for Xamarin
     # users, the Calabash component.
-    MIN_SERVER_VERSION = '0.11.5.pre2'
+    MIN_SERVER_VERSION = '0.11.5.pre3'
   end
 end


### PR DESCRIPTION
Attempt recovery from interrupted syscalls in run_loop.

Corresponds to:

https://github.com/calabash/run_loop/pull/83

Includes also:
https://github.com/calabash/calabash-ios/issues/607
https://github.com/calabash/calabash-ios-server/pull/99

Pre-released as: 0.11.5.pre3
