### PR TITLE
Calabash launcher defers decision to quit simulator to run-loop

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -745,13 +745,6 @@ class Calabash::Cucumber::Launcher
   # @!visibility private
   def new_run_loop(args)
 
-    # for stability, quit the simulator if Xcode version is > 5.1 and the
-    # target device is the simulator
-    target_is_sim = simulator_target?(args)
-    if target_is_sim and RunLoop::XCTools.new.xcode_version_gte_51?
-      self.simulator_launcher.stop
-    end
-
     last_err = nil
 
     num_retries = args[:launch_retries] || 5

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -424,6 +424,7 @@ class Calabash::Cucumber::Launcher
         :no_stop => calabash_no_stop?,
         :no_launch => calabash_no_launch?,
         :sdk_version => sdk_version,
+        :relaunch_simulator => true,
         # Do not advertise this to users!
         # For example, don't include documentation about this option.
         # This is used to instrument internal testing (failing fast).

--- a/changelog/0.14.1.md
+++ b/changelog/0.14.1.md
@@ -1,0 +1,37 @@
+### 0.14.1 changelog
+
+**This release requires a server update.**
+
+https://github.com/calabash/calabash-ios/wiki/B1-Updating-your-Calabash-iOS-version
+
+### Features
+
+#### calabash-ios
+
+* Calabash launcher defers decision to quit simulator to run-loop
+
+### Documentation
+
+This is a reminder to check out the Calabash documentation on the Xamarin site.  The information there is excellent and constantly improving.
+
+http://developer.xamarin.com/testcloud/
+
+* Updated the [README.md](../README.md)
+* [Improving Network Stability](https://github.com/calabash/calabash-ios/wiki/Improving-Network-Stability)
+* [Managing Privacy Alerts: Location Services, APNS, Contacts](https://github.com/calabash/calabash-ios/wiki/Managing-Privacy-Alerts%3A--Location-Services%2C-APNS%2C-Contacts)
+* [Load Calabash dylibs in Debug configuration at runtime](https://github.com/calabash/ios-smoke-test-app/pull/17)
+* [UIWebView and WKWebView API](https://github.com/calabash/calabash-ios/wiki/06-WebView-Support)
+
+
+### Deprecated
+
+See https://github.com/calabash/calabash-ios/wiki/Deprecated
+
+### Hot Topics
+
+See https://github.com/calabash/calabash-ios/wiki/Hot-Topics
+
+* Enable Development After Upgrading Devices to 8.\*
+* Errno::EINTR: Interrupted system call
+* NSLog output can cause apps to become unresponsive during testing
+* cucumber is not compatible with ruby 2.2.0


### PR DESCRIPTION
### Motivation

**Xcode 6.3 - instruments cannot launch an app that is already installed on iOS 8.3 Simulators** #744

The fix for this problem was implemented in run-loop.  This PR makes exploring different simulator relaunch policies possible.

The following table illustrates the Xcode 6.3 bug.

| app installed? | simulator | instruments behavior |
|:----------:|:---------:|:--------------------:|
|     yes    |    open   |      :+1:       |
|     no     |    open   |    cannot install    |
|     yes    |   closed  |     cannot launch    |
|     no     |   closed  |      :+1:       |

In a nutshell, quitting the simulator every time is causing the problem.  We adopted this policy of always restarting back in Xcode 5.1.1 as a workaround for flaky iOS Simulators.

In my testing of the patch for #744, I convinced myself that it is possible to run a test suite _without relaunching the simulator_.

Even if this was not the case, whether not to restart the simulator should be a decision that run-loop makes.
