### PR TITLE
fixup awesome print dependencies

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -67,7 +67,8 @@ Gem::Specification.new do |s|
   s.add_dependency('httpclient', '>= 2.3.2', '< 3.0')
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
-  s.add_dependency('awesome_print', '~> 1.6')
+  # Let run-loop and calabash-android control the version.
+  s.add_dependency('awesome_print')
   s.add_dependency('run_loop', '~> 1.2.5')
 
   s.add_development_dependency 'rake', '~> 10.3'

--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -69,7 +69,7 @@ Gem::Specification.new do |s|
   s.add_dependency('bundler', '~> 1.3')
   # Let run-loop and calabash-android control the version.
   s.add_dependency('awesome_print')
-  s.add_dependency('run_loop', '~> 1.2.5')
+  s.add_dependency('run_loop', '~> 1.2.6')
 
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -68,7 +68,7 @@ Gem::Specification.new do |s|
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
   s.add_dependency('awesome_print', '~> 1.6')
-  s.add_dependency('run_loop', '~> 1.2.4')
+  s.add_dependency('run_loop', '~> 1.2.5')
 
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/calabash-cucumber/spec/bin/calabash_ios_cli_spec.rb
+++ b/calabash-cucumber/spec/bin/calabash_ios_cli_spec.rb
@@ -23,4 +23,20 @@ describe 'Command Line Interface' do
       expect(err).to be == ''
     end
   end
+
+  it 'awesome-print monkey-patch in run-loop is applied' do
+    # Make sure run-loop has the patch applied.
+    Open3.popen3('sh') do |stdin, stdout, stderr, _|
+      stdin.puts 'IRBRC=../scripts/.irbrc bundle exec irb <<EOF'
+      stdin.puts "require 'run_loop'"
+      stdin.puts "foo = RunLoop::Version.new('9.9.9')"
+      stdin.puts 'EOF'
+      stdin.close
+      out = stdout.read.strip
+      err = stderr.read.strip
+      expect(out[/Error: undefined method `major' for/,0]).to be == nil
+      expect(out[/Error:/,0]).to be == nil
+      expect(err).to be == ''
+    end
+  end
 end


### PR DESCRIPTION
#### Motivation

Awesome-print is used by calabash-android, calabash-ios, and run-loop. 

We would like to use awesome_print ~> 1.6 because it has fixes for Objects (like RunLoop::Version) that implement `==`.  Unfortunately, if we require a ~> 1.6 version, x-platform users will need to update both the iOS and Android gem versions.  I am not complete convinced that this is the case (see below), but users running outside of bundler may encounter problems.

* #668 calabash 0.12.0: Unable to resolve dependencies: calabash-cucumber requires awesome_print (~> 1.2.0)

In any event, I this PR bumps the run-loop version to 1.2.6.  Run-loop 1.2.6 re-applies an awesome_print patch that fixes the problem mentioned above.  In addition, the version requirements for awesome_print have been removed; calabash-ios will use whatever awesome_print version run-loop is using.


#### Notes

Using a Gemfile like the one below + bundler shows that there is no conflict between awesome_print ~> 1.6 and calabash-android.

```
source "https://rubygems.org"

gem 'awesome_print', '~> 1.6'
gem 'calabash-android', '~> 0.5'
gem 'calabash-cucumber', '~> 0.12'

$ bundle update ==> awesome_print 1.6.1
```



