### PR TITLE
Feature/keyboard localizations

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -898,6 +898,10 @@ module Calabash
         end
       end
 
+      # Waits for a keyboard to appear and returns the localized name of the
+      # `key_code` signifier
+      #
+      # @param [String] key_code Maps to a specific name in some localization
       def lookup_key_name(key_code)
         wait_for_keyboard
         localized_lang = JSON.parse(http(:path => 'keyboard-language'))['results']['input_mode']

--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -904,7 +904,15 @@ module Calabash
       # @param [String] key_code Maps to a specific name in some localization
       def lookup_key_name(key_code)
         wait_for_keyboard
-        localized_lang = JSON.parse(http(:path => 'keyboard-language'))['results']['input_mode']
+        begin
+          response_json = JSON.parse(http(:path => 'keyboard-language'))
+        rescue JSON::ParserError
+          raise RuntimeError, "Could not parse output of keyboard-language route. Did the app crash?"
+        end
+        if response_json['outcome'] != 'SUCCESS'
+          screenshot_and_raise "failed to retrieve the keyboard localization"
+        end
+        localized_lang = response_json['results']['input_mode']
         (RunLoop::XCTools.new).lookup_localization_name(key_code, localized_lang)
       end
 

--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -898,63 +898,10 @@ module Calabash
         end
       end
 
-      def _key_name(path, key_code)
-        if(File.directory?(path))
-          keyboard_lookup_table = JSON.parse(`plutil -convert json #{File.join(path, 'Accessibility.strings')} -o -`)
-          return keyboard_lookup_table[key_code]
-        else
-          return nil
-        end
-      end
-
-      @@_full_name_lookup = {
-        'en' => 'English',
-        'nl' => 'Dutch',
-        'fr' => 'French',
-        'de' => 'German'
-      }
-
-      def _is_full_name?(two_letter_country_code)
-        @@_full_name_lookup.has_key?(two_letter_country_code)
-      end
-
-      def _l18n_uikit_bundle_path
-        (RunLoop::XCTools.new).uikit_bundle_l18n_path
-      end
-
-      def _key_name_lookup_table(lang_dir_name)
-        JSON.parse(`plutil -convert json #{File.join(_l18n_uikit_bundle_path, lang_dir_name, 'Accessibility.strings')} -o -`)
-      end
-
-
       def lookup_key_name(key_code)
-
-        l18n_path = _l18n_uikit_bundle_path
-
+        wait_for_keyboard
         localized_lang = JSON.parse(http(:path => 'keyboard-language'))['results']['input_mode']
-        lang_dir_name = "#{localized_lang}.lproj"
-        if(File.exists?(File.join(l18n_path, lang_dir_name)))
-          puts lang_dir_name
-          return _key_name_lookup_table(lang_dir_name)[key_code]
-        end
-
-        two_char_country_code = localized_lang.split('-')[0]
-        lang_dir_name = "#{two_char_country_code}.lproj"
-        if(File.exists?(File.join(l18n_path, lang_dir_name)))
-          puts lang_dir_name
-          return _key_name_lookup_table(lang_dir_name)[key_code]
-        end
-
-        if _is_full_name?(two_char_country_code)
-          puts two_char_country_code
-          return _key_name_lookup_table("#{@@_full_name_lookup[two_char_country_code]}.lproj")[key_code]
-        end
-
-        return _key_name_lookup_table(lang)[key_code]
-      end
-
-      def delete_key_name()
-        lookup_key_name('delete.key')
+        (RunLoop::XCTools.new).lookup_localization_name(key_code, localized_lang)
       end
 
       # @!visibility private


### PR DESCRIPTION
This PR defines an instance method that returns the localized name of a signifier-label. So assuming you had a danish keyboard open,

    lookup_key_name('delete.key')
    => "Slet"

This depends on https://github.com/calabash/calabash-ios-server/pull/221 and https://github.com/calabash/run_loop/pull/197