### PR TITLE
Fix touch after rotation

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |s|
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
   s.add_dependency('awesome_print', '~> 1.2.0')
-  s.add_dependency('run_loop', '~> 1.2.0.pre3')
+  s.add_dependency('run_loop', '~> 1.2.0.pre5')
 
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -171,6 +171,9 @@ module Calabash
       #   and causes the touch to be offset with `(x,y)` relative to the center (`center + (offset[:x], offset[:y])`).
       # @return {Array<Hash>} array containing the serialized version of the tapped view.
       def touch(uiquery, options={})
+        if uiquery.nil? && options[:offset].nil?
+          raise "called touch(nil) without specifying an offset in options (#{options})"
+        end
         query_action_with_options(:touch, uiquery, options)
       end
 

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -526,6 +526,11 @@ class Calabash::Cucumber::Launcher
     # @todo Use SimControl in Launcher in place of methods like simulator_target?
     args[:sim_control] = RunLoop::SimControl.new
 
+    if args[:app]
+      if !File.exist?(args[:app])
+        raise "Unable to find app bundle at #{args[:app]}. It should be an iOS Simulator build (typically a *.app directory)."
+      end
+    end
     args[:app] = args[:app] || args[:bundle_id] || app_path || detect_app_bundle_from_args(args)
 
 

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -90,6 +90,7 @@ module Calabash
           playback(candidate)
           # need a longer sleep for cloud testing
           sleep(0.4)
+          touch(nil,offset:{x:1,y:1})
 
           res = status_bar_orientation
           if res.nil?

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -171,7 +171,8 @@ module Calabash
       end
 
       def recalibrate_after_rotation
-        uia_tap_offset(x:0,y:0)
+        #uia_tap_offset(x:0,y:0)
+        uia_query :window
       end
 
 

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -90,7 +90,7 @@ module Calabash
           playback(candidate)
           # need a longer sleep for cloud testing
           sleep(0.4)
-          touch(nil,offset:{x:1,y:1})
+          recalibrate_after_rotation()
 
           res = status_bar_orientation
           if res.nil?
@@ -165,10 +165,15 @@ module Calabash
           end
         else
           result = playback("rotate_#{rotate_cmd}")
-          touch(nil,offset:{x:1,y:1})
+          recalibrate_after_rotation
           result
         end
       end
+
+      def recalibrate_after_rotation
+        uia_tap_offset(x:0,y:0)
+      end
+
 
     end
   end

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -163,7 +163,9 @@ module Calabash
             puts "Could not rotate device in direction '#{dir}' with orientation '#{current_orientation} - will do nothing"
           end
         else
-          playback("rotate_#{rotate_cmd}")
+          result = playback("rotate_#{rotate_cmd}")
+          touch(nil,offset:{x:1,y:1})
+          result
         end
       end
 

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -9,6 +9,12 @@ module Calabash
 
       include Calabash::Cucumber::Logging
 
+      # @!visibility private
+      def rotation_candidates
+        %w(rotate_left_home_down rotate_left_home_left rotate_left_home_right rotate_left_home_up
+           rotate_right_home_down rotate_right_home_left rotate_right_home_right rotate_right_home_up)
+      end
+
       # Rotates the home button position to the position indicated by `dir`.
       #
       # @example portrait
@@ -26,26 +32,154 @@ module Calabash
       # @note Refer to Apple's documentation for clarification about left vs.
       #  right landscape orientations.
       #
+      # @note For legacy support the `dir` argument can be a String or Symbol.
+      #  Please update your code to pass a Symbol.
+      #
+      # @note For legacy support `:top` and `top` are synonyms for `:up`.
+      #  Please update your code to pass `:up`.
+      #
+      # @note For legacy support `:bottom` and `bottom` are synonyms for `:down`.
+      #  Please update your code to pass `:down`.
+      #
+      # @note This method generates verbose messages when full console logging
+      #  is enabled.  See {Calabash::Cucumber::Logging#full_console_logging?}.
+      #
       # @param [Symbol] dir The position of the home button after the rotation.
       #  Can be one of `{:down | :left | :right | :up }`.
+      #
+      # @return [Symbol] The orientation of the button when all rotations have
+      #  been completed.  If there is problem rotating, this method will return
+      #  `:down` regardless of the actual home button position.
+      #
       def rotate_home_button_to(dir)
-        uia_rotate_home_button_to(dir)
+        if uia_available?
+          uia_rotate_home_button_to(dir)
+          return dir
+        end
+
+        dir_sym = dir.to_sym
+        if dir_sym.eql?(:top)
+          if full_console_logging?
+            calabash_warn "converting '#{dir}' to ':up' - please adjust your code"
+          end
+          dir_sym = :up
+        end
+
+        if dir_sym.eql?(:bottom)
+          if full_console_logging?
+            calabash_warn "converting '#{dir}' to ':down' - please adjust your code"
+          end
+          dir_sym = :down
+        end
+
+        directions = [:down, :up, :left, :right]
+        unless directions.include?(dir_sym)
+          screenshot_and_raise "expected one of '#{directions}' as an arg to 'rotate_home_button_to but found '#{dir}'"
+        end
+
+        res = status_bar_orientation()
+        if res.nil?
+          screenshot_and_raise "expected 'status_bar_orientation' to return a non-nil value"
+        else
+          res = res.to_sym
+        end
+
+        return res if res.eql? dir_sym
+
+        rotation_candidates.each { |candidate|
+          if full_console_logging?
+            puts "try to rotate to '#{dir_sym}' using '#{candidate}'"
+          end
+          playback(candidate)
+          # need a longer sleep for cloud testing
+          sleep(0.4)
+          recalibrate_after_rotation()
+
+          res = status_bar_orientation
+          if res.nil?
+            screenshot_and_raise "expected 'status_bar_orientation' to return a non-nil value"
+          else
+            res = res.to_sym
+          end
+
+          return if res.eql? dir_sym
+        }
+
+        if full_console_logging?
+          calabash_warn "Could not rotate home button to '#{dir}'."
+          calabash_warn 'Is rotation enabled for this controller?'
+          calabash_warn "Will return 'down'"
+        end
+        :down
       end
 
       # Rotates the device in the direction indicated by `dir`.
       #
       # @example rotate left
       #  rotate :left
-      #  same as rotate('counter-clockwise')
       #
       # @example rotate right
       #  rotate :right
-      #  same as rotate('clockwise')
       #
-      # @note The `dir` argument can be a String or Symbol.
+      # @example rotate down
+      #  rotate :down
+      #
+      # @example rotate up
+      #  rotate :up
+      #
+      # @note For legacy support the `dir` argument can be a String or Symbol.
+      #  Please update your code to pass a Symbol.
+      #
+      # @param [Symbol] dir The position of the home button after the rotation.
+      #  Can be one of `{:down | :left | :right | :up }`.
       def rotate(dir)
-        uia_rotate(dir)
+        if uia_available?
+          uia_rotate(dir)
+          return dir
+        end
+        dir = dir.to_sym
+        current_orientation = status_bar_orientation().to_sym
+        rotate_cmd = nil
+        case dir
+          when :left then
+            if current_orientation == :down
+              rotate_cmd = 'left_home_down'
+            elsif current_orientation == :right
+              rotate_cmd = 'left_home_right'
+            elsif current_orientation == :left
+              rotate_cmd = 'left_home_left'
+            elsif current_orientation == :up
+              rotate_cmd = 'left_home_up'
+            end
+          when :right then
+            if current_orientation == :down
+              rotate_cmd = 'right_home_down'
+            elsif current_orientation == :left
+              rotate_cmd = 'right_home_left'
+            elsif current_orientation == :right
+              rotate_cmd = 'right_home_right'
+            elsif current_orientation == :up
+              rotate_cmd = 'right_home_up'
+            end
+        end
+
+        if rotate_cmd.nil?
+          if full_console_logging?
+            puts "Could not rotate device in direction '#{dir}' with orientation '#{current_orientation} - will do nothing"
+          end
+        else
+          result = playback("rotate_#{rotate_cmd}")
+          recalibrate_after_rotation
+          result
+        end
       end
+
+      def recalibrate_after_rotation
+        #uia_tap_offset(x:0,y:0)
+        uia_query :window
+      end
+
+
     end
   end
 end

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -52,11 +52,6 @@ module Calabash
       #  `:down` regardless of the actual home button position.
       #
       def rotate_home_button_to(dir)
-        if uia_available?
-          uia_rotate_home_button_to(dir)
-          return dir
-        end
-
         dir_sym = dir.to_sym
         if dir_sym.eql?(:top)
           if full_console_logging?
@@ -133,10 +128,6 @@ module Calabash
       # @param [Symbol] dir The position of the home button after the rotation.
       #  Can be one of `{:down | :left | :right | :up }`.
       def rotate(dir)
-        if uia_available?
-          uia_rotate(dir)
-          return dir
-        end
         dir = dir.to_sym
         current_orientation = status_bar_orientation().to_sym
         rotate_cmd = nil
@@ -175,7 +166,6 @@ module Calabash
       end
 
       def recalibrate_after_rotation
-        #uia_tap_offset(x:0,y:0)
         uia_query :window
       end
 

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -9,12 +9,6 @@ module Calabash
 
       include Calabash::Cucumber::Logging
 
-      # @!visibility private
-      def rotation_candidates
-        %w(rotate_left_home_down rotate_left_home_left rotate_left_home_right rotate_left_home_up
-           rotate_right_home_down rotate_right_home_left rotate_right_home_right rotate_right_home_up)
-      end
-
       # Rotates the home button position to the position indicated by `dir`.
       #
       # @example portrait
@@ -32,150 +26,26 @@ module Calabash
       # @note Refer to Apple's documentation for clarification about left vs.
       #  right landscape orientations.
       #
-      # @note For legacy support the `dir` argument can be a String or Symbol.
-      #  Please update your code to pass a Symbol.
-      #
-      # @note For legacy support `:top` and `top` are synonyms for `:up`.
-      #  Please update your code to pass `:up`.
-      #
-      # @note For legacy support `:bottom` and `bottom` are synonyms for `:down`.
-      #  Please update your code to pass `:down`.
-      #
-      # @note This method generates verbose messages when full console logging
-      #  is enabled.  See {Calabash::Cucumber::Logging#full_console_logging?}.
-      #
       # @param [Symbol] dir The position of the home button after the rotation.
       #  Can be one of `{:down | :left | :right | :up }`.
-      #
-      # @return [Symbol] The orientation of the button when all rotations have
-      #  been completed.  If there is problem rotating, this method will return
-      #  `:down` regardless of the actual home button position.
-      #
-      # @todo When running under UIAutomation, we should use that API to rotate
-      #  instead of relying on playbacks.
       def rotate_home_button_to(dir)
-        dir_sym = dir.to_sym
-        if dir_sym.eql?(:top)
-          if full_console_logging?
-            calabash_warn "converting '#{dir}' to ':up' - please adjust your code"
-          end
-          dir_sym = :up
-        end
-
-        if dir_sym.eql?(:bottom)
-          if full_console_logging?
-            calabash_warn "converting '#{dir}' to ':down' - please adjust your code"
-          end
-          dir_sym = :down
-        end
-
-        directions = [:down, :up, :left, :right]
-        unless directions.include?(dir_sym)
-          screenshot_and_raise "expected one of '#{directions}' as an arg to 'rotate_home_button_to but found '#{dir}'"
-        end
-
-        res = status_bar_orientation()
-        if res.nil?
-          screenshot_and_raise "expected 'status_bar_orientation' to return a non-nil value"
-        else
-          res = res.to_sym
-        end
-
-        return res if res.eql? dir_sym
-
-        rotation_candidates.each { |candidate|
-          if full_console_logging?
-            puts "try to rotate to '#{dir_sym}' using '#{candidate}'"
-          end
-          playback(candidate)
-          # need a longer sleep for cloud testing
-          sleep(0.4)
-          recalibrate_after_rotation()
-
-          res = status_bar_orientation
-          if res.nil?
-            screenshot_and_raise "expected 'status_bar_orientation' to return a non-nil value"
-          else
-            res = res.to_sym
-          end
-
-          return if res.eql? dir_sym
-        }
-
-        if full_console_logging?
-          calabash_warn "Could not rotate home button to '#{dir}'."
-          calabash_warn 'Is rotation enabled for this controller?'
-          calabash_warn "Will return 'down'"
-        end
-        :down
+        uia_rotate_home_button_to(dir)
       end
 
       # Rotates the device in the direction indicated by `dir`.
       #
       # @example rotate left
       #  rotate :left
+      #  same as rotate('counter-clockwise')
       #
       # @example rotate right
       #  rotate :right
+      #  same as rotate('clockwise')
       #
-      # @example rotate down
-      #  rotate :down
-      #
-      # @example rotate up
-      #  rotate :up
-      #
-      # @note For legacy support the `dir` argument can be a String or Symbol.
-      #  Please update your code to pass a Symbol.
-      #
-      # @param [Symbol] dir The position of the home button after the rotation.
-      #  Can be one of `{:down | :left | :right | :up }`.
-      #
-      # @todo When running under UIAutomation, we should use that API to rotate
-      #  instead of relying on playbacks.
+      # @note The `dir` argument can be a String or Symbol.
       def rotate(dir)
-        dir = dir.to_sym
-        current_orientation = status_bar_orientation().to_sym
-        rotate_cmd = nil
-        case dir
-          when :left then
-            if current_orientation == :down
-              rotate_cmd = 'left_home_down'
-            elsif current_orientation == :right
-              rotate_cmd = 'left_home_right'
-            elsif current_orientation == :left
-              rotate_cmd = 'left_home_left'
-            elsif current_orientation == :up
-              rotate_cmd = 'left_home_up'
-            end
-          when :right then
-            if current_orientation == :down
-              rotate_cmd = 'right_home_down'
-            elsif current_orientation == :left
-              rotate_cmd = 'right_home_left'
-            elsif current_orientation == :right
-              rotate_cmd = 'right_home_right'
-            elsif current_orientation == :up
-              rotate_cmd = 'right_home_up'
-            end
-        end
-
-        if rotate_cmd.nil?
-          if full_console_logging?
-            puts "Could not rotate device in direction '#{dir}' with orientation '#{current_orientation} - will do nothing"
-          end
-        else
-          result = playback("rotate_#{rotate_cmd}")
-          recalibrate_after_rotation
-          result
-        end
+        uia_rotate(dir)
       end
-
-      def recalibrate_after_rotation
-        #uia_tap_offset(x:0,y:0)
-        uia_query :window
-      end
-
-
     end
   end
 end

--- a/calabash-cucumber/lib/calabash-cucumber/uia.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/uia.rb
@@ -277,6 +277,44 @@ module Calabash
         uia_handle_command(:screenshot, name)
       end
 
+      # Simulates Rotation of the device
+      # @param [String|Symbol] dir The position of the home button after the rotation.
+      #  Can be one of `{'clockwise' | 'counter-clockwise'| :left | :right}`.
+      #
+      def uia_rotate(dir)
+        uia_handle_command(:rotate, dir)
+      end
+
+      # Gets the current orientation of the device
+      # @return {String} the current orientation of the device
+      #   one of `{'portrait', 'portrait-upside-down', 'landscape-left', 'landscape-right', 'faceup', 'facedown' }`
+      def uia_orientation
+        o = uia_handle_command(:orientation).to_s
+        o[1..o.length]
+      end
+
+      # Rotates the home button position to the position indicated by `dir`.
+      # @note Refer to Apple's documentation for clarification about left vs.
+      #  right landscape orientations.
+      # @param [Symbol|String] dir The position of the home button after the rotation.
+      #  Can be one of `{:down, :left, :right, :up }`.
+      def uia_rotate_home_button_to(dir)
+        dir = dir.to_sym
+        uia_orientation = case dir
+                           when :left then
+                             'UIA_DEVICE_ORIENTATION_LANDSCAPERIGHT'
+                           when :right then
+                             'UIA_DEVICE_ORIENTATION_LANDSCAPELEFT'
+                           when :up then
+                             'UIA_DEVICE_ORIENTATION_PORTRAIT'
+                           when :down then
+                             'UIA_DEVICE_ORIENTATION_PORTRAIT_UPSIDEDOWN'
+                           else
+                             raise "Unexpected direction #{dir}"
+                          end
+        uia("target.setDeviceOrientation(#{uia_orientation})")
+      end
+
       # @!visibility private
       def uia_type_string(string, opt_text_before='', escape=true)
         result = uia_handle_command(:typeString, string, opt_text_before)

--- a/calabash-cucumber/lib/calabash-cucumber/uia.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/uia.rb
@@ -300,6 +300,11 @@ module Calabash
       #  Can be one of `{:down, :left, :right, :up }`.
       def uia_rotate_home_button_to(dir)
         dir = dir.to_sym
+        if dir == :top
+          dir = :up
+        elsif dir == :bottom
+          dir = :down
+        end
         uia_orientation = case dir
                            when :left then
                              'UIA_DEVICE_ORIENTATION_LANDSCAPERIGHT'

--- a/calabash-cucumber/lib/calabash-cucumber/uia.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/uia.rb
@@ -306,9 +306,9 @@ module Calabash
                            when :right then
                              'UIA_DEVICE_ORIENTATION_LANDSCAPELEFT'
                            when :up then
-                             'UIA_DEVICE_ORIENTATION_PORTRAIT'
-                           when :down then
                              'UIA_DEVICE_ORIENTATION_PORTRAIT_UPSIDEDOWN'
+                           when :down then
+                             'UIA_DEVICE_ORIENTATION_PORTRAIT'
                            else
                              raise "Unexpected direction #{dir}"
                           end

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -3,7 +3,7 @@ module Calabash
 
     # @!visibility public
     # The Calabash iOS gem version.
-    VERSION = '0.12.0.pre3'
+    VERSION = '0.12.0.pre4'
 
     # @!visibility public
     # The minimum required version of the calabash.framework or, for Xamarin

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -3,7 +3,7 @@ module Calabash
 
     # @!visibility public
     # The Calabash iOS gem version.
-    VERSION = '0.12.0.pre5'
+    VERSION = '0.12.0.pre6'
 
     # @!visibility public
     # The minimum required version of the calabash.framework or, for Xamarin

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -3,7 +3,7 @@ module Calabash
 
     # @!visibility public
     # The Calabash iOS gem version.
-    VERSION = '0.12.0.pre2'
+    VERSION = '0.12.0.pre3'
 
     # @!visibility public
     # The minimum required version of the calabash.framework or, for Xamarin

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -3,7 +3,7 @@ module Calabash
 
     # @!visibility public
     # The Calabash iOS gem version.
-    VERSION = '0.12.0.pre4'
+    VERSION = '0.12.0.pre5'
 
     # @!visibility public
     # The minimum required version of the calabash.framework or, for Xamarin


### PR DESCRIPTION
Fixes 'lost' touches after a rotation occurring in the :preferences strategy. We don't know exatly why this happens. But it seems that UIAutomation is not in sync with the apps orientation. We synchronize the UIA process view hiearchy with the app view hiearchy by making a uia_query action after rotation.



### Other

* Launcher raises an error if .app does not exist (fail fast)
* Fails fast if `touch` arguments do not contain a query or an :offset #641