### PR TITLE
Fixing wiki link for updating calabash version

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -1083,7 +1083,7 @@ class Calabash::Cucumber::Launcher
       msgs = [
             'The server version is not compatible with gem version.',
             'Please update your server.',
-            'https://github.com/calabash/calabash-ios/wiki/B1-Updating-your-Calabash-iOS-version',
+            'https://github.com/calabash/calabash-ios/wiki/Updating-your-Calabash-iOS-version',
             "       gem version: '#{gem_version}'",
             "min server version: '#{min_server_version}'",
             "    server version: '#{server_version}'"]

--- a/calabash-cucumber/lib/calabash-cucumber/playback_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/playback_helpers.rb
@@ -75,7 +75,7 @@ module Calabash
           Most likely you have updated your calabash-cucumber client
           but not your server. Please follow closely:
 
-https://github.com/calabash/calabash-ios/wiki/B1-Updating-your-Calabash-iOS-version
+https://github.com/calabash/calabash-ios/wiki/Updating-your-Calabash-iOS-version
 
           If you are running version 0.9.120+ then please report this message as a bug.
 EOF
@@ -194,7 +194,7 @@ EOF
           Most likely you have updated your calabash-cucumber client
           but not your server. Please follow closely:
 
-https://github.com/calabash/calabash-ios/wiki/B1-Updating-your-Calabash-iOS-version
+https://github.com/calabash/calabash-ios/wiki/Updating-your-Calabash-iOS-version
 
           If you are running version 0.9.120+ then please report this message as a bug.
 EOF


### PR DESCRIPTION
The link to the wiki currently points to:

https://github.com/calabash/calabash-ios/wiki/B1-Updating-your-Calabash-iOS-version

It should be:

https://github.com/calabash/calabash-ios/wiki/Updating-your-Calabash-iOS-version