### PR TITLE
Fix issue #246 - undefined method embed

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/operations.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/operations.rb
@@ -27,6 +27,17 @@ module Calabash
       include Calabash::Cucumber::DatePicker
       include Calabash::Cucumber::IPad
 
+      def self.extended(base)
+        if (class << base; included_modules.map(&:to_s).include?('Cucumber::RbSupport::RbWorld'); end)
+          unless instance_methods.include?(:embed)
+            original_embed = base.method(:embed)
+            define_method(:embed) do |*args|
+              original_embed.call(*args)
+            end
+          end
+        end
+      end
+
     end
   end
 end

--- a/calabash-cucumber/test/cucumber/features/models/not-pom/home_page.rb
+++ b/calabash-cucumber/test/cucumber/features/models/not-pom/home_page.rb
@@ -1,0 +1,10 @@
+module NotPOM
+  class HomePage
+    include Calabash::Cucumber::Operations
+
+    def my_exceptional_method
+      screenshot_and_raise 'Hey!'
+    end
+
+  end
+end

--- a/calabash-cucumber/test/cucumber/features/screenshot_and_raise.feature
+++ b/calabash-cucumber/test/cucumber/features/screenshot_and_raise.feature
@@ -1,0 +1,15 @@
+@screenshot_and_raise
+@issue_246
+Feature:  Screenshot and raise
+  In order to delight calabash clients all the world round
+  As a calabash developer
+  I want to take screenshots and raise exceptions
+
+  Scenario: screenshot_and_raise in the context of cucumber
+    When I use screenshot_and_raise in the context of cucumber
+    Then I should get a runtime exception
+
+  Scenario: screenshot_and_raise outside the context of cucumber
+    When I screenshot_and_raise outside the context of cucumber
+    Then I should get a runtime exception
+    But it should not be a NoMethod exception for embed

--- a/calabash-cucumber/test/cucumber/features/step_definitions/screenshot_and_raise_steps.rb
+++ b/calabash-cucumber/test/cucumber/features/step_definitions/screenshot_and_raise_steps.rb
@@ -1,0 +1,30 @@
+When(/^I use screenshot_and_raise in the context of cucumber$/) do
+  begin
+    screenshot_and_raise 'Hey!'
+  rescue StandardError => e
+    @screenshot_and_raise_exception = e
+  end
+end
+
+Then(/^I should get a runtime exception$/) do
+  if @screenshot_and_raise_exception.nil?
+    raise 'Expected the previous step to raise an exception'
+  end
+end
+
+When(/^I screenshot_and_raise outside the context of cucumber$/) do
+  begin
+    NotPOM::HomePage.new.my_exceptional_method
+  rescue StandardError => e
+    @screenshot_and_raise_exception = e
+  end
+end
+
+But(/^it should not be a NoMethod exception for embed$/) do
+  error = @screenshot_and_raise_exception
+  is_a_no_method_error = error.is_a?(NoMethodError)
+
+  if is_a_no_method_error
+    raise "Expected '#{error}' not to be a NoMethodError"
+  end
+end


### PR DESCRIPTION
**undefined method `embed` (NoMethodError) when calling screenshot_and_raise** #246

### Notes

Users who still see this should be sure to include `Calabash::Cucumber::Operations` in their non-IBase classes.

###### Bad

```
module NotPOM
  class HomePage
    include Calabash::Cucumber::FailureHelpers

    # Will raise undefined method `embed' error.
    def my_exceptional_method
      screenshot_and_raise 'Hey!'
    end

  end
end
```

###### Good

```
module NotPOM
  class HomePage
    include Calabash::Cucumber::Operations

    def my_exceptional_method
      screenshot_and_raise 'Hey!'
    end

  end
end
```


