### PR TITLE
Stop rescuing exceptions

### DIFF
--- a/calabash-cucumber/README_YARDOC.md
+++ b/calabash-cucumber/README_YARDOC.md
@@ -171,7 +171,7 @@ end
 
 ```
 # @!visibility private
-# raises an error by raising a exception and conditionally takes a
+# raises an error by raising an error and conditionally takes a
 # screenshot based on the value of +screenshot_on_error+.
 # ...
 def handle_error_with_options(ex, timeout_message, screenshot_on_error)

--- a/calabash-cucumber/lib/calabash-cucumber/http_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/http_helpers.rb
@@ -62,7 +62,7 @@ module Calabash
             raise Errno::ECONNREFUSED if response.status_code == 502
 
             return response.body
-          rescue Exception => e
+          rescue => e
 
             if retryable_errors.include?(e) || retryable_errors.any? { |c| e.is_a?(c) }
 

--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -155,7 +155,7 @@ module Calabash
       #
       # @param [Hash] opts controls the `wait_for` behavior
       # @option opts [String] :timeout_message ('keyboard did not appear')
-      #  Controls the message that appears in the exception.
+      #  Controls the message that appears in the error.
       # @option opts [Number] :post_timeout (0.3) Controls how long to wait
       #  _after_ the keyboard has appeared.
       #

--- a/calabash-cucumber/lib/calabash-cucumber/launch/simulator_launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launch/simulator_launcher.rb
@@ -459,8 +459,6 @@ module Calabash
                   begin
                     connected = (ping_app == '200')
                     break if connected
-                  rescue Exception => e
-                    # nop
                   ensure
                     sleep 1 unless connected
                   end

--- a/calabash-cucumber/lib/calabash-cucumber/launch/simulator_launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launch/simulator_launcher.rb
@@ -26,7 +26,7 @@ module Calabash
 
       # Custom error indicating a timeout in launching and connecting to the
       # embedded calabash server.
-      # @todo This is duplicated in Launcher class - consider exceptions.rb module.
+      # @todo This is duplicated in Launcher class - consider errors.rb module.
       class TimeoutErr < RuntimeError
       end
 

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -787,9 +787,6 @@ class Calabash::Cucumber::Launcher
               begin
                 connected = (ping_app == '200')
                 break if connected
-              rescue Exception => e
-                #p e
-                #retry
               ensure
                 sleep 1 unless connected
               end
@@ -819,11 +816,8 @@ class Calabash::Cucumber::Launcher
       sess.request Net::HTTP::Get.new(ENV['CALABASH_VERSION_PATH'] || "version")
     end
     status = res.code
-    begin
-      http.finish if http and http.started?
-    rescue Exception => e
 
-    end
+    http.finish if http and http.started?
 
     if status == '200'
       version_body = JSON.parse(res.body)

--- a/calabash-cucumber/lib/calabash-cucumber/utils/logging.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/utils/logging.rb
@@ -76,7 +76,7 @@ module Calabash
       # @param [String] version indicates when the feature was deprecated
       # @param [String] msg deprecation message (possibly suggesting alternatives)
       # @param [Symbol] type { :warn | :pending } - :pending will raise a
-      #   cucumber pending exception
+      #   cucumber pending error
       # @return [void]
       def _deprecated(version, msg, type)
         allowed = [:pending, :warn]

--- a/calabash-cucumber/lib/calabash-cucumber/wait_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/wait_helpers.rb
@@ -112,7 +112,7 @@ module Calabash
           else
             raise wait_error(msg)
           end
-        rescue Exception => e
+        rescue => e
           handle_error_with_options(e, nil, screenshot_on_error)
         end
       end
@@ -407,23 +407,26 @@ module Calabash
       end
 
       # @!visibility private
-      # raises an error by raising a exception and conditionally takes a
-      # screenshot based on the value of +screenshot_on_error+.
-      # @param [Exception,nil] ex an exception to raise
+      # Raises an error by raising a error and conditionally takes a screenshot
+      # based on the value of +screenshot_on_error+.
+      # @param [RuntimeError,nil] error an error to raise
       # @param [String,nil] timeout_message the message of the raise
       # @param [Boolean] screenshot_on_error if true takes a screenshot before
       #  raising an error
       # @return [nil]
-      # @raise RuntimeError based on +ex+ and +timeout_message+
-      def handle_error_with_options(ex, timeout_message, screenshot_on_error)
-        msg = (timeout_message || ex)
-        if ex
-          msg = "#{msg} (#{ex.class})"
+      # @raise [StandardError] If `error`, then that kind of error is raised.
+      #  Otherwise raise a RuntimeError.
+      def handle_error_with_options(error, timeout_message, screenshot_on_error)
+        msg = (timeout_message || error)
+        if error
+          error_class = error.class
+        else
+          error_class = RuntimeError
         end
         if screenshot_on_error
           screenshot_and_raise msg
         else
-          raise msg
+          raise error_class, msg
         end
       end
 

--- a/calabash-cucumber/lib/calabash-cucumber/wait_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/wait_helpers.rb
@@ -289,8 +289,8 @@ module Calabash
           else
             raise wait_error(msg)
           end
-        rescue Exception => e
-          handle_error_with_options(e,nil, screenshot_on_error)
+        rescue => e
+          handle_error_with_options(e, nil, screenshot_on_error)
         end
       end
 

--- a/calabash-cucumber/spec/lib/http_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/http_helpers_spec.rb
@@ -1,0 +1,12 @@
+describe Calabash::Cucumber::HTTPHelpers do
+  include Calabash::Cucumber::HTTPHelpers
+
+  describe '.make_http_request' do
+    it 'rescues StandardError' do
+      expect(self).to receive(:init_request).and_raise(StandardError, "I'll raise you 100")
+      expect {
+        make_http_request({})
+      }.to raise_error(StandardError, "I'll raise you 100")
+    end
+  end
+end

--- a/calabash-cucumber/spec/lib/wait_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/wait_helpers_spec.rb
@@ -24,14 +24,14 @@ describe Calabash::Cucumber::WaitHelpers do
       end
 
       it 'uses error message if timeout_message is nil' do
-        error = RuntimeError.new('Some other exception')
+        error = RuntimeError.new('Some other error')
         expect {
           handle_error_with_options(error, nil, false)
-        }.to raise_error(RuntimeError, 'Some other exception')
+        }.to raise_error(RuntimeError, 'Some other error')
       end
     end
 
-    describe 'getting the exception class right' do
+    describe 'getting the error class right' do
       it 'uses error class if available' do
         error = ArgumentError.new('An argument error.')
         expect {

--- a/calabash-cucumber/spec/lib/wait_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/wait_helpers_spec.rb
@@ -66,4 +66,14 @@ describe Calabash::Cucumber::WaitHelpers do
       end
     end
   end
+
+  describe '.wait_for_condition' do
+    include Calabash::Cucumber::HTTPHelpers
+    it 'rescues StandardError' do
+      expect(self).to receive(:http).and_raise(StandardError, 'I got raised!')
+      expect {
+        wait_for_condition({screenshot_on_error: false})
+      }.to raise_error(StandardError, 'I got raised!')
+    end
+  end
 end

--- a/calabash-cucumber/spec/lib/wait_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/wait_helpers_spec.rb
@@ -1,0 +1,69 @@
+describe Calabash::Cucumber::WaitHelpers do
+  include Calabash::Cucumber::WaitHelpers
+
+  # def handle_error_with_options(ex, timeout_message, screenshot_on_error)
+  #   msg = (timeout_message || ex)
+  #   if ex
+  #     error_class = ex.class
+  #   else
+  #     error_class = RuntimeError
+  #   end
+  #   if screenshot_on_error
+  #     screenshot_and_raise msg
+  #   else
+  #     raise error_class, msg
+  #   end
+  # end
+
+  describe '.handle_error_with_options' do
+    describe 'getting the message right' do
+      it 'uses timeout_message if available' do
+        expect {
+          handle_error_with_options(nil, 'timed out!', false)
+        }.to raise_error(RuntimeError, 'timed out!')
+      end
+
+      it 'uses error message if timeout_message is nil' do
+        error = RuntimeError.new('Some other exception')
+        expect {
+          handle_error_with_options(error, nil, false)
+        }.to raise_error(RuntimeError, 'Some other exception')
+      end
+    end
+
+    describe 'getting the exception class right' do
+      it 'uses error class if available' do
+        error = ArgumentError.new('An argument error.')
+        expect {
+          handle_error_with_options(error, nil, false)
+        }.to raise_error(ArgumentError, 'An argument error.' )
+      end
+
+      it 'raises a Runtime error otherwise' do
+        expect {
+          handle_error_with_options(nil, 'Generic error', false)
+        }.to raise_error(RuntimeError, 'Generic error' )
+      end
+    end
+
+    describe 'taking a screenshot' do
+      it 'takes screenshot if argument is true' do
+        timeout_message = 'Generic error'
+        expect(self).to receive(:screenshot_and_raise).and_raise(RuntimeError, timeout_message)
+        expect {
+          handle_error_with_options(nil, timeout_message, true)
+        }.to raise_error(RuntimeError, timeout_message )
+      end
+
+      # @todo This is probably the wrong behavior for screenshot_and_raise
+      it 'always raise RuntimeError' do
+        timeout_message = 'An argument error'
+        error = ArgumentError.new(timeout_message)
+        expect(self).to receive(:screenshot_and_raise).and_raise(RuntimeError, timeout_message)
+        expect {
+          handle_error_with_options(error, nil, true)
+        }.to raise_error(RuntimeError, timeout_message)
+      end
+    end
+  end
+end

--- a/calabash-cucumber/test/cucumber/features/models/not-pom/home_page.rb
+++ b/calabash-cucumber/test/cucumber/features/models/not-pom/home_page.rb
@@ -2,7 +2,7 @@ module NotPOM
   class HomePage
     include Calabash::Cucumber::Operations
 
-    def my_exceptional_method
+    def my_buggy_method
       screenshot_and_raise 'Hey!'
     end
 

--- a/calabash-cucumber/test/cucumber/features/screenshot_and_raise.feature
+++ b/calabash-cucumber/test/cucumber/features/screenshot_and_raise.feature
@@ -3,13 +3,13 @@
 Feature:  Screenshot and raise
   In order to delight calabash clients all the world round
   As a calabash developer
-  I want to take screenshots and raise exceptions
+  I want to take screenshots and raise errors
 
   Scenario: screenshot_and_raise in the context of cucumber
     When I use screenshot_and_raise in the context of cucumber
-    Then I should get a runtime exception
+    Then I should get a runtime error
 
   Scenario: screenshot_and_raise outside the context of cucumber
     When I screenshot_and_raise outside the context of cucumber
-    Then I should get a runtime exception
-    But it should not be a NoMethod exception for embed
+    Then I should get a runtime error
+    But it should not be a NoMethod error for embed

--- a/calabash-cucumber/test/cucumber/features/step_definitions/screenshot_and_raise_steps.rb
+++ b/calabash-cucumber/test/cucumber/features/step_definitions/screenshot_and_raise_steps.rb
@@ -2,26 +2,26 @@ When(/^I use screenshot_and_raise in the context of cucumber$/) do
   begin
     screenshot_and_raise 'Hey!'
   rescue StandardError => e
-    @screenshot_and_raise_exception = e
+    @screenshot_and_raise_error = e
   end
 end
 
-Then(/^I should get a runtime exception$/) do
-  if @screenshot_and_raise_exception.nil?
-    raise 'Expected the previous step to raise an exception'
+Then(/^I should get a runtime error$/) do
+  if @screenshot_and_raise_error.nil?
+    raise 'Expected the previous step to raise an error'
   end
 end
 
 When(/^I screenshot_and_raise outside the context of cucumber$/) do
   begin
-    NotPOM::HomePage.new.my_exceptional_method
+    NotPOM::HomePage.new.my_buggy_method
   rescue StandardError => e
-    @screenshot_and_raise_exception = e
+    @screenshot_and_raise_error = e
   end
 end
 
-But(/^it should not be a NoMethod exception for embed$/) do
-  error = @screenshot_and_raise_exception
+But(/^it should not be a NoMethod error for embed$/) do
+  error = @screenshot_and_raise_error
   is_a_no_method_error = error.is_a?(NoMethodError)
 
   if is_a_no_method_error


### PR DESCRIPTION
### Motivation

Replace or remove rescue blocks that try to handle Exception.

@TobiasRoikjer Needs a review.  Merge if you have a moment.
