### PR TITLE
send_app_to_background uses "suspend" server route

### DIFF
--- a/calabash-cucumber/spec/lib/core_spec.rb
+++ b/calabash-cucumber/spec/lib/core_spec.rb
@@ -192,4 +192,81 @@ describe Calabash::Cucumber::Core do
       expect(actual).to be == hash["results"]
     end
   end
+
+  describe "send_app_to_background" do
+    describe "raises errors" do
+
+      it "raises argument error when seconds < 1.0" do
+        expect do
+          world.send_app_to_background(0.5)
+        end.to raise_error ArgumentError, /must be >= 1.0/
+      end
+
+      it "http call fails" do
+        class MyHTTPError < RuntimeError ; end
+        expect(world).to receive(:http).and_raise MyHTTPError, "My error"
+
+        expect do
+          world.send_app_to_background(1.0)
+        end.to raise_error RuntimeError, /My error/
+      end
+
+      it "parsing the response fails" do
+        expect(world).to receive(:http).and_return ""
+        class MyJSONError < RuntimeError ; end
+        expect(world).to receive(:response_body_to_hash).with("").and_raise MyJSONError, "JSON error"
+
+        expect do
+          world.send_app_to_background(1.0)
+        end.to raise_error RuntimeError, /JSON error/
+      end
+
+      it "outcome is FAILURE" do
+        hash = {
+          "outcome" => "FAILURE",
+          "reason" => "This is unreasonable",
+          "details" => "The sordid details"
+        }
+
+        expect(world).to receive(:http).and_return ""
+        expect(world).to receive(:response_body_to_hash).with("").and_return(hash)
+
+        expect do
+          world.send_app_to_background(1.0)
+        end.to raise_error RuntimeError, /Could not send app to background:/
+      end
+    end
+
+    let(:args) { {:method => :post, :path => "suspend"} }
+    let(:parameters) { {:duration => 1.0 } }
+
+    it "sets the http parameters correctly" do
+      parameters[:duration] = 5.0
+
+      hash = {
+        "outcome" => "SUCCESS",
+        "results" => 1
+      }
+
+      expect(world).to receive(:http).with(args, parameters).and_return ""
+      expect(world).to receive(:response_body_to_hash).with("").and_return(hash)
+
+      actual = world.send_app_to_background(5.0)
+      expect(actual).to be == hash["results"]
+    end
+
+    it "returns the results key" do
+
+      hash = {
+        "outcome" => "SUCCESS",
+        "results" => 1
+      }
+
+      expect(world).to receive(:http).with(args, parameters).and_return ""
+      expect(world).to receive(:response_body_to_hash).with("").and_return hash
+
+      actual = world.send_app_to_background(1.0)
+      expect(actual).to be == hash["results"]
+    end
+  end
 end


### PR DESCRIPTION
### Motivation

Starting in iOS 9, the UIAutomation `deactivateAppForDuration` is broken.

Fixes: **Xcode 7/iOS 9 send_app_to_background is broken** #836

I decide _not_ to branch on iOS version for this.  Instead, we'll use the LPSuspendApp route.

Thanks to everyone who contributed to this fix.