### PR TITLE
Remove version dependencies from gems provided by run loop

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -67,8 +67,6 @@ Gem::Specification.new do |s|
   s.add_dependency('bundler', '~> 1.3')
   s.add_dependency('run_loop', '~> 1.2.6')
 
-  s.add_development_dependency 'rake', '~> 10.3'
-  s.add_development_dependency 'rspec', '~> 3.0'
   # Shared with run-loop.
   s.add_dependency('json')
   s.add_dependency('CFPropertyList')
@@ -76,10 +74,15 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'yard', '~> 0.8'
   s.add_development_dependency 'redcarpet', '3.2.0'
-  s.add_development_dependency 'pry', '~> 0.9'
-  s.add_development_dependency 'pry-nav', '~> 0.2'
-  s.add_development_dependency 'guard-rspec', '~> 4.3'
-  s.add_development_dependency 'guard-bundler', '~> 2.0'
-  s.add_development_dependency 'growl', '~> 1.0'
-  s.add_development_dependency 'stub_env', '~> 0.2'
+
+  # Shared with run-loop.
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'pry-nav'
+  s.add_development_dependency 'guard-rspec'
+  s.add_development_dependency 'guard-bundler'
+  s.add_development_dependency 'growl'
+  s.add_development_dependency 'stub_env'
+
 end

--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -55,8 +55,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency('cucumber', '~> 1.3.17')
   s.add_dependency('calabash-common', '~> 0.0.1')
-  s.add_dependency('json', '~> 1.8')
-  s.add_dependency('CFPropertyList','~> 2.2.8')
   # Avoid 1.0.5 release; has an errant 'binding.pry'.
   s.add_dependency('edn', '>= 1.0.6', '< 2.0')
   # Avoid 0.5 release because it does not contain ios-sim binary.
@@ -67,12 +65,15 @@ Gem::Specification.new do |s|
   s.add_dependency('httpclient', '>= 2.3.2', '< 3.0')
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
-  # Let run-loop and calabash-android control the version.
-  s.add_dependency('awesome_print')
   s.add_dependency('run_loop', '~> 1.2.6')
 
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'
+  # Shared with run-loop.
+  s.add_dependency('json')
+  s.add_dependency('CFPropertyList')
+  s.add_dependency('awesome_print')
+
   s.add_development_dependency 'yard', '~> 0.8'
   s.add_development_dependency 'redcarpet', '3.2.0'
   s.add_development_dependency 'pry', '~> 0.9'


### PR DESCRIPTION
**FORCE PUSHED** Tue 3 Feb 13:37 CET

#### Motivation

I want to reduce the gem dependencies to avoid problems like:

* **calabash 0.12.0: Unable to resolve dependencies: calabash-cucumber requires awesome_print (~> 1.2.0)** #668
* **undefined local variable or method `start_test_server_in_background' in calabash-ios 0.12.0** #669 - which was ultimately an awesome-print dependency mismatch