### PR TITLE
Docs: minor versions can contain breaking changes

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -2,7 +2,19 @@
 
 Calabash tries very hard to comply with Semantic Versioning [1] rules.
 
-However, the semantic versioning spec is incompatible with RubyGem's patterns for pre-release gems.
+There are two problems:
+
+1. Calabash 0.x cannot update the major version.  This means that _minor_ releases must be allowed introduce breaking changes.
+2. The Semantic versioning spec is incompatible with RubyGem's patterns for pre-release gems.
+
+
+### Minor Versions
+
+For marketing and technical reasons, we cannot bump the major version of this gem.  When we bump the minor version of the repo, _expect non-backward compatible changes._  We go to great lengths to limit this breaking changes, but sometimes it cannot be helped.  We will document when these changes occur.
+
+### Pre-releases
+
+The semantic versioning spec is incompatible with RubyGem's patterns for pre-release gems.
 
 > "But returning to the practical: No release version of SemVer is compatible with Rubygems." - _David Kellum_ [2]
 


### PR DESCRIPTION
### Motivation

We cannot release Calabash 1.0.  However, we must be able to introduce breaking changes.

The docs now formalize our existing policy of introducing breaking changes in minor releases.

