### PR TITLE
Device rotation with UIAutomation

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -10,6 +10,7 @@ module Calabash
       include Calabash::Cucumber::Logging
 
       # @!visibility private
+      # @deprecated 0.16.1
       def rotation_candidates
         %w(rotate_left_home_down rotate_left_home_left rotate_left_home_right rotate_left_home_up
            rotate_right_home_down rotate_right_home_left rotate_right_home_right rotate_right_home_up)
@@ -136,6 +137,7 @@ module Calabash
       }.freeze
 
       # @! visibility private
+      # @deprecated 0.16.1
       def rotate_home_button_to_position_with_playback(home_button_position)
 
         rotation_candidates.each do |candidate|
@@ -218,6 +220,7 @@ Is rotation enabled for this controller?}
       end
 
       # @! visibility private
+      # @deprecated 0.16.1
       def recording_name(direction, current_orientation)
         recording_name = nil
         case direction
@@ -249,6 +252,7 @@ Is rotation enabled for this controller?}
       end
 
       # @! visibility private
+      # @deprecated 0.16.1
       def rotate_with_playback(direction, current_orientation)
         name = recording_name(direction, current_orientation)
 

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -195,46 +195,45 @@ module Calabash
         key
       end
 
-        rotate_cmd = nil
-        case dir
+      def recording_name(direction, current_orientation)
+        recording_name = nil
+        case direction
           when :left then
             if current_orientation == :down
-              rotate_cmd = 'left_home_down'
+              recording_name = 'left_home_down'
             elsif current_orientation == :right
-              rotate_cmd = 'left_home_right'
+              recording_name = 'left_home_right'
             elsif current_orientation == :left
-              rotate_cmd = 'left_home_left'
+              recording_name = 'left_home_left'
             elsif current_orientation == :up
-              rotate_cmd = 'left_home_up'
+              recording_name = 'left_home_up'
             end
           when :right then
             if current_orientation == :down
-              rotate_cmd = 'right_home_down'
+              recording_name = 'right_home_down'
             elsif current_orientation == :left
-              rotate_cmd = 'right_home_left'
+              recording_name = 'right_home_left'
             elsif current_orientation == :right
-              rotate_cmd = 'right_home_right'
+              recording_name = 'right_home_right'
             elsif current_orientation == :up
-              rotate_cmd = 'right_home_up'
+              recording_name = 'right_home_up'
             end
+          else
+            raise ArgumentError,
+                  "Expected '#{direction}' to be 'left' or 'right'"
         end
-
-        if rotate_cmd.nil?
-          if full_console_logging?
-            puts "Could not rotate device in direction '#{dir}' with orientation '#{current_orientation} - will do nothing"
-          end
-        else
-          result = playback("rotate_#{rotate_cmd}")
-          recalibrate_after_rotation
-          result
-        end
+        "rotate_#{recording_name}"
       end
 
-      def recalibrate_after_rotation
-        uia_query :window
+      def rotate_with_playback(direction, current_orientation)
+        name = recording_name(direction, current_orientation)
+
+        if debug_logging?
+          puts "Could not rotate device '#{direction}' given '#{current_orientation}'; nothing to do."
+        end
+
+        playback(name)
       end
-
-
     end
   end
 end

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -146,6 +146,23 @@ module Calabash
 
       private
 
+      def ensure_valid_rotate_home_to_arg(arg)
+        coerced = arg.to_sym
+
+        if coerced == :top
+          coerced = :up
+        elsif coerced == :bottom
+          coerced = :down
+        end
+
+        allowed = [:down, :up, :left, :right]
+        unless allowed.include?(coerced)
+          raise ArgumentError,
+                "Expected '#{arg}' to be :down, :up, :left, or :right"
+        end
+        coerced
+      end
+
       UIA_DEVICE_ORIENTATION = {
             :portrait => 1,
             :upside_down => 2,

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -135,8 +135,28 @@ module Calabash
             :landscape_right => 4
       }.freeze
 
-      def recalibrate_after_rotation
-        uia_query :window
+      def rotate_home_button_to_position_with_playback(home_button_position)
+
+        rotation_candidates.each do |candidate|
+          if debug_logging?
+            calabash_info "Trying to rotate Home Button to '#{home_button_position}' using '#{candidate}'"
+          end
+
+          playback(candidate)
+          sleep(0.4)
+          recalibrate_after_rotation
+
+          current_orientation = status_bar_orientation.to_sym
+          if current_orientation == home_button_position
+            return current_orientation
+          end
+        end
+
+        if debug_logging?
+          calabash_warn "Could not rotate Home Button to '#{home_button_position}'."
+          calabash_warn 'Is rotation enabled for this controller?'
+        end
+        :down
       end
 
       def rotate_to_uia_orientation(orientation)

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -44,7 +44,7 @@ module Calabash
       # @note This method generates verbose messages when full console logging
       #  is enabled.  See {Calabash::Cucumber::Logging#full_console_logging?}.
       #
-      # @param [Symbol] dir The position of the home button after the rotation.
+      # @param [Symbol] direction The position of the home button after the rotation.
       #  Can be one of `{:down | :left | :right | :up }`.
       #
       # @note A rotation will only occur if your view controller and application
@@ -52,25 +52,12 @@ module Calabash
       #
       # @return [Symbol] The position of the home button relative to the status
       #  bar when all rotations have been completed.
-      def rotate_home_button_to(dir)
-        dir_sym = dir.to_sym
-        if dir_sym.eql?(:top)
-          if full_console_logging?
-            calabash_warn "converting '#{dir}' to ':up' - please adjust your code"
-          end
-          dir_sym = :up
-        end
+      def rotate_home_button_to(direction)
 
-        if dir_sym.eql?(:bottom)
-          if full_console_logging?
-            calabash_warn "converting '#{dir}' to ':down' - please adjust your code"
-          end
-          dir_sym = :down
-        end
-
-        directions = [:down, :up, :left, :right]
-        unless directions.include?(dir_sym)
-          screenshot_and_raise "expected one of '#{directions}' as an arg to 'rotate_home_button_to but found '#{dir}'"
+        begin
+          as_symbol = ensure_valid_rotate_home_to_arg(direction)
+        rescue ArgumentError => e
+          raise ArgumentError, e.message
         end
 
         res = status_bar_orientation()
@@ -80,11 +67,11 @@ module Calabash
           res = res.to_sym
         end
 
-        return res if res.eql? dir_sym
+        return res if res.eql? as_symbol
 
         rotation_candidates.each { |candidate|
           if full_console_logging?
-            puts "try to rotate to '#{dir_sym}' using '#{candidate}'"
+            puts "try to rotate to '#{as_symbol}' using '#{candidate}'"
           end
           playback(candidate)
           sleep(0.4)
@@ -97,11 +84,11 @@ module Calabash
             res = res.to_sym
           end
 
-          return if res.eql? dir_sym
+          return if res.eql? as_symbol
         }
 
         if full_console_logging?
-          calabash_warn "Could not rotate home button to '#{dir}'."
+          calabash_warn "Could not rotate home button to '#{direction}'."
           calabash_warn 'Is rotation enabled for this controller?'
           calabash_warn "Will return 'down'"
         end

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -119,7 +119,7 @@ module Calabash
       # @param [Symbol] direction The direction to rotate. Can be :left or :right.
       #
       # @return [Symbol] The position of the home button relative to the status
-      #   bar after the rotation.  Can be one of `{:down | :left | :right | :up }`.
+      #   bar after the rotation.  Will be one of `{:down | :left | :right | :up }`.
       # @raise [ArgumentError] If direction is not :left or :right.
       def rotate(direction)
 
@@ -138,7 +138,61 @@ module Calabash
           result = rotate_with_playback(as_symbol, current_orientation)
         end
         recalibrate_after_rotation
-        result
+
+        ap result if debug_logging?
+
+        status_bar_orientation
+      end
+
+      private
+
+      UIA_DEVICE_ORIENTATION = {
+            :portrait => 1,
+            :upside_down => 2,
+            :landscape_left => 3,
+            :landscape_right => 4
+      }.freeze
+
+      def recalibrate_after_rotation
+        uia_query :window
+      end
+
+      def rotate_with_uia(direction, current_orientation)
+        key = uia_orientation_key(direction, current_orientation)
+        value = UIA_DEVICE_ORIENTATION[key]
+        cmd = "UIATarget.localTarget().setDeviceOrientation(#{value})"
+        uia(cmd)
+      end
+
+      def uia_orientation_key(direction, current_orientation)
+
+        key = nil
+        case direction
+          when :left then
+            if current_orientation == :down
+              key = :landscape_right
+            elsif current_orientation == :right
+              key = :portrait
+            elsif current_orientation == :left
+              key = :upside_down
+            elsif current_orientation == :up
+              key = :landscape_left
+            end
+          when :right then
+            if current_orientation == :down
+              key = :landscape_left
+            elsif current_orientation == :right
+              key = :upside_down
+            elsif current_orientation == :left
+              key = :portrait
+            elsif current_orientation == :up
+              key = :landscape_right
+            end
+          else
+            raise ArgumentError,
+                  "Expected '#{direction}' to be :left or :right"
+        end
+        key
       end
 
         rotate_cmd = nil

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -108,7 +108,7 @@ module Calabash
         :down
       end
 
-      # Rotates the device in the direction indicated by `dir`.
+      # Rotates the device in the direction indicated by `direction`.
       #
       # @example rotate left
       #  rotate :left
@@ -116,13 +116,31 @@ module Calabash
       # @example rotate right
       #  rotate :right
       #
-      # @param [Symbol] dir The direction to rotate.  Can be :left or :right.
+      # @param [Symbol] direction The direction to rotate. Can be :left or :right.
       #
       # @return [Symbol] The position of the home button relative to the status
       #   bar after the rotation.  Can be one of `{:down | :left | :right | :up }`.
-      def rotate(dir)
-        dir = dir.to_sym
-        current_orientation = status_bar_orientation().to_sym
+      # @raise [ArgumentError] If direction is not :left or :right.
+      def rotate(direction)
+
+        as_symbol = direction.to_sym
+
+        if as_symbol != :left && as_symbol != :right
+          raise ArgumentError,
+                "Expected '#{direction}' to be :left or :right"
+        end
+
+        current_orientation = status_bar_orientation.to_sym
+
+        if ios_version >= RunLoop::Version.new('9.0')
+          result = rotate_with_uia(as_symbol, current_orientation)
+        else
+          result = rotate_with_playback(as_symbol, current_orientation)
+        end
+        recalibrate_after_rotation
+        result
+      end
+
         rotate_cmd = nil
         case dir
           when :left then

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -153,8 +153,9 @@ module Calabash
         end
 
         if debug_logging?
-          calabash_warn "Could not rotate Home Button to '#{home_button_position}'."
-          calabash_warn 'Is rotation enabled for this controller?'
+          calabash_warn %Q{
+Could not rotate Home Button to '#{home_button_position}'."
+Is rotation enabled for this controller?}
         end
         :down
       end

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -111,6 +111,12 @@ module Calabash
 
       private
 
+      # @! visibility private
+      def recalibrate_after_rotation
+        uia_query :window
+      end
+
+      # @! visibility private
       def ensure_valid_rotate_home_to_arg(arg)
         coerced = arg.to_sym
 
@@ -128,6 +134,7 @@ module Calabash
         coerced
       end
 
+      # @! visibility private
       UIA_DEVICE_ORIENTATION = {
             :portrait => 1,
             :upside_down => 2,
@@ -135,6 +142,7 @@ module Calabash
             :landscape_right => 4
       }.freeze
 
+      # @! visibility private
       def rotate_home_button_to_position_with_playback(home_button_position)
 
         rotation_candidates.each do |candidate|
@@ -160,6 +168,7 @@ Is rotation enabled for this controller?}
         :down
       end
 
+      # @! visibility private
       def rotate_to_uia_orientation(orientation)
         case orientation
           when :down then key = :portrait
@@ -175,6 +184,7 @@ Is rotation enabled for this controller?}
         uia(cmd)
       end
 
+      # @! visibility private
       def rotate_with_uia(direction, current_orientation)
         key = uia_orientation_key(direction, current_orientation)
         value = UIA_DEVICE_ORIENTATION[key]
@@ -182,6 +192,7 @@ Is rotation enabled for this controller?}
         uia(cmd)
       end
 
+      # @! visibility private
       def uia_orientation_key(direction, current_orientation)
 
         key = nil
@@ -213,6 +224,7 @@ Is rotation enabled for this controller?}
         key
       end
 
+      # @! visibility private
       def recording_name(direction, current_orientation)
         recording_name = nil
         case direction
@@ -243,6 +255,7 @@ Is rotation enabled for this controller?}
         "rotate_#{recording_name}"
       end
 
+      # @! visibility private
       def rotate_with_playback(direction, current_orientation)
         name = recording_name(direction, current_orientation)
 

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -157,6 +157,21 @@ module Calabash
         uia_query :window
       end
 
+      def rotate_to_uia_orientation(orientation)
+        case orientation
+          when :down then key = :portrait
+          when :up then key = :upside_down
+          when :left then key = :landscape_right
+          when :right then key = :landscape_left
+          else
+            raise ArgumentError,
+                  "Expected '#{orientation}' to be :left, :right, :up, or :down"
+        end
+        value = UIA_DEVICE_ORIENTATION[key]
+        cmd = "UIATarget.localTarget().setDeviceOrientation(#{value})"
+        uia(cmd)
+      end
+
       def rotate_with_uia(direction, current_orientation)
         key = uia_orientation_key(direction, current_orientation)
         value = UIA_DEVICE_ORIENTATION[key]

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -64,13 +64,9 @@ module Calabash
 
         return current_orientation if current_orientation == as_symbol
 
-        if ios_version >= RunLoop::Version.new('9.0')
-          rotate_to_uia_orientation(as_symbol)
-          recalibrate_after_rotation
-          status_bar_orientation.to_sym
-        else
-          rotate_home_button_to_position_with_playback(as_symbol)
-        end
+        rotate_to_uia_orientation(as_symbol)
+        recalibrate_after_rotation
+        status_bar_orientation.to_sym
       end
 
       # Rotates the device in the direction indicated by `direction`.
@@ -97,11 +93,8 @@ module Calabash
 
         current_orientation = status_bar_orientation.to_sym
 
-        if ios_version >= RunLoop::Version.new('9.0')
-          result = rotate_with_uia(as_symbol, current_orientation)
-        else
-          result = rotate_with_playback(as_symbol, current_orientation)
-        end
+        result = rotate_with_uia(as_symbol, current_orientation)
+
         recalibrate_after_rotation
 
         ap result if debug_logging?

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -8,6 +8,7 @@ describe Calabash::Cucumber::RotationHelpers do
       def uia_query(_); ; end
       def status_bar_orientation; ; end
       def uia(_); ; end
+      def playback(_); ; end
     end.new
   end
 
@@ -64,12 +65,11 @@ describe Calabash::Cucumber::RotationHelpers do
     expect(helper.send(:rotate_with_uia, :left, :down)).to be == :result
   end
 
-  describe '#rotate_with_playback' do
-    it 'raises error' do
-      expect do
-        helper.send(:rotate_with_playback, :invalid, :orientation)
-      end.to raise_error ArgumentError
-    end
+  it '#rotate_with_playback' do
+    expect(helper).to receive(:recording_name).and_return 'recording name'
+    expect(helper).to receive(:playback).with('recording name').and_return :result
+
+    expect(helper.send(:rotate_with_playback, :left, :down)).to be == :result
   end
 
   describe '#uia_orientation_key' do
@@ -85,6 +85,44 @@ describe Calabash::Cucumber::RotationHelpers do
       it ':right' do helper.send(:uia_orientation_key, :right, :right) == :upside_down end
       it ':left' do helper.send(:uia_orientation_key, :right, :left) == :portrait end
       it ':up' do helper.send(:uia_orientation_key, :right, :up) == :landscape_right end
+    end
+  end
+
+  describe '#recording_name' do
+    describe ':left' do
+      it ':down' do
+        helper.send(:recording_name, :left, :down) == 'rotate_left_home_down'
+      end
+
+      it ':right' do
+        helper.send(:recording_name, :left, :right) == 'rotate_left_home_right'
+      end
+
+      it ':left' do
+        helper.send(:recording_name, :left, :left) == 'rotate_left_home_left'
+      end
+
+      it ':up' do
+        helper.send(:recording_name, :left, :up) == 'rotate_left_home_up'
+      end
+    end
+
+    describe ':right' do
+      it ':down' do
+        helper.send(:recording_name, :left, :down) == 'rotate_right_home_down'
+      end
+
+      it ':right' do
+        helper.send(:recording_name, :left, :right) == 'rotate_right_home_right'
+      end
+
+      it ':left' do
+        helper.send(:recording_name, :left, :left) == 'rotate_right_home_left'
+      end
+
+      it ':up' do
+        helper.send(:recording_name, :left, :up) == 'rotate_right_home_up'
+      end
     end
   end
 end

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -12,6 +12,10 @@ describe Calabash::Cucumber::RotationHelpers do
     end.new
   end
 
+  before do
+    stub_env({'DEBUG' => '1'})
+  end
+
   describe '#rotate_home_button_to' do
     it 're-raises ArgumentError' do
       error = ArgumentError.new('Expect ArgumentError')

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -7,11 +7,12 @@ describe Calabash::Cucumber::RotationHelpers do
 
       def uia_query(_); ; end
       def status_bar_orientation; ; end
+      def uia(_); ; end
     end.new
   end
 
 
-  describe '.rotate' do
+  describe '#rotate' do
     describe 'validates arguments' do
       it 'raises error on invalid arguments' do
         expect do
@@ -23,52 +24,67 @@ describe Calabash::Cucumber::RotationHelpers do
 
         before do
           expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('9.0')
-          expect(helper).to receive(:status_bar_orientation).and_return :current
+          expect(helper).to receive(:status_bar_orientation).and_return(:before, :after)
           expect(helper).to receive(:rotate_with_uia).and_return :orientation
           expect(helper).to receive(:recalibrate_after_rotation).and_call_original
         end
 
-        it 'left' do expect(helper.rotate('left')).to be == :orientation end
-        it ':left' do expect(helper.rotate(:left)).to be == :orientation end
-        it 'right' do expect(helper.rotate('right')).to be == :orientation end
-        it ':right' do expect(helper.rotate(:right)).to be == :orientation end
+        it 'left' do expect(helper.rotate('left')).to be == :after end
+        it ':left' do expect(helper.rotate(:left)).to be == :after end
+        it 'right' do expect(helper.rotate('right')).to be == :after end
+        it ':right' do expect(helper.rotate(:right)).to be == :after end
       end
     end
 
     it 'iOS 9' do
       expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('9.0')
-      expect(helper).to receive(:status_bar_orientation).and_return :current
-      expect(helper).to receive(:rotate_with_uia).with(:left, :current).and_return :orientation
+      expect(helper).to receive(:status_bar_orientation).and_return(:before, :after)
+      expect(helper).to receive(:rotate_with_uia).with(:left, :before).and_return :orientation
       expect(helper).to receive(:recalibrate_after_rotation).and_call_original
 
-      expect(helper.rotate(:left)).to be == :orientation
+      expect(helper.rotate(:left)).to be == :after
     end
 
     it 'iOS < 9' do
       expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('8.0')
-      expect(helper).to receive(:status_bar_orientation).and_return :current
-      expect(helper).to receive(:rotate_with_playback).with(:left, :current).and_return :orientation
+      expect(helper).to receive(:status_bar_orientation).and_return(:before, :after)
+      expect(helper).to receive(:rotate_with_playback).with(:left, :before).and_return :orientation
       expect(helper).to receive(:recalibrate_after_rotation).and_call_original
 
-      expect(helper.rotate(:left)).to be == :orientation
+      expect(helper.rotate(:left)).to be == :after
     end
   end
 
-  describe '.rotate_with_uia' do
-    it 'raises error' do
-      expect do
-        helper.send(:rotate_with_uia, :invalid, :orientation)
-      end.to raise_error ArgumentError
-    end
+  it '#rotate_with_uia' do
+    expect(helper).to receive(:uia_orientation_key).and_return :key
+    stub_const('Calabash::Cucumber::RotationHelpers::UIA_DEVICE_ORIENTATION', {:key => 'value' })
+    expected = 'UIATarget.localTarget().setDeviceOrientation(value)'
+    expect(helper).to receive(:uia).with(expected).and_return :result
 
-
+    expect(helper.send(:rotate_with_uia, :left, :down)).to be == :result
   end
 
-  describe '.rotate_with_playback' do
+  describe '#rotate_with_playback' do
     it 'raises error' do
       expect do
-        helper.send(:rotate_with_playback, :invalid, :orienation)
+        helper.send(:rotate_with_playback, :invalid, :orientation)
       end.to raise_error ArgumentError
+    end
+  end
+
+  describe '#uia_orientation_key' do
+    describe ':left' do
+      it ':down' do helper.send(:uia_orientation_key, :left, :down) == :landscape_right end
+      it ':right' do helper.send(:uia_orientation_key, :left, :right) == :portrait end
+      it ':left' do helper.send(:uia_orientation_key, :left, :left) == :upside_down end
+      it ':up' do helper.send(:uia_orientation_key, :left, :up) == :landscape_left end
+    end
+
+    describe ':right' do
+      it ':down' do helper.send(:uia_orientation_key, :right, :down) == :landscape_left end
+      it ':right' do helper.send(:uia_orientation_key, :right, :right) == :upside_down end
+      it ':left' do helper.send(:uia_orientation_key, :right, :left) == :portrait end
+      it ':up' do helper.send(:uia_orientation_key, :right, :up) == :landscape_right end
     end
   end
 end

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -21,6 +21,30 @@ describe Calabash::Cucumber::RotationHelpers do
         helper.rotate_home_button_to(:invalid)
       end.to raise_error ArgumentError, /Expect ArgumentError/
     end
+
+    it 'does nothing if device is already in the target orientation' do
+      expect(helper).to receive(:ensure_valid_rotate_home_to_arg).and_return :down
+      expect(helper).to receive(:status_bar_orientation).and_return 'down'
+
+      expect(helper.rotate_home_button_to('down')).to be == :down
+    end
+
+    it 'iOS >= 9' do
+      expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('9.0')
+      expect(helper).to receive(:rotate_to_uia_orientation).with(:down).and_return :rotation_result
+      expect(helper).to receive(:recalibrate_after_rotation).and_call_original
+      expect(helper).to receive(:status_bar_orientation).and_return('before', 'after')
+
+      expect(helper.rotate_home_button_to('down')).to be == :after
+    end
+
+    it 'iOS < 9' do
+      expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('8.0')
+      expect(helper).to receive(:status_bar_orientation).and_return('before')
+      expect(helper).to receive(:rotate_home_button_to_position_with_playback).with(:down).and_return :after
+
+      expect(helper.rotate_home_button_to('down')).to be == :after
+    end
   end
 
   describe '#rotate' do

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -12,9 +12,33 @@ describe Calabash::Cucumber::RotationHelpers do
 
 
   describe '.rotate' do
+    describe 'validates arguments' do
+      it 'raises error on invalid arguments' do
+        expect do
+          helper.rotate(:invalid)
+          end.to raise_error ArgumentError, /Expected/
+      end
+
+      describe 'valid arguments' do
+
+        before do
+          expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('9.0')
+          expect(helper).to receive(:status_bar_orientation).and_return :current
+          expect(helper).to receive(:rotate_with_uia).and_return :orientation
+          expect(helper).to receive(:recalibrate_after_rotation).and_call_original
+        end
+
+        it 'left' do expect(helper.rotate('left')).to be == :orientation end
+        it ':left' do expect(helper.rotate(:left)).to be == :orientation end
+        it 'right' do expect(helper.rotate('right')).to be == :orientation end
+        it ':right' do expect(helper.rotate(:right)).to be == :orientation end
+      end
+    end
+
     it 'iOS 9' do
       expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('9.0')
-      expect(helper).to receive(:rotate_with_uia).with(:left).and_return :orientation
+      expect(helper).to receive(:status_bar_orientation).and_return :current
+      expect(helper).to receive(:rotate_with_uia).with(:left, :current).and_return :orientation
       expect(helper).to receive(:recalibrate_after_rotation).and_call_original
 
       expect(helper.rotate(:left)).to be == :orientation
@@ -22,7 +46,8 @@ describe Calabash::Cucumber::RotationHelpers do
 
     it 'iOS < 9' do
       expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('8.0')
-      expect(helper).to receive(:rotate_with_playback).with(:left).and_return :orientation
+      expect(helper).to receive(:status_bar_orientation).and_return :current
+      expect(helper).to receive(:rotate_with_playback).with(:left, :current).and_return :orientation
       expect(helper).to receive(:recalibrate_after_rotation).and_call_original
 
       expect(helper.rotate(:left)).to be == :orientation
@@ -31,20 +56,18 @@ describe Calabash::Cucumber::RotationHelpers do
 
   describe '.rotate_with_uia' do
     it 'raises error' do
-      expect(helper).to receive(:status_bar_orientation).and_return :orientation
-
       expect do
-        helper.send(:rotate_with_uia, :invalid)
+        helper.send(:rotate_with_uia, :invalid, :orientation)
       end.to raise_error ArgumentError
     end
+
+
   end
 
   describe '.rotate_with_playback' do
     it 'raises error' do
-      expect(helper).to receive(:status_bar_orientation).and_return :orientation
-
       expect do
-        helper.send(:rotate_with_playback, :invalid)
+        helper.send(:rotate_with_playback, :invalid, :orienation)
       end.to raise_error ArgumentError
     end
   end

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -169,4 +169,30 @@ describe Calabash::Cucumber::RotationHelpers do
       end
     end
   end
+
+  describe '#ensure_valid_rotate_home_to_arg' do
+    it 'raises error when arg is invalid' do
+      expect do
+        helper.send(:ensure_valid_rotate_home_to_arg, :invalid)
+      end.to raise_error ArgumentError, /Expected/
+    end
+
+    describe 'valid arguments' do
+      it 'top' do
+        expect(helper.send(:ensure_valid_rotate_home_to_arg, 'top')).to be == :up
+      end
+
+      it ':top' do
+        expect(helper.send(:ensure_valid_rotate_home_to_arg, :top)).to be == :up
+      end
+
+      it 'bottom' do
+        expect(helper.send(:ensure_valid_rotate_home_to_arg, 'bottom')).to be == :down
+      end
+
+      it ':bottom' do
+        expect(helper.send(:ensure_valid_rotate_home_to_arg, :bottom)).to be == :down
+      end
+    end
+  end
 end

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -1,0 +1,51 @@
+describe Calabash::Cucumber::RotationHelpers do
+
+  let(:helper) do
+    Class.new do
+      include Calabash::Cucumber::RotationHelpers
+      include Calabash::Cucumber::EnvironmentHelpers
+
+      def uia_query(_); ; end
+      def status_bar_orientation; ; end
+    end.new
+  end
+
+
+  describe '.rotate' do
+    it 'iOS 9' do
+      expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('9.0')
+      expect(helper).to receive(:rotate_with_uia).with(:left).and_return :orientation
+      expect(helper).to receive(:recalibrate_after_rotation).and_call_original
+
+      expect(helper.rotate(:left)).to be == :orientation
+    end
+
+    it 'iOS < 9' do
+      expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('8.0')
+      expect(helper).to receive(:rotate_with_playback).with(:left).and_return :orientation
+      expect(helper).to receive(:recalibrate_after_rotation).and_call_original
+
+      expect(helper.rotate(:left)).to be == :orientation
+    end
+  end
+
+  describe '.rotate_with_uia' do
+    it 'raises error' do
+      expect(helper).to receive(:status_bar_orientation).and_return :orientation
+
+      expect do
+        helper.send(:rotate_with_uia, :invalid)
+      end.to raise_error ArgumentError
+    end
+  end
+
+  describe '.rotate_with_playback' do
+    it 'raises error' do
+      expect(helper).to receive(:status_bar_orientation).and_return :orientation
+
+      expect do
+        helper.send(:rotate_with_playback, :invalid)
+      end.to raise_error ArgumentError
+    end
+  end
+end

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -125,4 +125,48 @@ describe Calabash::Cucumber::RotationHelpers do
       end
     end
   end
+
+  describe '#rotate_to_uia_orientation' do
+    it 'raises an error for invalid arguments' do
+      expect do
+        helper.send(:rotate_to_uia_orientation, :invalid)
+      end.to raise_error ArgumentError, /Expected/
+    end
+
+    describe 'valid arguments' do
+      it ':down' do
+        expected = 'UIATarget.localTarget().setDeviceOrientation(1)'
+        expect(helper).to receive(:uia).with(expected).and_return :result
+
+        actual = helper.send(:rotate_to_uia_orientation, :down)
+        expect(actual).to be == :result
+      end
+
+      it ':up' do
+        expected = 'UIATarget.localTarget().setDeviceOrientation(2)'
+        expect(helper).to receive(:uia).with(expected).and_return :result
+
+        actual = helper.send(:rotate_to_uia_orientation, :up)
+        expect(actual).to be == :result
+
+      end
+
+      it ':left' do
+        expected = 'UIATarget.localTarget().setDeviceOrientation(4)'
+        expect(helper).to receive(:uia).with(expected).and_return :result
+
+        actual = helper.send(:rotate_to_uia_orientation, :left)
+        expect(actual).to be == :result
+
+      end
+
+      it ':right' do
+        expected = 'UIATarget.localTarget().setDeviceOrientation(3)'
+        expect(helper).to receive(:uia).with(expected).and_return :result
+
+        actual = helper.send(:rotate_to_uia_orientation, :right)
+        expect(actual).to be == :result
+      end
+    end
+  end
 end

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -33,19 +33,10 @@ describe Calabash::Cucumber::RotationHelpers do
       expect(helper.rotate_home_button_to('down')).to be == :down
     end
 
-    it 'iOS >= 9' do
-      expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('9.0')
+    it 'rotates' do
       expect(helper).to receive(:rotate_to_uia_orientation).with(:down).and_return :rotation_result
       expect(helper).to receive(:recalibrate_after_rotation).and_call_original
       expect(helper).to receive(:status_bar_orientation).and_return('before', 'after')
-
-      expect(helper.rotate_home_button_to('down')).to be == :after
-    end
-
-    it 'iOS < 9' do
-      expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('8.0')
-      expect(helper).to receive(:status_bar_orientation).and_return('before')
-      expect(helper).to receive(:rotate_home_button_to_position_with_playback).with(:down).and_return :after
 
       expect(helper.rotate_home_button_to('down')).to be == :after
     end
@@ -62,7 +53,6 @@ describe Calabash::Cucumber::RotationHelpers do
       describe 'valid arguments' do
 
         before do
-          expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('9.0')
           expect(helper).to receive(:status_bar_orientation).and_return(:before, :after)
           expect(helper).to receive(:rotate_with_uia).and_return :orientation
           expect(helper).to receive(:recalibrate_after_rotation).and_call_original
@@ -75,19 +65,9 @@ describe Calabash::Cucumber::RotationHelpers do
       end
     end
 
-    it 'iOS 9' do
-      expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('9.0')
+    it 'rotates' do
       expect(helper).to receive(:status_bar_orientation).and_return(:before, :after)
       expect(helper).to receive(:rotate_with_uia).with(:left, :before).and_return :orientation
-      expect(helper).to receive(:recalibrate_after_rotation).and_call_original
-
-      expect(helper.rotate(:left)).to be == :after
-    end
-
-    it 'iOS < 9' do
-      expect(helper).to receive(:ios_version).and_return RunLoop::Version.new('8.0')
-      expect(helper).to receive(:status_bar_orientation).and_return(:before, :after)
-      expect(helper).to receive(:rotate_with_playback).with(:left, :before).and_return :orientation
       expect(helper).to receive(:recalibrate_after_rotation).and_call_original
 
       expect(helper.rotate(:left)).to be == :after

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -229,4 +229,26 @@ describe Calabash::Cucumber::RotationHelpers do
       end
     end
   end
+
+  describe '#rotate_home_button_to_position_with_playback' do
+    let(:method_name) { :rotate_home_button_to_position_with_playback }
+
+    it 'returns :down if rotation cannot be performed' do
+      expect(helper).to receive(:rotation_candidates).and_return([])
+
+      expect(helper.send(method_name, :any_arg)).to be == :down
+    end
+
+    let(:candidates) { [:a, :b, :c, :left] }
+
+    it 'calls playback with candidates' do
+      expect(helper).to receive(:playback).exactly(4).times.and_return nil
+      expect(helper).to receive(:sleep).exactly(4).times.and_return nil
+      expect(helper).to receive(:recalibrate_after_rotation).exactly(4).times.and_call_original
+      expect(helper).to receive(:status_bar_orientation).and_return(*candidates)
+      expect(helper).to receive(:rotation_candidates).and_return candidates
+
+      expect(helper.send(method_name, :left)).to be == :left
+    end
+  end
 end

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -12,6 +12,16 @@ describe Calabash::Cucumber::RotationHelpers do
     end.new
   end
 
+  describe '#rotate_home_button_to' do
+    it 're-raises ArgumentError' do
+      error = ArgumentError.new('Expect ArgumentError')
+      expect(helper).to receive(:ensure_valid_rotate_home_to_arg).and_raise error
+
+      expect do
+        helper.rotate_home_button_to(:invalid)
+      end.to raise_error ArgumentError, /Expect ArgumentError/
+    end
+  end
 
   describe '#rotate' do
     describe 'validates arguments' do


### PR DESCRIPTION
**FORCE PUSHED** Tue Sep 15 10:55

### Motivation

Calabash iOS used the deprecated playback API for device rotation.  As of iOS 9, this is causing crashes in the server.

This PR detects iOS 9 and use the alternative UIAutomation calls to set the device orientation.

One side effect of using UIAutomation is that the device will "remember" the last orientation and when the app is next launched, it will be in that orientation, regardless of the device orientation.

Apps running under iOS 8, but with the server compiled with Xcode 7 can still use the playback API.

It might be that we need to make new recordings for iOS 9...

@krukow @sapieneptus 