### PR TITLE
Drop ruby 1.9 support; >= 2.0 is required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_script:
   - script/ci/travis/install-gem-libs.rb
 
 script:
-  # Skip XTC run on all but 2.1.5 to avoid redundant testing. This is just a
+  # Skip XTC run on all but the latest to avoid redundant testing. This is just a
   # smoke test to ensure a job can be validated; the ruby version is immaterial.
-  #- if [[ ( ! -z $XTC_API_TOKEN && ! -z $XTC_USER && `ruby -e 'print RUBY_VERSION'` == '2.1.5' ) ]]; then script/ci/travis/xtc-submit-ci.rb; fi
+  # - if [[ ( ! -z $XTC_API_TOKEN && ! -z $XTC_USER && `ruby -e 'print RUBY_VERSION'` == '2.2.3' ) ]]; then script/ci/travis/xtc-submit-ci.rb; fi
   - script/ci/travis/bundle-install.rb
   - script/ci/travis/install-gem-ci.rb
   - script/ci/travis/rspec-ci.rb
@@ -19,7 +19,8 @@ script:
 
 rvm:
   - 2.0.0
-  - 2.1.5
+  - 2.1.7
+  - 2.2.3
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ script:
   - script/ci/travis/cucumber-ci.rb --tags ~@no_ci
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.5
 

--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
   s.license       = 'EPL-1.0'
 
-  s.required_ruby_version = '>= 1.9'
+  s.required_ruby_version = '>= 2.0'
 
   s.add_dependency('cucumber', '~> 1.3.17')
   s.add_dependency('calabash-common', '~> 0.0.2')


### PR DESCRIPTION
### Motivation

I've made several announcements and we've been announcing on the wiki that we are migrating to 2.0 for 6 months.

Several gems we depend on updated to 2.0 so the time is now.