### PR TITLE
Relax json dependency to 1.8

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('cucumber', '~> 1.3.17')
   s.add_dependency('calabash-common', '~> 0.0.1')
-  s.add_dependency('json', '1.8.1')
+  s.add_dependency('json', '~> 1.8')
   s.add_dependency('edn', '~> 1.0.6')
   s.add_dependency('CFPropertyList','~> 2.2.8')
   # Avoid 0.5 release because it does not contain ios-sim binary.


### PR DESCRIPTION
### Motivation

No longer need to restrict json version.