### PR TITLE
Adds iphone_6?, iphone_6_plus?, and iphone_35in? form-factor helper methods

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -136,7 +136,7 @@ module Calabash
       # @return [Hash] screen dimensions, scale and down/up sampling fraction.
       attr_reader :screen_dimensions
 
-      # @deprecated 0.13.0 no replacement
+      # @deprecated 0.13.1 no replacement
       # Indicates whether or not this device has a 4in screen.
       # @attribute [r] iphone_4in
       # @return [Boolean] `true` if this device has a 4in screen.
@@ -322,6 +322,15 @@ module Calabash
       def iphone_5?
         _deprecated('0.9.168', "use 'iphone_4in?' instead", :warn)
         iphone_4in?
+      end
+
+      # @deprecated 0.13.1 - Call `iphone_4in?` instead.
+      # @see #iphone_4in?
+      # @note Deprecated after introducing new `form_factor` behavior.
+      # @return [Boolean] true if this device is an iPhone 5 or 5s
+      def iphone_4in
+        _deprecated('0.13.1', "use 'iphone_4in?' instead", :warn)
+        @iphone_4in
       end
     end
   end

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -118,6 +118,18 @@ module Calabash
       # @return [String] The udid of this device.
       attr_accessor :udid
 
+      # The form factor of this device.
+      # @attribute [r] form_factor
+      #
+      # Will be one of:
+      #   * ipad
+      #   * iphone 4in
+      #   * iphone 3.5in
+      #   * iphone 6
+      #   * iphone 6+
+      #   * "" # if no information can be found.
+      attr_reader :form_factor
+
       # For Calabash server version > 0.10.2 provides
       # device specific screen information.
       #
@@ -158,6 +170,7 @@ module Calabash
             @screen_dimensions[key.to_sym] = val
           end
         end
+        @form_factor = version_data['form_factor']
       end
 
       # Is this device a simulator or physical device?

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -209,7 +209,7 @@ module Calabash
       # Is this device a 4in iPhone?
       # @return [Boolean] true if this device is a 4in iphone
       def iphone_4in?
-        @iphone_4in
+        form_factor == 'iphone 4in'
       end
 
       # Is this device an iPhone 6?

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -209,6 +209,24 @@ module Calabash
         @iphone_4in
       end
 
+      # Is this device an iPhone 6?
+      # @return [Boolean] true if this device is an iPhone 6
+      def iphone_6?
+        form_factor == 'iphone 6'
+      end
+
+      # Is this device an iPhone 6+?
+      # @return [Boolean] true if this device is an iPhone 6+
+      def iphone_6_plus?
+        form_factor == 'iphone 6+'
+      end
+
+      # Is this device an iPhone 3.5in?
+      # @return [Boolean] true if this device is an iPhone 3.5in?
+      def iphone_35in?
+        form_factor == 'iphone 3.5in'
+      end
+
       # @deprecated 0.9.168 replaced with iphone_4in?
       # @see #iphone_4in?
       # Is this device an iPhone 5?

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -108,11 +108,6 @@ module Calabash
       # @return [Boolean] `true` if the app under test is emulated
       attr_reader :iphone_app_emulated_on_ipad
 
-      # Indicates whether or not this device has a 4in screen.
-      # @attribute [r] iphone_4in
-      # @return [Boolean] `true` if this device has a 4in screen.
-      attr_reader :iphone_4in
-
       # @deprecated 0.10.0 no replacement
       # @!attribute [rw] udid
       # @return [String] The udid of this device.
@@ -146,6 +141,12 @@ module Calabash
       # @return [Hash] screen dimensions, scale and down/up sampling fraction.
       attr_reader :screen_dimensions
 
+      # @deprecated 0.13.0 no replacement
+      # Indicates whether or not this device has a 4in screen.
+      # @attribute [r] iphone_4in
+      # @return [Boolean] `true` if this device has a 4in screen.
+      attr_reader :iphone_4in
+
       # Creates a new instance of Device.
       #
       # @see Calabash::Cucumber::Core#server_version
@@ -162,7 +163,6 @@ module Calabash
         @ios_version = version_data['iOS_version']
         @server_version = version_data['version']
         @iphone_app_emulated_on_ipad = version_data['iphone_app_emulated_on_ipad']
-        @iphone_4in = version_data['4inch']
         screen_dimensions = version_data['screen_dimensions']
         if screen_dimensions
           @screen_dimensions = {}
@@ -171,6 +171,9 @@ module Calabash
           end
         end
         @form_factor = version_data['form_factor']
+
+        # Deprecated 0.13.0
+        @iphone_4in = version_data['4inch']
       end
 
       # Is this device a simulator or physical device?

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -108,11 +108,6 @@ module Calabash
       # @return [Boolean] `true` if the app under test is emulated
       attr_reader :iphone_app_emulated_on_ipad
 
-      # @deprecated 0.10.0 no replacement
-      # @!attribute [rw] udid
-      # @return [String] The udid of this device.
-      attr_accessor :udid
-
       # The form factor of this device.
       # @attribute [r] form_factor
       #
@@ -146,6 +141,11 @@ module Calabash
       # @attribute [r] iphone_4in
       # @return [Boolean] `true` if this device has a 4in screen.
       attr_reader :iphone_4in
+
+      # @deprecated 0.10.0 no replacement
+      # @!attribute [rw] udid
+      # @return [String] The udid of this device.
+      attr_accessor :udid
 
       # Creates a new instance of Device.
       #

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -230,16 +230,6 @@ module Calabash
         form_factor == 'iphone 3.5in'
       end
 
-      # @deprecated 0.9.168 replaced with iphone_4in?
-      # @see #iphone_4in?
-      # Is this device an iPhone 5?
-      # @note Deprecated because the iPhone 5S reports as an iPhone6,*.
-      # @return [Boolean] true if this device is an iPhone 5
-      def iphone_5?
-        _deprecated('0.9.168', "use 'iphone_4in?' instead", :warn)
-        iphone_4in?
-      end
-
       # @!visibility private
       def version_hash (version_str)
         tokens = version_str.split(/[,.]/)
@@ -322,6 +312,16 @@ module Calabash
       def udid=(value)
         _deprecated('0.10.0', 'no replacement', :warn)
         @udid = value
+      end
+
+      # @deprecated 0.9.168 replaced with iphone_4in?
+      # @see #iphone_4in?
+      # Is this device an iPhone 5?
+      # @note Deprecated because the iPhone 5S reports as an iPhone6,*.
+      # @return [Boolean] true if this device is an iPhone 5
+      def iphone_5?
+        _deprecated('0.9.168', "use 'iphone_4in?' instead", :warn)
+        iphone_4in?
       end
     end
   end

--- a/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
@@ -102,6 +102,27 @@ module Calabash
         _default_device_or_create().iphone_4in?
       end
 
+      # Is this device an iPhone 6?
+      # @raise [RuntimeError] if the server cannot be reached
+      # @return [Boolean] true if this device is an iPhone 6
+      def iphone_6?
+        _default_device_or_create.iphone_6?
+      end
+
+      # Is this device an iPhone 6+?
+      # @raise [RuntimeError] if the server cannot be reached
+      # @return [Boolean] true if this device is an iPhone 6+
+      def iphone_6_plus?
+        _default_device_or_create.iphone_6_plus?
+      end
+
+      # Is this device an iPhone 3.5in?
+      # @raise [RuntimeError] if the server cannot be reached
+      # @return [Boolean] true if this device is an iPhone 3.5in?
+      def iphone_35in?
+        _default_device_or_create.iphone_35in?
+      end
+
       # Is the device under test running iOS 5?
       #
       # @note

--- a/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
@@ -94,13 +94,6 @@ module Calabash
         _default_device_or_create().simulator?
       end
 
-      # @deprecated 0.9.168 replaced with `iphone_4in?`
-      # @see #iphone_4in?
-      def iphone_5?
-        _deprecated('0.9.168', "use 'iphone_4in?' instead", :warn)
-        iphone_4in?
-      end
-
       # Does the device under test have 4in screen?
       #
       # @raise [RuntimeError] if the server cannot be reached
@@ -139,7 +132,6 @@ module Calabash
         _OS_ENV.eql?(_canonical_os_version(:ios6)) || _default_device_or_create().ios6?
       end
 
-
       # Is the device under test running iOS 7?
       #
       # @note
@@ -175,6 +167,13 @@ module Calabash
       # @return [Boolean] true if app is being emulated on an iPad.
       def iphone_app_emulated_on_ipad?
         _default_device_or_create().iphone_app_emulated_on_ipad?
+      end
+
+      # @deprecated 0.9.168 replaced with `iphone_4in?`
+      # @see #iphone_4in?
+      def iphone_5?
+        _deprecated('0.9.168', "use 'iphone_4in?' instead", :warn)
+        iphone_4in?
       end
 
       private

--- a/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
@@ -56,68 +56,68 @@ module Calabash
 
       # Is the device under test an iPad?
       #
-      # @raise [RuntimeError] if the server cannot be reached
+      # @raise [RuntimeError] If the server cannot be reached.
       # @return [Boolean] true if device under test is an iPad.
       def ipad?
-        _default_device_or_create().ipad?
+        _default_device_or_create.ipad?
       end
 
       # Is the device under test an iPhone?
       #
-      # @raise [RuntimeError] if the server cannot be reached
+      # @raise [RuntimeError] If the server cannot be reached.
       # @return [Boolean] true if device under test is an iPhone.
       def iphone?
-        _default_device_or_create().iphone?
+        _default_device_or_create.iphone?
       end
 
       # Is the device under test an iPod?
       #
-      # @raise [RuntimeError] if the server cannot be reached
+      # @raise [RuntimeError] If the server cannot be reached.
       # @return [Boolean] true if device under test is an iPod.
       def ipod?
-        _default_device_or_create().ipod?
+        _default_device_or_create.ipod?
       end
 
       # Is the device under test an iPhone or iPod?
       #
-      # @raise [RuntimeError] if the server cannot be reached
-      # @return [Boolean] true if device under test is an iPhone or iPod.
+      # @raise [RuntimeError] If the server cannot be reached.
+      # @return [Boolean] true If device under test is an iPhone or iPod.
       def device_family_iphone?
         iphone? or ipod?
       end
 
       # Is the device under test a simulator?
       #
-      # @raise [RuntimeError] if the server cannot be reached
+      # @raise [RuntimeError] If the server cannot be reached.
       # @return [Boolean] true if device under test is a simulator.
       def simulator?
-        _default_device_or_create().simulator?
+        _default_device_or_create.simulator?
       end
 
-      # Does the device under test have 4in screen?
+      # Is the device under test have a 4 inch screen?
       #
-      # @raise [RuntimeError] if the server cannot be reached
+      # @raise [RuntimeError] If the server cannot be reached.
       # @return [Boolean] true if device under test has a 4in screen.
       def iphone_4in?
-        _default_device_or_create().iphone_4in?
+        _default_device_or_create.iphone_4in?
       end
 
-      # Is this device an iPhone 6?
-      # @raise [RuntimeError] if the server cannot be reached
+      # Is the device under test an iPhone 6.
+      # @raise [RuntimeError] If the server cannot be reached.
       # @return [Boolean] true if this device is an iPhone 6
       def iphone_6?
         _default_device_or_create.iphone_6?
       end
 
-      # Is this device an iPhone 6+?
-      # @raise [RuntimeError] if the server cannot be reached
+      # Is the device under test an iPhone 6+?
+      # @raise [RuntimeError] If the server cannot be reached.
       # @return [Boolean] true if this device is an iPhone 6+
       def iphone_6_plus?
         _default_device_or_create.iphone_6_plus?
       end
 
-      # Is this device an iPhone 3.5in?
-      # @raise [RuntimeError] if the server cannot be reached
+      # Is the device under test an iPhone 3.5in?
+      # @raise [RuntimeError] If the server cannot be reached.
       # @return [Boolean] true if this device is an iPhone 3.5in?
       def iphone_35in?
         _default_device_or_create.iphone_35in?
@@ -184,10 +184,10 @@ module Calabash
       #
       # @see Calabash::Cucumber::IPad
       #
-      # @raise [RuntimeError] if the server cannot be reached
+      # @raise [RuntimeError] If the server cannot be reached.
       # @return [Boolean] true if app is being emulated on an iPad.
       def iphone_app_emulated_on_ipad?
-        _default_device_or_create().iphone_app_emulated_on_ipad?
+        _default_device_or_create.iphone_app_emulated_on_ipad?
       end
 
       # @deprecated 0.9.168 replaced with `iphone_4in?`

--- a/calabash-cucumber/spec/integration/device_spec.rb
+++ b/calabash-cucumber/spec/integration/device_spec.rb
@@ -10,7 +10,7 @@ describe Calabash::Cucumber::Device do
 
   let(:endpoint) { 'http://localhost:37265' }
 
-  describe '#iphone_4in?' do
+  describe '#form_factor' do
     let(:device)  do
       options = {
             :app => Resources.shared.app_bundle_path(:lp_simple_example),
@@ -30,7 +30,7 @@ describe Calabash::Cucumber::Device do
           expect(true).to be == true
         end
       else
-        subject { device.iphone_4in? }
+        subject { device.form_factor }
         xcode_installs.each do |developer_dir|
           context "#{developer_dir}" do
             before do
@@ -47,7 +47,7 @@ describe Calabash::Cucumber::Device do
                   'iPhone Retina (4-inch) - Simulator - iOS 7.1'
                 end
               }
-              it { should be == true }
+              it { is_expected.to be == 'iphone 4in' }
             end
             context 'device is a 3.5" iphone' do
               let(:device_target) {
@@ -59,7 +59,7 @@ describe Calabash::Cucumber::Device do
                   'iPhone Retina (3.5-inch) - Simulator - iOS 7.1'
                 end
               }
-              it { should be == false }
+              it { is_expected.to be == 'iphone 3.5in' }
             end
             context 'device is an iphone 6' do
               let(:device_target) {
@@ -72,7 +72,7 @@ describe Calabash::Cucumber::Device do
                   nil
                 end
               }
-              it { should be == false if device_target }
+              it { is_expected.to be == 'iphone 6' if device_target }
             end
             context 'device is an iphone 6+' do
               let(:device_target) {
@@ -85,7 +85,7 @@ describe Calabash::Cucumber::Device do
                   nil
                 end
               }
-              it { should be == false if device_target }
+              it { is_expected.to be == 'iphone 6+' if device_target }
             end
           end
         end

--- a/calabash-cucumber/spec/integration/device_spec.rb
+++ b/calabash-cucumber/spec/integration/device_spec.rb
@@ -1,21 +1,13 @@
 describe Calabash::Cucumber::Device do
 
   before(:example) do
-    ENV.delete('DEVELOPER_DIR')
-    ENV.delete('DEBUG')
-    ENV.delete('DEBUG_UNIX_CALLS')
     RunLoop::SimControl.terminate_all_sims
   end
 
   after(:example) {
-    ENV.delete('DEVELOPER_DIR')
-    ENV.delete('DEBUG')
-    ENV.delete('DEBUG_UNIX_CALLS')
     RunLoop::SimControl.terminate_all_sims
   }
 
-  # noinspection RubyStringKeysInHashInspection
-  let(:simulator_data) { Resources.shared.server_version :simulator }
   let(:endpoint) { 'http://localhost:37265' }
 
   describe '#iphone_4in?' do
@@ -42,18 +34,15 @@ describe Calabash::Cucumber::Device do
         xcode_installs.each do |developer_dir|
           context "#{developer_dir}" do
             before do
-              ENV['DEVELOPER_DIR'] = developer_dir
+              stub_env('DEVELOPER_DIR', developer_dir)
             end
 
             context 'device is an 4in iphone' do
               let(:device_target) {
                 xcode_tools = RunLoop::XCTools.new
-                if xcode_tools.xcode_version_gte_62?
-                  'iPhone 5 (8.2 Simulator)'
-                elsif xcode_tools.xcode_version_gte_61?
-                  'iPhone 5 (8.1 Simulator)'
-                elsif xcode_tools.xcode_version_gte_6?
-                  'iPhone 5 (8.0 Simulator)'
+                version = xcode_tools.xcode_version
+                if xcode_tools.xcode_version_gte_6?
+                  Resources.shared.core_simulator_for_xcode_version('iPhone', '5', version)
                 else
                   'iPhone Retina (4-inch) - Simulator - iOS 7.1'
                 end
@@ -63,12 +52,9 @@ describe Calabash::Cucumber::Device do
             context 'device is a 3.5" iphone' do
               let(:device_target) {
                 xcode_tools = RunLoop::XCTools.new
-                if xcode_tools.xcode_version_gte_62?
-                  'iPhone 4s (8.2 Simulator)'
-                elsif xcode_tools.xcode_version_gte_61?
-                  'iPhone 4s (8.1 Simulator)'
-                elsif xcode_tools.xcode_version_gte_6?
-                  'iPhone 4s (8.0 Simulator)'
+                version = xcode_tools.xcode_version
+                if xcode_tools.xcode_version_gte_6?
+                  Resources.shared.core_simulator_for_xcode_version('iPhone', '4s', version)
                 else
                   'iPhone Retina (3.5-inch) - Simulator - iOS 7.1'
                 end
@@ -78,12 +64,9 @@ describe Calabash::Cucumber::Device do
             context 'device is an iphone 6' do
               let(:device_target) {
                 xcode_tools = RunLoop::XCTools.new
-                if xcode_tools.xcode_version_gte_62?
-                  'iPhone 6 (8.2 Simulator)'
-                elsif xcode_tools.xcode_version_gte_61?
-                  'iPhone 6 (8.1 Simulator)'
-                elsif xcode_tools.xcode_version_gte_6?
-                  'iPhone 6 (8.0 Simulator)'
+                version = xcode_tools.xcode_version
+                if xcode_tools.xcode_version_gte_6?
+                  Resources.shared.core_simulator_for_xcode_version('iPhone', '6', version)
                 else
                   # iPhone 6 does not exist on Xcode < 6
                   nil
@@ -94,12 +77,9 @@ describe Calabash::Cucumber::Device do
             context 'device is an iphone 6+' do
               let(:device_target) {
                 xcode_tools = RunLoop::XCTools.new
-                if xcode_tools.xcode_version_gte_62?
-                  'iPhone 6 Plus (8.2 Simulator)'
-                elsif xcode_tools.xcode_version_gte_61?
-                  'iPhone 6 Plus (8.1 Simulator)'
-                elsif xcode_tools.xcode_version_gte_6?
-                  'iPhone 6 Plus (8.0 Simulator)'
+                version = xcode_tools.xcode_version
+                if xcode_tools.xcode_version_gte_6?
+                  Resources.shared.core_simulator_for_xcode_version('iPhone', '6 Plus', version)
                 else
                   # iPhone 6 does not exist on Xcode < 6
                   nil

--- a/calabash-cucumber/spec/integration/device_spec.rb
+++ b/calabash-cucumber/spec/integration/device_spec.rb
@@ -62,6 +62,7 @@ describe Calabash::Cucumber::Device do
               }
               it { is_expected.to be == 'iphone 4in' }
             end
+
             context 'device is a 3.5" iphone' do
               let(:device_target) {
                 xcode_tools = RunLoop::XCTools.new
@@ -74,6 +75,7 @@ describe Calabash::Cucumber::Device do
               }
               it { is_expected.to be == 'iphone 3.5in' }
             end
+
             context 'device is an iphone 6' do
               let(:device_target) {
                 xcode_tools = RunLoop::XCTools.new
@@ -87,6 +89,7 @@ describe Calabash::Cucumber::Device do
               }
               it { is_expected.to be == 'iphone 6' if device_target }
             end
+
             context 'device is an iphone 6+' do
               let(:device_target) {
                 xcode_tools = RunLoop::XCTools.new

--- a/calabash-cucumber/spec/integration/device_spec.rb
+++ b/calabash-cucumber/spec/integration/device_spec.rb
@@ -37,6 +37,19 @@ describe Calabash::Cucumber::Device do
               stub_env('DEVELOPER_DIR', developer_dir)
             end
 
+            context 'device is an ipad' do
+              let(:device_target) {
+                xcode_tools = RunLoop::XCTools.new
+                version = xcode_tools.xcode_version
+                if xcode_tools.xcode_version_gte_6?
+                  Resources.shared.core_simulator_for_xcode_version('iPad', 'Retina', version)
+                else
+                  'iPad Retina (64-bit) - Simulator - iOS 7.1'
+                end
+              }
+              it { is_expected.to be == 'ipad' }
+            end
+
             context 'device is an 4in iphone' do
               let(:device_target) {
                 xcode_tools = RunLoop::XCTools.new

--- a/calabash-cucumber/spec/lib/deprecated_spec.rb
+++ b/calabash-cucumber/spec/lib/deprecated_spec.rb
@@ -21,5 +21,17 @@ describe Calabash::Cucumber do
         expect(val).to be == nil
       end
     end
+
+    it 'Device iphone_4in attribute' do
+      simulator_data = Resources.shared.server_version :simulator
+      endpoint = 'http://localhost:37265'
+      device = Calabash::Cucumber::Device.new(endpoint, simulator_data)
+      out = capture_stderr do
+        device.iphone_4in
+      end
+      expect(out.string).not_to be == nil
+      expect(out.string).not_to be == ''
+      expect(out.string =~ /WARN: deprecated '0.13.1' - 'use 'iphone_4in\?' instead/).not_to be == nil
+    end
   end
 end

--- a/calabash-cucumber/spec/lib/device_spec.rb
+++ b/calabash-cucumber/spec/lib/device_spec.rb
@@ -16,19 +16,6 @@ describe Calabash::Cucumber::Device do
     end
   end
 
-  describe '#iphone_4in?' do
-    let(:device) { Calabash::Cucumber::Device.new(double('end_point'), version_data) }
-    subject { device.iphone_4in? }
-    context 'when server says it is 4"' do
-      let(:version_data) { Resources.shared.server_version(:simulator).merge({'4inch' => true}) }
-      it { is_expected.to be_truthy }
-    end
-    context 'when server says it is not 4"' do
-      let(:version_data) { Resources.shared.server_version(:simulator).merge({'4inch' => false}) }
-      it { is_expected.not_to be_truthy }
-    end
-  end
-
   it '#form_factor' do
     version_data = Resources.shared.server_version(:simulator)
     device = Calabash::Cucumber::Device.new(double('end_point'), version_data)
@@ -74,6 +61,18 @@ describe Calabash::Cucumber::Device do
       it 'is false otherwise' do
         expect(device).to receive(:form_factor).and_return('any other value')
         expect(device.iphone_35in?).to be == false
+      end
+    end
+
+    describe '#iphone_4in?' do
+      it "is true when form factor is 'iphone 4in'" do
+        expect(device).to receive(:form_factor).and_return('iphone 4in')
+        expect(device.iphone_4in?).to be == true
+      end
+
+      it 'is false otherwise' do
+        expect(device).to receive(:form_factor).and_return('any other value')
+        expect(device.iphone_4in?).to be == false
       end
     end
   end

--- a/calabash-cucumber/spec/lib/device_spec.rb
+++ b/calabash-cucumber/spec/lib/device_spec.rb
@@ -35,4 +35,46 @@ describe Calabash::Cucumber::Device do
     expect(device.form_factor).to be == 'iphone 4in'
   end
 
+  describe 'form_factor query methods' do
+    let(:device) {
+      version_data = Resources.shared.server_version(:simulator)
+      Calabash::Cucumber::Device.new(double('end_point'), version_data)
+    }
+
+    describe '#iphone_6?' do
+      it "is true when form factor is 'iphone 6'" do
+        expect(device).to receive(:form_factor).and_return('iphone 6')
+        expect(device.iphone_6?).to be == true
+      end
+
+      it 'is false otherwise' do
+        expect(device).to receive(:form_factor).and_return('any other value')
+        expect(device.iphone_6?).to be == false
+      end
+    end
+
+    describe '#iphone_6_plus?' do
+      it "is true when form factor is 'iphone 6+'" do
+        expect(device).to receive(:form_factor).and_return('iphone 6+')
+        expect(device.iphone_6_plus?).to be == true
+      end
+
+      it 'is false otherwise' do
+        expect(device).to receive(:form_factor).and_return('any other value')
+        expect(device.iphone_6_plus?).to be == false
+      end
+    end
+
+    describe '#iphone_35in?' do
+      it "is true when form factor is 'iphone 3.5in'" do
+        expect(device).to receive(:form_factor).and_return('iphone 3.5in')
+        expect(device.iphone_35in?).to be == true
+      end
+
+      it 'is false otherwise' do
+        expect(device).to receive(:form_factor).and_return('any other value')
+        expect(device.iphone_35in?).to be == false
+      end
+    end
+  end
 end

--- a/calabash-cucumber/spec/lib/device_spec.rb
+++ b/calabash-cucumber/spec/lib/device_spec.rb
@@ -28,4 +28,11 @@ describe Calabash::Cucumber::Device do
       it { is_expected.not_to be_truthy }
     end
   end
+
+  it '#form_factor' do
+    version_data = Resources.shared.server_version(:simulator)
+    device = Calabash::Cucumber::Device.new(double('end_point'), version_data)
+    expect(device.form_factor).to be == 'iphone 4in'
+  end
+
 end

--- a/calabash-cucumber/spec/lib/environment_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_helpers_spec.rb
@@ -13,7 +13,7 @@ describe Calabash::Cucumber::EnvironmentHelpers do
   let(:endpoint) { 'http://localhost:37265' }
   let(:test_obj) { Calabash::RspecTests::EnvironmentHelpers::TestObject.new }
 
-  describe 'ios8?' do
+  describe '.ios8?' do
     let(:simulator_data) { Resources.shared.server_version :simulator }
 
     it 'returns true when device under test is iOS 8' do

--- a/calabash-cucumber/spec/lib/environment_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_helpers_spec.rb
@@ -10,11 +10,12 @@ end
 
 describe Calabash::Cucumber::EnvironmentHelpers do
 
-  let(:simulator_data) { Resources.shared.server_version :simulator }
   let(:endpoint) { 'http://localhost:37265' }
   let(:test_obj) { Calabash::RspecTests::EnvironmentHelpers::TestObject.new }
 
   describe 'ios8?' do
+    let(:simulator_data) { Resources.shared.server_version :simulator }
+
     it 'returns true when device under test is iOS 8' do
       simulator_data['iOS_version'] = '8.0'
       device = Calabash::Cucumber::Device.new(endpoint, simulator_data)

--- a/calabash-cucumber/spec/lib/environment_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_helpers_spec.rb
@@ -30,4 +30,61 @@ describe Calabash::Cucumber::EnvironmentHelpers do
       expect(test_obj.ios8?).to be == false
     end
   end
+
+  describe 'form factor helpers' do
+    let(:device) {
+      simulator_data = Resources.shared.server_version :simulator
+      device = Calabash::Cucumber::Device.new(endpoint, simulator_data)
+      expect(test_obj).to receive(:default_device).and_return(device)
+      device
+    }
+
+    describe '.iphone_35in?' do
+      it 'returns true' do
+        expect(device).to receive(:iphone_35in?).and_return(true)
+        expect(test_obj.iphone_35in?).to be == true
+      end
+
+      it 'returns false' do
+        expect(device).to receive(:iphone_35in?).and_return(false)
+        expect(test_obj.iphone_35in?).to be == false
+      end
+    end
+
+    describe '.iphone_4in?' do
+      it 'returns true' do
+        expect(device).to receive(:iphone_4in?).and_return(true)
+        expect(test_obj.iphone_4in?).to be == true
+      end
+
+      it 'returns false' do
+        expect(device).to receive(:iphone_4in?).and_return(false)
+        expect(test_obj.iphone_4in?).to be == false
+      end
+    end
+
+    describe '.iphone_6?' do
+      it 'returns true' do
+        expect(device).to receive(:iphone_6?).and_return(true)
+        expect(test_obj.iphone_6?).to be == true
+      end
+
+      it 'returns false' do
+        expect(device).to receive(:iphone_6?).and_return(false)
+        expect(test_obj.iphone_6?).to be == false
+      end
+    end
+
+    describe '.iphone_6_plus?' do
+      it 'returns true' do
+        expect(device).to receive(:iphone_6_plus?).and_return(true)
+        expect(test_obj.iphone_6_plus?).to be == true
+      end
+
+      it 'returns false' do
+        expect(device).to receive(:iphone_6_plus?).and_return(false)
+        expect(test_obj.iphone_6_plus?).to be == false
+      end
+    end
+  end
 end

--- a/calabash-cucumber/spec/resources.rb
+++ b/calabash-cucumber/spec/resources.rb
@@ -23,6 +23,21 @@ class Resources
     }.call
   end
 
+  def core_simulator_for_xcode_version(idiom, form_factor, xcode_version)
+    if xcode_version < RunLoop::Version.new('6.1')
+      ios_version = '8.0'
+    elsif xcode_version < RunLoop::Version.new('6.2')
+      ios_version = '8.1'
+    elsif xcode_version < RunLoop::Version.new('6.3')
+      ios_version = '8.2'
+    elsif xcode_version >= RunLoop::Version.new('6.3')
+      ios_version = '8.3'
+    else
+      raise "Unsupported Xcode version: #{xcode_version}"
+    end
+    "#{idiom} #{form_factor} (#{ios_version} Simulator)"
+  end
+
   def resources_dir
     @resources_dir ||= File.expand_path(File.join(File.dirname(__FILE__), 'resources'))
   end

--- a/calabash-cucumber/spec/resources.rb
+++ b/calabash-cucumber/spec/resources.rb
@@ -110,7 +110,8 @@ class Resources
               },
               'iOS_version' => '7.1',
               'system' => 'x86_64',
-              'simulator' => 'CoreSimulator 110.2 - Device: iPhone 5 - Runtime: iOS 7.1 (11D167) - DeviceType: iPhone 5'
+              'simulator' => 'CoreSimulator 110.2 - Device: iPhone 5 - Runtime: iOS 7.1 (11D167) - DeviceType: iPhone 5',
+              'form_factor' => 'iphone 4in'
         }
       else
         raise "expected '#{device_or_simulator}' to be one of #{[:simulator, :device]}"

--- a/changelog/0.13.1.md
+++ b/changelog/0.13.1.md
@@ -1,0 +1,25 @@
+### 0.13.1 changelog
+
+This release requires a server update.
+
+We've updated the [Updating Your Calabash iOS Version](https://github.com/calabash/calabash-ios/wiki/B1-Updating-your-Calabash-iOS-version) page as part of our on-going effort to improve the wiki.
+
+### Summary
+
+### Features
+
+### Fixes
+
+### Deprecated
+
+See https://github.com/calabash/calabash-ios/wiki/Deprecated
+
+* since 0.13.1 `Calabash::Device iphone_4in attribute` - Call `iphone_4in?` instead.
+
+### Hot Topics
+
+See https://github.com/calabash/calabash-ios/wiki/Hot-Topics
+
+* NSLog output can cause apps to become unresponsive during testing
+* cucumber is not compatible with ruby 2.2.0
+* Does not contain a compatible architecture for target device - Expected 'i386' but found ["x86_64"]. (RunLoop::IncompatibleArchitecture) **AKA** _When targeting a Simulator, the app launches, then quits several times in rapid succession._

--- a/changelog/0.13.1.md
+++ b/changelog/0.13.1.md
@@ -20,6 +20,8 @@ See https://github.com/calabash/calabash-ios/wiki/Deprecated
 
 See https://github.com/calabash/calabash-ios/wiki/Hot-Topics
 
+* Enable Development After Upgrading Devices to 8.*
+* Errno::EINTR: Interrupted system call
 * NSLog output can cause apps to become unresponsive during testing
 * cucumber is not compatible with ruby 2.2.0
 * Does not contain a compatible architecture for target device - Expected 'i386' but found ["x86_64"]. (RunLoop::IncompatibleArchitecture) **AKA** _When targeting a Simulator, the app launches, then quits several times in rapid succession._


### PR DESCRIPTION
### Motivation

* **Device needs iphone_6? and iphone_6plus? methods.** #727

Requires a server update: **Feature/can report iphone6 form factors** [#141](https://github.com/calabash/calabash-ios-server/pull/141)

@jrudolf @michaelkirk