### PR TITLE
Fixup Launcher#attach for Xcode 7

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -122,8 +122,7 @@ class Calabash::Cucumber::Launcher
     # Sets the device attribute.
     ensure_connectivity(merged_options[:max_retry], merged_options[:timeout])
 
-    # The default strategy for iOS 8 devices is :host.
-    if strategy_from_options.nil? && self.device.ios_major_version > '8'
+    if strategy_from_options.nil? && xcode.version_gte_7?
       self.run_loop = RunLoop::HostCache.default.read
       return self
     end


### PR DESCRIPTION
### Motivation

Xcode 7 requires :host for all targets.

The diff may look like a mistake:

```
strategy_from_options.nil? && self.device.ios_major_version > '8'
```

In Xcode 6, that would always eval to false, so the condition was never met; a bug.

* **Launcher.attach needs Xcode 7 love** #828

This is just a patch.  Some retooling of run-loop needs to happen to make this easier.