### PR TITLE
Fixes #762.  Typo in tableViewCell touch call.

### DIFF
--- a/calabash-cucumber/features/step_definitions/calabash_steps.rb
+++ b/calabash-cucumber/features/step_definitions/calabash_steps.rb
@@ -62,7 +62,7 @@ end
 
 Then /^I (?:press|touch) list item "([^\"]*)"$/ do |cell_name|
   if query("tableViewCell marked: '#{cell_name}'").empty?
-    touch("tableViewCell text:' #{cell_name}'")
+    touch("tableViewCell text: '#{cell_name}'")
   else
     touch("tableViewCell marked: '#{cell_name}'")
   end


### PR DESCRIPTION
One line fix to `calabash_steps.rb` for typo in step definition.