### PR TITLE
Rescue `awesome_print` LoadError in default .irbrc.

### DIFF
--- a/calabash-cucumber/scripts/.irbrc
+++ b/calabash-cucumber/scripts/.irbrc
@@ -1,7 +1,26 @@
 require 'rubygems'
 require 'irb/completion'
 require 'irb/ext/save-history'
-require 'awesome_print'
+
+begin
+  require 'awesome_print'
+rescue LoadError => e
+  msg = ["Caught a LoadError: could not load 'awesome_print'",
+         "#{e}",
+         '',
+         'Use bundler (recommended) or uninstall awesome_print.',
+         '',
+         '# Use bundler (recommended)',
+         '$ bundle update',
+         '$ bundle exec calabash-ios console',
+         '',
+         '# Uninstall',
+         '$ gem update --system',
+         '$ gem uninstall -Vax --force --no-abort-on-dependent awesome_print']
+  puts msg
+  exit(1)
+end
+
 AwesomePrint.irb!
 
 ARGV.concat [ '--readline',

--- a/calabash-cucumber/spec/bin/calabash_ios_cli_spec.rb
+++ b/calabash-cucumber/spec/bin/calabash_ios_cli_spec.rb
@@ -38,4 +38,28 @@ describe 'Command Line Interface' do
       expect(err).to be == ''
     end
   end
+
+  it 'handles gem LoadError by exiting' do
+    original_irbrc = Resources.shared.irbrc_path
+    target_dir = Dir.mktmpdir('run-loop-rspec')
+    copied_irbrc = File.join(target_dir, '.irbrc')
+    FileUtils.cp(original_irbrc, copied_irbrc)
+    contents = File.read(copied_irbrc)
+    substituted = contents.gsub(/require 'awesome_print'/, "require 'unknown_gem'")
+    File.open(copied_irbrc, 'w') do |file|
+      file.puts substituted
+    end
+
+    Open3.popen3('sh') do |stdin, stdout, stderr, process_status|
+      stdin.puts "IRBRC=#{copied_irbrc} bundle exec irb <<EOF"
+      stdin.puts 'EOF'
+      stdin.close
+      out = stdout.read.strip
+      err = stderr.read.strip
+
+      expect(err).to be == ''
+      expect(out[/Caught a LoadError: could not load 'awesome_print'/,0]).to_not be nil
+      expect(process_status.value.exitstatus).to be == 1
+    end
+  end
 end

--- a/calabash-cucumber/spec/resources.rb
+++ b/calabash-cucumber/spec/resources.rb
@@ -27,6 +27,10 @@ class Resources
     @resources_dir ||= File.expand_path(File.join(File.dirname(__FILE__), 'resources'))
   end
 
+  def irbrc_path
+    @irbrc_path ||= File.expand_path(File.join(File.dirname(__FILE__), '..', 'scripts', '.irbrc'))
+  end
+
   def app_bundle_path(bundle_name)
     case bundle_name
       when :lp_simple_example


### PR DESCRIPTION
#### Motivation

`LoadError`s generated by `require` statements in `.irbrc` generate no output; they fail silently.  To the casual user, the irb appears to have loaded correctly, but in fact the evaluation of the .irbrc stops at the first exception.

We've been handling a lot of support questions about "Why aren't the calabash methods loaded in the console?".  Most of these have been because of incompatible versions of `awesome_print`.

