### PR TITLE
Feature: dump prerelease

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |s|
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
   s.add_dependency('awesome_print', '~> 1.2.0')
-  s.add_dependency('run_loop', '~> 1.1.1.pre9')
+  s.add_dependency('run_loop', '~> 1.2.0.pre1')
 
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -3,11 +3,11 @@ module Calabash
 
     # @!visibility public
     # The Calabash iOS gem version.
-    VERSION = '0.11.5.pre5'
+    VERSION = '0.12.0.pre1'
 
     # @!visibility public
     # The minimum required version of the calabash.framework or, for Xamarin
     # users, the Calabash component.
-    MIN_SERVER_VERSION = '0.11.5.pre3'
+    MIN_SERVER_VERSION = '0.12.0.pre1'
   end
 end


### PR DESCRIPTION
Provide a pre-release with the server supporting the dump feature. Also updates run_loop to 1.2.0.pre1

Pre-release: 0.12.0.pre1
