### PR TITLE
Feature/console attach needs to chose the correct strategy

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -67,7 +67,7 @@ Gem::Specification.new do |s|
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
   s.add_dependency('awesome_print', '~> 1.6')
-  s.add_dependency('run_loop', '~> 1.2.2')
+  s.add_dependency('run_loop', '~> 1.2.3')
 
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -1081,11 +1081,16 @@ module Calabash
       #
       #  to connect to the current launcher
       #
+      # @param [Symbol] uia_strategy Optionally specify the uia strategy, which
+      #   can be one of :shared_element, :preferences, :host.  If you don't
+      #   know which to choose, don't specify one and calabash will try deduce
+      #   the correct strategy to use based on the environment variables used
+      #   when starting the console.
       # @return [Calabash::Cucumber::Launcher,nil] the currently active
       #  calabash launcher
-      def console_attach
+      def console_attach(uia_strategy = nil)
         # setting the @calabash_launcher here for backward compatibility
-        @calabash_launcher = launcher.attach
+        @calabash_launcher = launcher.attach({:uia_strategy => uia_strategy})
       end
 
       # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -96,7 +96,12 @@ class Calabash::Cucumber::Launcher
   end
 
   # @see Calabash::Cucumber::Core#console_attach
-  def attach(max_retry=1, timeout=10)
+  def attach(options={})
+    default_options = {:max_retry => 1,
+                       :timeout => 10,
+                       :uia_strategy => nil}
+    merged_options = default_options.merge(options)
+
     if calabash_no_launch?
       self.actions= Calabash::Cucumber::PlaybackActions.new
       return
@@ -114,10 +119,10 @@ class Calabash::Cucumber::Launcher
     end
 
     # Sets the device attribute.
-    ensure_connectivity(max_retry, timeout)
+    ensure_connectivity(merged_options[:max_retry], merged_options[:timeout])
 
-    if self.device.simulator?
-      run_loop[:uia_strategy] = :preferences
+    if merged_options[:uia_strategy]
+      run_loop[:uia_strategy] = merged_options[:uia_strategy]
     else
       if self.device.ios_major_version < '8'
         run_loop[:uia_strategy] = :preferences

--- a/calabash-cucumber/spec/integration/launcher_spec.rb
+++ b/calabash-cucumber/spec/integration/launcher_spec.rb
@@ -48,27 +48,9 @@ describe 'Calabash Launcher' do
       end
     end
 
-    it 'can attach to a running instruments instance' do
-      launcher.relaunch(launch_options)
-      expect(launcher.run_loop).not_to be == nil
-
-      other_launcher.attach
-
-      expect(other_launcher.run_loop).not_to be nil
-      expect(other_launcher.run_loop[:uia_strategy]).to be == :shared_element
-
-      calabash_console_with_strategy() do |stdout, stderr|
-        expect(stdout.read.strip[/Error/,0]).to be == nil
-        expect(stderr.read.strip).to be == ''
-      end
-    end
-
-    describe 'non-default uia strategies can connect to launched apps' do
-      [:preferences, :host].shuffle.each do |strategy|
+    describe 'can connect to launched apps' do
+      [:preferences, :host, :shared_element].shuffle.each do |strategy|
         it strategy do
-          if strategy.intern == :host
-            pending ':host strategy requires a fix. https://github.com/calabash/calabash-ios/issues/638'
-          end
 
           launch_options[:uia_strategy] = strategy
 

--- a/calabash-cucumber/spec/integration/launcher_spec.rb
+++ b/calabash-cucumber/spec/integration/launcher_spec.rb
@@ -18,34 +18,70 @@ describe 'Calabash Launcher' do
   end
 
   describe '#attach' do
-    it 'can attach to a running instruments instance' do
-      stub_env('DEVICE_TARGET', nil)
-      sim_control = RunLoop::SimControl.new
-      options =
-            {
-                  :app => Resources.shared.app_bundle_path(:lp_simple_example),
-                  :device_target => 'simulator',
-                  :no_stop => true,
-                  :sim_control => sim_control,
-                  :launch_retries => Resources.shared.launch_retries
-            }
-      launcher.relaunch(options)
-      expect(launcher.run_loop).not_to be == nil
+    before(:each) {   stub_env('DEVICE_TARGET', nil) }
+    let(:launch_options) {
+      {
+            :app => Resources.shared.app_bundle_path(:lp_simple_example),
+            :device_target => 'simulator',
+            :no_stop => true,
+            :sim_control => RunLoop::SimControl.new,
+            :launch_retries => Resources.shared.launch_retries
+      }
+    }
 
-      other_launcher = Calabash::Cucumber::Launcher.new
-      other_launcher.attach
+    let(:other_launcher) { Calabash::Cucumber::Launcher.new }
 
-      expect(other_launcher.run_loop).not_to be nil
-      expect(other_launcher.run_loop[:uia_strategy]).to be == :preferences
-
+    def calabash_console_with_strategy(strategy=nil)
+      if strategy.nil?
+        attach_cmd = 'console_attach'
+      else
+        # Super weird, but we need to force the : here.
+        attach_cmd = "console_attach(:#{strategy})"
+      end
       Open3.popen3('sh') do |stdin, stdout, stderr, _|
         stdin.puts 'bundle exec calabash-ios console <<EOF'
-        stdin.puts 'console_attach'
+        stdin.puts attach_cmd
         stdin.puts "touch 'textField'"
         stdin.puts 'EOF'
         stdin.close
+        yield stdout, stderr
+      end
+    end
+
+    it 'can attach to a running instruments instance' do
+      launcher.relaunch(launch_options)
+      expect(launcher.run_loop).not_to be == nil
+
+      other_launcher.attach
+
+      expect(other_launcher.run_loop).not_to be nil
+      expect(other_launcher.run_loop[:uia_strategy]).to be == :shared_element
+
+      calabash_console_with_strategy() do |stdout, stderr|
         expect(stdout.read.strip[/Error/,0]).to be == nil
         expect(stderr.read.strip).to be == ''
+      end
+    end
+
+    describe 'non-default uia strategies can connect to launched apps' do
+      [:preferences, :host].shuffle.each do |strategy|
+        it strategy do
+
+          launch_options[:uia_strategy] = strategy
+
+          launcher.relaunch(launch_options)
+          expect(launcher.run_loop).not_to be == nil
+
+          other_launcher.attach({:uia_strategy => strategy})
+
+          expect(other_launcher.run_loop).not_to be nil
+          expect(other_launcher.run_loop[:uia_strategy]).to be == strategy
+
+          calabash_console_with_strategy(strategy) do |stdout, stderr|
+            expect(stdout.read.strip[/Error/,0]).to be == nil
+            expect(stderr.read.strip).to be == ''
+          end
+        end
       end
     end
   end

--- a/calabash-cucumber/spec/integration/launcher_spec.rb
+++ b/calabash-cucumber/spec/integration/launcher_spec.rb
@@ -49,6 +49,9 @@ describe 'Calabash Launcher' do
     end
 
     describe 'can connect to launched apps' do
+
+      before(:each) { FileUtils.rm_rf(RunLoop::HostCache.default_directory) }
+
       [:preferences, :host, :shared_element].shuffle.each do |strategy|
         it strategy do
 

--- a/calabash-cucumber/spec/integration/launcher_spec.rb
+++ b/calabash-cucumber/spec/integration/launcher_spec.rb
@@ -66,6 +66,9 @@ describe 'Calabash Launcher' do
     describe 'non-default uia strategies can connect to launched apps' do
       [:preferences, :host].shuffle.each do |strategy|
         it strategy do
+          if strategy.intern == :host
+            pending ':host strategy requires a fix. https://github.com/calabash/calabash-ios/issues/638'
+          end
 
           launch_options[:uia_strategy] = strategy
 


### PR DESCRIPTION
#### Motivation

Fixes:

* **When :uia_strategy => :host, `console_attach` attaches, but throws exception when performing gestures.** #638
* **"TypeError: no implicit conversion of nil into String" for write_request when user needs to establish/re-establish a valid run_loop is not user-friendly** [run_loop #102](https://github.com/calabash/run_loop/issues/102)

See also:  **Feature/enable host strategy caching for console attach** [run_loop #107](https://github.com/calabash/run_loop/pull/107)