### PR TITLE
Pin stub_env to 0.2; 1.0.0 release is buggy

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -83,6 +83,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-rspec'
   s.add_development_dependency 'guard-bundler'
   s.add_development_dependency 'growl'
-  s.add_development_dependency 'stub_env'
+  # stub_env 1.0.0 is buggy.
+  s.add_development_dependency 'stub_env', '0.2.0'
 
 end


### PR DESCRIPTION
#### Motivation

* **version 1.0.0 `stub_env` is raising {} does not implement: stubbed?** [#1](https://github.com/littleowllabs/stub_env/issues/1)
