### PR TITLE
Gem: allow any version of cucumber

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency('cucumber', '~> 1.3.17')
+  s.add_dependency("cucumber")
   s.add_dependency('calabash-common', '~> 0.0.2')
   # Avoid 1.0.5 release; has an errant 'binding.pry'.
   s.add_dependency('edn', '>= 1.0.6', '< 2.0')


### PR DESCRIPTION
### Motivation

There is no reason _not_ to allow Cucumber 2.0.