### PR TITLE
Travis: limit rspec to unit tests

### DIFF
--- a/calabash-cucumber/Rakefile
+++ b/calabash-cucumber/Rakefile
@@ -5,11 +5,13 @@ Bundler::GemHelper.install_tasks
 
 begin
   require 'rspec/core/rake_task'
-  RSpec::Core::RakeTask.new
-  task :test => :spec
+  RSpec::Core::RakeTask.new(:spec)
+
+  RSpec::Core::RakeTask.new(:unit) do |task|
+    task.pattern = 'spec/lib/**{,/*/**}/*_spec.rb'
+  end
 rescue LoadError => _
 end
-
 
 begin
   require 'yard'

--- a/script/ci/travis/rspec-ci.rb
+++ b/script/ci/travis/rspec-ci.rb
@@ -4,10 +4,9 @@ require File.expand_path(File.join(File.dirname(__FILE__), 'ci-helpers'))
 
 working_directory = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'calabash-cucumber'))
 
-
 Dir.chdir working_directory do
 
-  do_system('bundle exec rake spec',
+  do_system('bundle exec rake unit',
             {:pass_msg => 'rspec tests passed',
              :fail_msg => 'rspec tests failed'})
 


### PR DESCRIPTION
### Motivation

Travis is erroring with a timeout when running the integration tests with an XTC submit.

Will only run the rspec unit tests in travis.