### PR TITLE
Set min run-loop version 1.5.0 and replace calls to RunLoop::XCTools

### DIFF
--- a/calabash-cucumber/README_YARDOC.md
+++ b/calabash-cucumber/README_YARDOC.md
@@ -59,7 +59,6 @@ The following files have good examples of yard format:
 ```
 lib/calabash-cucumber/utils/plist_buddy.rb
 lib/calabash-cucumber/utils/simulator_accessibility.rb
-lib/calabash-cucumber/utils/xctools.rb
 
 ```
 

--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |s|
   s.add_dependency('httpclient', '>= 2.3.2', '< 3.0')
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
-  s.add_dependency('run_loop', '>= 1.3.3', '< 2.0')
+  s.add_dependency('run_loop', '>= 1.5.0', '< 2.0')
 
   # Shared with run-loop.
   s.add_dependency('json')

--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -76,7 +76,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'redcarpet', '3.2.0'
 
   # Shared with run-loop.
-  s.add_development_dependency 'luffa'
+  s.add_development_dependency 'luffa', '>= 1.1.0' # Remove ASAP.
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'pry'

--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -913,7 +913,7 @@ module Calabash
           screenshot_and_raise "failed to retrieve the keyboard localization"
         end
         localized_lang = response_json['results']['input_mode']
-        (RunLoop::XCTools.new).lookup_localization_name(key_code, localized_lang)
+        RunLoop::L10N.new.lookup_localization_name(key_code, localized_lang)
       end
 
       # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -55,6 +55,7 @@ class Calabash::Cucumber::Launcher
   attr_accessor :actions
   attr_accessor :launch_args
   attr_accessor :simulator_launcher
+  attr_reader :xcode
 
   # @!visibility private
   # Generated when calabash cannot launch the app.
@@ -74,6 +75,10 @@ class Calabash::Cucumber::Launcher
   # @!visibility private
   # Generated when calabash cannot communicate with the app.
   class CalabashLauncherTimeoutErr < Timeout::Error
+  end
+
+  def xcode
+    @xcode ||= RunLoop::Xcode.new
   end
 
   # @!visibility private
@@ -274,7 +279,7 @@ class Calabash::Cucumber::Launcher
 
     sim_control = opts.fetch(:sim_control, RunLoop::SimControl.new)
     if sim_control.xcode_version_gte_6?
-      default_sim = RunLoop::Core.default_simulator(sim_control.xctools)
+      default_sim = RunLoop::Core.default_simulator(xcode)
       name_or_udid = merged_opts[:udid] || ENV['DEVICE_TARGET'] || default_sim
 
       target_simulator = nil
@@ -539,7 +544,7 @@ class Calabash::Cucumber::Launcher
     # @todo Use SimControl in Launcher in place of methods like simulator_target?
     args[:sim_control] = RunLoop::SimControl.new
     args[:instruments] = RunLoop::Instruments.new
-    args[:xcode] = RunLoop::Xcode.new
+    args[:xcode] = xcode
 
     if args[:app]
       if !File.exist?(args[:app])

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -487,7 +487,7 @@ class Calabash::Cucumber::Launcher
     return :instruments if major && major >= 7 # Only instruments supported for iOS7+
     return :sim_launcher if major # and then we have <= 6
 
-    if RunLoop::XCTools.new.xcode_version_gte_51?
+    if RunLoop::Xcode.new.version_gte_51?
       return use_sim_launcher_env? ? :sim_launcher : :instruments
     end
 
@@ -535,9 +535,7 @@ class Calabash::Cucumber::Launcher
 
     # RunLoop::Core.run_with_options can reuse the SimControl instance.  Many
     # of the Xcode tool calls, like instruments -s templates, take a long time
-    # to execute.  The SimControl instance has XCTool attribute which caches
-    # the results of many of these time-consuming calls so they only need to
-    # be called 1 time per launch.
+    # to execute.
     # @todo Use SimControl in Launcher in place of methods like simulator_target?
     args[:sim_control] = RunLoop::SimControl.new
     args[:instruments] = RunLoop::Instruments.new

--- a/calabash-cucumber/spec/integration/core/calabash_exit_spec.rb
+++ b/calabash-cucumber/spec/integration/core/calabash_exit_spec.rb
@@ -29,15 +29,16 @@ describe Calabash::Cucumber::Core do
 
     unless Luffa::Environment.travis_ci? &&
           Luffa::IDeviceInstaller.ideviceinstaller_available? &&
-          !Resources.shared.physical_devices_for_testing(RunLoop::XCTools.new).empty?
+          !Resources.shared.physical_devices_for_testing(RunLoop::Instruments.new).empty?
 
       describe 'targeting physical devices' do
         sim_control = RunLoop::SimControl.new
-        xcode_tools = sim_control.xctools
-        xcode_version = xcode_tools.xcode_version
-        Resources.shared.physical_devices_for_testing(xcode_tools).each do |device|
+        xcode = sim_control.xcode
+        xcode_version = xcode.version
+        instruments = RunLoop::Instruments.new
+        Resources.shared.physical_devices_for_testing(instruments).each do |device|
           if Luffa::Xcode::ios_version_incompatible_with_xcode_version?(device.version, xcode_version)
-            it "Skipping #{device.name} iOS #{device.version} with Xcode #{xcode_tools} - combination not supported" do
+            it "Skipping #{device.name} iOS #{device.version} with Xcode #{xcode} - combination not supported" do
               expect(true).to be == true
             end
           else

--- a/calabash-cucumber/spec/integration/device_spec.rb
+++ b/calabash-cucumber/spec/integration/device_spec.rb
@@ -25,9 +25,9 @@ unless Luffa::Environment.travis_ci?
 
       context 'device is an ipad' do
         let(:device_target) {
-          xcode_tools = RunLoop::XCTools.new
-          version = xcode_tools.xcode_version
-          if xcode_tools.xcode_version_gte_6?
+          xcode = RunLoop::Xcode.new
+          version = xcode.version
+          if xcode.version_gte_6?
             Luffa::Simulator.instance.core_simulator_for_xcode_version('iPad', 'Retina', version)
           else
             'iPad Retina (64-bit) - Simulator - iOS 7.1'
@@ -38,9 +38,9 @@ unless Luffa::Environment.travis_ci?
 
       context 'device is an 4in iphone' do
         let(:device_target) {
-          xcode_tools = RunLoop::XCTools.new
-          version = xcode_tools.xcode_version
-          if xcode_tools.xcode_version_gte_6?
+          xcode = RunLoop::Xcode.new
+          version = xcode.version
+          if xcode.version_gte_6?
             Luffa::Simulator.instance.core_simulator_for_xcode_version('iPhone', '5', version)
           else
             'iPhone Retina (4-inch) - Simulator - iOS 7.1'
@@ -51,9 +51,9 @@ unless Luffa::Environment.travis_ci?
 
       context 'device is a 3.5" iphone' do
         let(:device_target) {
-          xcode_tools = RunLoop::XCTools.new
-          version = xcode_tools.xcode_version
-          if xcode_tools.xcode_version_gte_6?
+          xcode = RunLoop::Xcode.new
+          version = xcode.version
+          if xcode.version_gte_6?
             Luffa::Simulator.instance.core_simulator_for_xcode_version('iPhone', '4s', version)
           else
             'iPhone Retina (3.5-inch) - Simulator - iOS 7.1'
@@ -64,9 +64,9 @@ unless Luffa::Environment.travis_ci?
 
       context 'device is an iphone 6' do
         let(:device_target) {
-          xcode_tools = RunLoop::XCTools.new
-          version = xcode_tools.xcode_version
-          if xcode_tools.xcode_version_gte_6?
+          xcode = RunLoop::Xcode.new
+          version = xcode.version
+          if xcode.version_gte_6?
             Luffa::Simulator.instance.core_simulator_for_xcode_version('iPhone', '6', version)
           else
             # iPhone 6 does not exist on Xcode < 6
@@ -78,9 +78,9 @@ unless Luffa::Environment.travis_ci?
 
       context 'device is an iphone 6+' do
         let(:device_target) {
-          xcode_tools = RunLoop::XCTools.new
-          version = xcode_tools.xcode_version
-          if xcode_tools.xcode_version_gte_6?
+          xcode = RunLoop::Xcode.new
+          version = xcode.version
+          if xcode.version_gte_6?
             Luffa::Simulator.instance.core_simulator_for_xcode_version('iPhone', '6 Plus', version)
           else
             # iPhone 6 does not exist on Xcode < 6

--- a/calabash-cucumber/spec/integration/launcher/reset_app_sandbox_spec.rb
+++ b/calabash-cucumber/spec/integration/launcher/reset_app_sandbox_spec.rb
@@ -66,7 +66,7 @@ module Calabash
         end
 
         def default_simulator_as_device(sim_control)
-          default_sim = RunLoop::Core.default_simulator(sim_control.xctools)
+          default_sim = RunLoop::Core.default_simulator(sim_control.xcode)
           target_simulator = nil
           sim_control.simulators.each do |device|
             instruments_launch_name = "#{device.name} (#{device.version.to_s} Simulator)"

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -17,30 +17,39 @@ describe 'Calabash Launcher' do
     describe 'returns :preferences when target is' do
       it 'a simulator' do
         launch_args = { :device_target => 'simulator' }
-        actual = launcher.default_uia_strategy(launch_args, sim_control)
+        instruments = RunLoop::Instruments.new
+        actual = launcher.default_uia_strategy(launch_args, sim_control, instruments)
         expect(actual).to be == :preferences
       end
 
       it 'an iOS device running iOS < 8.0' do
         devices = [RunLoop::Device.new('name', '7.1', UDID)]
         launch_args = { :device_target => UDID }
-        expect(sim_control.xctools).to receive(:instruments).with(:devices).and_return(devices)
-        actual = launcher.default_uia_strategy(launch_args, sim_control)
+        instruments = RunLoop::Instruments.new
+        expect(instruments).to receive(:physical_devices).and_return(devices)
+
+        actual = launcher.default_uia_strategy(launch_args, sim_control, instruments)
         expect(actual).to be == :preferences
       end
 
       it 'not found' do
         launch_args = { :device_target => 'a udid of a device that does not exist' }
-        expect(sim_control.xctools).to receive(:instruments).with(:devices).and_return([])
-        expect {launcher.default_uia_strategy(launch_args, sim_control)}.to raise_error(RuntimeError)
+        instruments = RunLoop::Instruments.new
+        expect(instruments).to receive(:physical_devices).and_return([])
+
+        expect do
+          launcher.default_uia_strategy(launch_args, sim_control, instruments)
+        end.to raise_error RuntimeError
       end
     end
 
     it 'returns :host when target is an iOS device running iOS >= 8.0' do
       devices = [RunLoop::Device.new('name', '8.0', UDID)]
       launch_args = { :device_target => UDID }
-      expect(sim_control.xctools).to receive(:instruments).with(:devices).and_return(devices)
-      actual = launcher.default_uia_strategy(launch_args, sim_control)
+      instruments = RunLoop::Instruments.new
+      expect(instruments).to receive(:physical_devices).and_return(devices)
+
+      actual = launcher.default_uia_strategy(launch_args, sim_control, instruments)
       expect(actual).to be == :host
     end
   end

--- a/calabash-cucumber/spec/resources.rb
+++ b/calabash-cucumber/spec/resources.rb
@@ -117,12 +117,12 @@ class Resources
     Luffa::IDeviceInstaller.new(ipa_path, bundle_id)
   end
 
-  def physical_devices_for_testing(xcode_tools)
-    version = xcode_tools.xcode_version.to_s
+  def physical_devices_for_testing(instruments)
+    version = instruments.xcode.version.to_s
     @physical_devices ||= {}
 
     unless @physical_devices[version]
-      @physical_devices[version] = Luffa::IDeviceInstaller.physical_devices_for_testing(xcode_tools)
+      @physical_devices[version] = Luffa::IDeviceInstaller.physical_devices_for_testing(instruments)
     end
     @physical_devices[version]
   end

--- a/calabash-cucumber/spec/resources.rb
+++ b/calabash-cucumber/spec/resources.rb
@@ -9,7 +9,7 @@ class Resources
   end
 
   def active_xcode_version
-    @active_xcode_version ||= RunLoop::XCTools.new.xcode_version
+    @active_xcode_version ||= RunLoop::Xcode.new.version
   end
 
   def resources_dir

--- a/calabash-cucumber/test/cucumber/config/cucumber.yml
+++ b/calabash-cucumber/test/cucumber/config/cucumber.yml
@@ -2,9 +2,9 @@
 
 require 'run_loop'
 
-xcode_tools = RunLoop::XCTools.new
+xcode_tools = RunLoop::Xcode.new
 sims = {}
-if xcode_tools.xcode_version_gte_61?
+if xcode_tools.version_gte_61?
   sims[:ipad2]     = 'iPad 2 (8.1 Simulator)'
   sims[:ipad2_mid] = 'iPad 2 (7.1 Simulator)'
 


### PR DESCRIPTION
### Motivation

RunLoop::XCTools has be deprecated and its responsibilities divided into three class:

* Xcode
* Instruments
* L10N
