### PR TITLE
Scroll ensures valid direction argument

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -393,9 +393,17 @@ module Calabash
       # @note this is implemented by calling the Obj-C `setContentOffset:animated:` method and can do things users cant.
       #
       # @param {String} uiquery query describing view scroll (should be  UIScrollView or a web view).
+      # @param [Symbol] direction The direction to scroll. Valid directions are:
+      #   :up, :down, :left, and :right
       def scroll(uiquery, direction)
-        views_touched=map(uiquery, :scroll, direction)
-        msg = "could not find view to scroll: '#{uiquery}', args: #{direction}"
+        allowed_directions = [:up, :down, :left, :right]
+        dir_symbol = direction.to_sym
+        unless allowed_directions.include?(dir_symbol)
+          raise ArgumentError, "Expected '#{direction} to be one of #{allowed_directions}"
+        end
+
+        views_touched=map(uiquery, :scroll, dir_symbol)
+        msg = "could not find view to scroll: '#{uiquery}', args: #{dir_symbol}"
         assert_map_results(views_touched, msg)
         views_touched
       end

--- a/calabash-cucumber/spec/lib/core.rb
+++ b/calabash-cucumber/spec/lib/core.rb
@@ -1,0 +1,53 @@
+describe Calabash::Cucumber::Core do
+
+  let(:world) do
+    Class.new do
+      include Calabash::Cucumber::Core
+    end.new
+  end
+
+  describe '#scroll' do
+    describe 'handling direction argument' do
+      describe 'raises error if invalid' do
+        it 'keywords' do
+          expect do
+            world.scroll("query", :sideways)
+          end.to raise_error ArgumentError
+        end
+
+        it 'strings' do
+          expect do
+            world.scroll("query", 'diagonal')
+          end.to raise_error ArgumentError
+        end
+      end
+
+      describe 'valid' do
+        before do
+          expect(world).to receive(:map).twice.and_return [true]
+          expect(world).to receive(:assert_map_results).twice.and_return true
+        end
+
+        it 'up' do
+          expect(world.scroll('', 'up')).to be_truthy
+          expect(world.scroll('', :up)).to be_truthy
+        end
+
+        it 'down' do
+          expect(world.scroll('', 'down')).to be_truthy
+          expect(world.scroll('', :down)).to be_truthy
+        end
+
+        it 'left' do
+          expect(world.scroll('', 'left')).to be_truthy
+          expect(world.scroll('', :left)).to be_truthy
+        end
+
+        it 'right' do
+          expect(world.scroll('', 'right')).to be_truthy
+          expect(world.scroll('', :right)).to be_truthy
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Motivation

While working on the server, I realized it was possible to pass an invalid direction.  On the server side, I put a guard to help simplify some hacking I had to do to get stuff working on the main thread.  This causes the client to raise an unhelpful error when an invalid direction is passed.

