### PR TITLE
Added rescue block to handle ECONNREFUSED exception.

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -787,7 +787,7 @@ class Calabash::Cucumber::Launcher
               begin
                 connected = (ping_app == '200')
                 break if connected
-              rescue Exception => e
+              rescue StandardError => e
                 if full_console_logging?
                   puts "Could not connect. #{e.message}"
                   puts "Will retry ..."

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -787,6 +787,11 @@ class Calabash::Cucumber::Launcher
               begin
                 connected = (ping_app == '200')
                 break if connected
+              rescue Exception => e
+                if full_console_logging?
+                  puts "Could not connect. #{e.message}"
+                  puts "Will retry ..."
+                end
               ensure
                 sleep 1 unless connected
               end

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -3,7 +3,7 @@ module Calabash
 
     # @!visibility public
     # The Calabash iOS gem version.
-    VERSION = '0.14.3'
+    VERSION = '0.14.4'
 
     # @!visibility public
     # The minimum required version of the Calabash embedded server.

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -3,7 +3,7 @@ module Calabash
 
     # @!visibility public
     # The Calabash iOS gem version.
-    VERSION = '0.14.4'
+    VERSION = '0.14.3'
 
     # @!visibility public
     # The minimum required version of the Calabash embedded server.


### PR DESCRIPTION
If there is an exception on calling the ping_app method, the while loop which tries reconnection will exit. A rescue block is required to keep the loop running.
Here is the link to the google group discussion around this : https://groups.google.com/forum/#!topic/calabash-ios/9MFsFyhGoYg