### PR TITLE
Force recording name prefix to 'iphone' or 'ipad'

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/playback_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/playback_helpers.rb
@@ -55,7 +55,17 @@ module Calabash
 
       # @!visibility private
       def load_playback_data(recording_name, options={})
+
         device = options['DEVICE'] || ENV['DEVICE'] || 'iphone'
+
+        # Xcode 7/iOS 9 - Playback file not found for rotation #837
+        # As of iOS 7 and Xcode 5.1.1, the only part of the playback API that
+        # is being used is the rotation API.  We've incorrectly been using
+        # iPhone recordings for iPad rotations.  The iPhone recordings are
+        # working, so I am not inclined to make any dramatic changes.
+        if device != 'iphone' || device != 'ipad'
+          device = 'iphone'
+        end
 
         major = Calabash::Cucumber::Launcher.launcher.ios_major_version
 


### PR DESCRIPTION
### Motivation

**Xcode 7/iOS 9 - Playback file not found for rotation** #837

Ultimately, this was a result of user error.

The problem is that particular shell defined a `DEVICE` env var as a simulator UDID which caused this line:

```ruby
device = options['DEVICE'] || ENV['DEVICE'] || 'iphone'
```

to incorrectly create the recording name.

Added a guard to force 'phone' or 'ipad' as a recording prefix.