### PR TITLE
Add client API for UISlider set value operation

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -739,6 +739,40 @@ module Calabash
         texts
       end
 
+      # Set the sliders indicated by `uiquery` to `value`.
+      #
+      # @example
+      #  slider_set_value "UISlider marked:'office slider'", 2
+      #  slider_set_value "slider marked:'weather slider'", -1
+      #  slider_set_value "* marked:'science slider'", 3
+      #  slider_set_value "UISlider", 11
+      #
+      # @param [String] uiquery A query.
+      # @param [Number] value The value to set the slider to.  value.to_s should
+      #  produce a String representation of a Number.
+      # @param [options] options Options to control the behavior of the gesture.
+      # @option options [Boolean] :animate (true) Animate the change.
+      # @option options [Boolean] :notify_targets (true) Simulate a UIEvent by
+      #  calling every target/action pair defined on the UISliders matching
+      #  `uiquery`.
+      # @raise [RuntimeError] When setting the value of the sliders match by
+      #  `uiquery` is not successful.
+      # @return [Array<String>] An array of query results.
+      def slider_set_value(uiquery, value,  options={})
+        default_options =  {:animate => true,
+                            :notify_targets => true}
+        merged_options = default_options.merge(options)
+
+        value_str = value.to_s
+
+        args = [merged_options[:animate], merged_options[:notify_targets]]
+        views_touched = map(uiquery, :changeSlider, value_str, *args)
+
+        msg = "Could not set value of slider to '#{value}' using query '#{uiquery}'"
+        assert_map_results(views_touched, msg)
+        views_touched
+      end
+
       # Calls a method on the app's AppDelegate object.
       #
       # This is an escape hatch for calling an arbitrary hook inside

--- a/calabash-cucumber/lib/calabash-cucumber/map.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/map.rb
@@ -78,24 +78,24 @@ module Calabash
         res
       end
 
-      # asserts the result of a calabash `map` call and raises an error with
+      # Asserts the result of a calabash `map` call and raises an error with
       # `msg` if no valid results are found.
       #
-      # casual gem users should never need to call this method; this is a
+      # Casual gem users should never need to call this method; this is a
       # convenience method for gem maintainers.
       #
-      # raises an error if `map_results`:
+      # Raises an error if `map_results`:
       #
       #              is an empty list #=> []
       #    contains a '<VOID>' string #=> [ "<VOID>" ]
       #       contains '*****' string #=> [ "*****"  ]
       #         contains a single nil #=> [ nil ]
       #
-      # when evaluating whether a `map` call is successful it is important to
+      # When evaluating whether a `map` call is successful it is important to
       # note that sometimes a <tt>[ nil ]</tt> or <tt>[nil, <val>, nil]</tt> is
       # a valid result.
       #
-      # consider a controller with 3 labels:
+      # Consider a controller with 3 labels:
       #
       #    label @ index 0 has text "foo"
       #    label @ index 1 has text nil (the [label text] => nil)
@@ -104,13 +104,13 @@ module Calabash
       #    map('label', :text) => ['foo', nil, 'bar']
       #    map('label index:1', :text) => [nil]
       #
-      # in other cases, <tt>[ nil ]</tt> should be treated as an invalid result
+      # In other cases, <tt>[ nil ]</tt> should be treated as an invalid result
       #
       #    # invalid
       #    > mark = 'mark does not exist'
       #    > map('tableView', :scrollToRowWithMark, mark, args) => [ nil ]
       #
-      # here a <tt>[ nil ]</tt> should be considered invalid because the
+      # Here a <tt>[ nil ]</tt> should be considered invalid because the
       # the operation could not be performed because there is not row that
       # matches `mark`
       def assert_map_results(map_results, msg)
@@ -119,7 +119,6 @@ module Calabash
           screenshot_and_raise msg
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
### Motivation

* 0.9.x adds a LPSliderOperation to ease the pain of interacting with UISliders [#26]( https://github.com/calabash/calabash-ios-server/pull/26)
* 0.9.x adds client code for interacting with UISliders via LPSliderOperation [#227]( https://github.com/calabash/calabash-ios/pull/227)


```
slider_set_value "UISlider marked:'office slider'", 2
slider_set_value "slider marked:'weather slider'", -1
slider_set_value "* marked:'science slider'", 3
slider_set_value "UISlider", 11
```

### Tests

With Briar iOS Example

```
@sliders @rotation
Feature: Testing the slider operation

  Background: Navigate to the sliders tab
    When I touch the "Sliders" tab I should see the "sliders" view
    Then I should see the emotions slider group at the top of the view
    Then I rotate the device so the home button is on the bottom
    Then I should see the slider table
    Then I rotate the device 2 times in a random direction

  Scenario: Emoticon should change when slider is moved
    When I change the "emotion" slider to 2, I should see the "happy" emoticon
    When I change the "emotion" slider to -2, I should see the "sad" emoticon
    When I change the "emotion" slider to -0.4, I should see the "bored" emoticon

  Scenario: I should be able to interact with sliders in table rows
    Then I scroll to the "weather" row
    Then I observe that it is raining
    Then I scroll to the "office" row
    Then I decide we really need a paper airplane in the office
    Then I scroll to the "science" row
    Then I note that used the telescope in my experiment
```