### PR TITLE
Update backdoor method to handle new LPBackdoorRoute behavior

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/connection_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/connection_helpers.rb
@@ -3,6 +3,8 @@ require 'calabash-cucumber/connection'
 module Calabash
   module Cucumber
 
+    class ResponseError < RuntimeError ; end
+
     # @!visibility private
     module ConnectionHelpers
 
@@ -14,6 +16,51 @@ module Calabash
       # @!visibility private
       def connection
         Calabash::Cucumber::Connection.instance
+      end
+
+      # @!visibility private
+      def response_body_to_hash(body)
+        if body.nil? || body == ""
+          raise ResponseError,
+            "Server replied with an empty response.  Your app has probably crashed"
+        end
+
+        begin
+          hash = JSON.parse(body)
+        rescue TypeError, JSON::ParserError => e
+          raise ResponseError,
+%Q{Could not parse server response '#{body}':
+
+#{e}
+
+This usually means your app has crashed.
+}
+        end
+
+        outcome = hash['outcome']
+
+        case outcome
+          when 'FAILURE'
+            reason = hash['reason']
+            if reason.nil? || reason.empty?
+              hash['reason'] = 'Server provided no reason.'
+            end
+
+            details = hash['details']
+            if details.nil? || details.empty?
+              hash['details'] = 'Server provided no details.'
+            end
+
+          when 'SUCCESS'
+            if !hash.has_key?('results')
+              raise ResponseError, "Server responded with '#{outcome}'" \
+                  "but response #{hash} does not contain 'results' key"
+            end
+          else
+            raise ResponseError, 'Server responded with an invalid outcome:' \
+                "'#{hash['outcome']}'"
+        end
+        hash
       end
 
     end

--- a/calabash-cucumber/spec/lib/connection_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/connection_helpers_spec.rb
@@ -1,0 +1,111 @@
+describe Calabash::Cucumber::ConnectionHelpers do
+
+  let(:world) do
+    Class.new do
+      include Calabash::Cucumber::ConnectionHelpers
+    end.new
+  end
+
+  let(:response_error) { Calabash::Cucumber::ResponseError }
+
+  describe "#response_body_to_hash" do
+    let(:success_body) { "{\"results\":1,\"result\":1,\"outcome\":\"SUCCESS\"}" }
+    let(:failure_hash) do
+      {
+        "outcome" => "FAILURE",
+        "details" => "The sordid details",
+        "reason" => "Just the facts"
+      }
+    end
+
+    let(:failure_body) { JSON.generate(failure_hash) }
+
+    it "SUCCESS" do
+      hash = world.response_body_to_hash(success_body)
+      expect(hash["result"]).to be == 1
+    end
+
+    describe "FAILURE" do
+      it "has reason and details" do
+        hash = world.response_body_to_hash(failure_body)
+
+        expect(hash["reason"]).to be == "Just the facts"
+        expect(hash["details"]).to be == "The sordid details"
+        expect(hash["outcome"]).to be == "FAILURE"
+      end
+
+      it "has no reason" do
+        failure_hash[:reason] = nil
+
+        hash = world.response_body_to_hash(failure_body)
+
+        expect(hash["reason"]).to be == "Server provided no reason."
+        expect(hash["details"]).to be == "The sordid details"
+        expect(hash["outcome"]).to be == "FAILURE"
+      end
+
+      it "hash no details" do
+        failure_hash[:details] = nil
+
+        hash = world.response_body_to_hash(failure_body)
+
+        expect(hash["reason"]).to be == "Just the facts"
+        expect(hash["details"]).to be == "Server provided no details."
+        expect(hash["outcome"]).to be == "FAILURE"
+      end
+    end
+
+    describe "raises errors" do
+      describe "when body is empty" do
+        it "body is nil" do
+          expect do
+            world.response_body_to_hash(nil)
+          end.to raise_error response_error, /Server replied with an empty response/
+        end
+
+        it "body is the empty string" do
+          expect do
+            world.response_body_to_hash("")
+          end.to raise_error response_error, /Server replied with an empty response/
+        end
+      end
+
+      describe "when JSON jcannot parse body" do
+        it "TypeError" do
+          expect(JSON).to receive(:parse).with(success_body).and_raise TypeError
+
+          expect do
+            world.response_body_to_hash(success_body)
+          end.to raise_error response_error, /Could not parse server response/
+        end
+
+        it "JSON::ParserError" do
+          expect(JSON).to receive(:parse).with(success_body).and_raise JSON::ParserError
+
+          expect do
+            world.response_body_to_hash(success_body)
+          end.to raise_error response_error, /Could not parse server response/
+        end
+      end
+
+      it "SUCCESS response has no results key" do
+        hash = { "outcome" => "SUCCESS" }
+        expect(JSON).to receive(:parse).with(success_body).and_return(hash)
+
+        expect do
+          world.response_body_to_hash(success_body)
+        end.to raise_error response_error, /does not contain 'results' key/
+      end
+
+      it "response has invalid outcome" do
+        hash = { "outcome" => "an invalid outcome" }
+        expect(JSON).to receive(:parse).with(success_body).and_return(hash)
+
+        expect do
+          world.response_body_to_hash(success_body)
+        end.to raise_error response_error, /Server responded with an invalid outcome/
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
### Motivation

The capabilities of the LPBackdoorRoute have been expanded.

* **Expand backdoor route to handle arbitrary method signatures** [#220](https://github.com/calabash/calabash-ios-server/pull/220)

In practice, this means that most _common_ return types can be handled:

```ruby
> backdoor("methodThatReturnsVoid")
"<VOID>"  # matches Calabash Android

> backdoor("methodThatReturnsBOOL_YES")
true

> backdoor("methodThatReturnsBOOL_NO")
false

> backdoor("methodThatReturnsCGFloat")
56.46

> backdoor("methodThatReturnsPoint")
{"X" => 10, "Y" => 60}

> backdoor("methodThatReturnsCGRect")
{"X" => 10, "Y" => 60, "Height" => 44, "Width" => 60}
```

Backdoor methods can now have multiple arguments and the argument types can be primitives.  Again _common_ types are support.

```ruby
> backdoor("arrayWithString:NSUInteger:CGFloat:", "a", 1, 0.314)
["a", 1, 0.314]
```

Additionally, you can pass two special tokens as arguments: `"__self__"` and `"__nil__"`.

Examples will be provided once this PR is merged.
