### PR TITLE
Fix the "reset app sandbox between Scenarios" behavior

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -471,33 +471,26 @@ Remove direct calls to reset_app_sandbox.
     end
   end
 
-  # Launches your app on the connected device or simulator. Stops the app if it is already running.
-  # `relaunch` does a lot of error detection and handling to reliably start the app and test. Instruments (particularly the cli)
-  # has stability issues which we workaround by restarting the simulator process and checking that UIAutomation is correctly
-  # attaching.
+  # Launches your app on the connected device or simulator.
   #
-  # Takes optional args to specify details of the launch (e.g. device or simulator, sdk version, target device, launch method...).
-  # @note an important part of relaunch behavior is controlled by environment variables, specified below
+  # `relaunch` does a lot of error detection and handling to reliably start the
+  # app and test. Instruments (particularly the cli) has stability issues which
+  # we workaround by restarting the simulator process and checking that
+  # UIAutomation is correctly attaching to your application.
   #
-  # The two most important environment variables are `DEVICE_TARGET` and `APP_BUNDLE_PATH`.
+  # Use the `args` parameter to to control:
   #
-  # - `DEVICE_TARGET` controls which device you're running on. To see the options run: `instruments -s devices`.
-  #   In addition you can specify `DEVICE_TARGET=device` to run on a (unique) usb-connected device.
-  # - `APP_BUNDLE_PATH` controls which `.app` bundle to launch in simulator (don't use for on-device testing, instead use `BUNDLE_ID`).
-  # - `BUNDLE_ID` used with `DEVICE_TARGET=device` to specify which app to launch on device
-  # - `DEBUG` - set to "1" to obtain debug info (typically used to debug launching, UIAutomation and other issues)
-  # - `DEBUG_HTTP` - set to "1" to show raw HTTP traffic
+  # * `:app` - which app to launch.
+  # * `:device_target` - simulator or device to target.
+  # * `:reset_app_sandbox - reset he app's data (sandbox) before testing
   #
+  # and many other behaviors.
   #
-  # @example Launching on iPad simulator with DEBUG settings
-  #   DEBUG_HTTP=1 DEVICE_TARGET="iPad - Simulator - iOS 7.1" DEBUG=1 APP_BUNDLE_PATH=FieldServiceiOS.app bundle exec calabash-ios console
-  # @param {Hash} args optional args to specify details of the launch (e.g. device or simulator, sdk version,
-  #   target device, launch method...).
-  # @option args {String} :app (detect the location of the bundle from project settings) app bundle path
-  # @option args {String} :bundle_id if launching on device, specify this or env `BUNDLE_ID` to be the bundle identifier
-  #   of the application to launch
-  # @option args {Hash} :privacy_settings preset privacy settings for the, e.g., `{:photos => {:allow => true}}`.
-  #    See {KNOWN_PRIVACY_SETTINGS}
+  # Many of these behaviors can be be controlled by environment variables. The
+  # most important environment variables are `APP`, `DEVICE_TARGET`, and
+  # `DEVICE_ENDPOINT`.
+  #
+  # @param {Hash} args optional arguments to control the how the app is launched
   def relaunch(args={})
     #TODO stopping is currently broken, but this works anyway because instruments stop the process before relaunching
     RunLoop.stop(run_loop) if run_loop

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -492,8 +492,6 @@ Remove direct calls to reset_app_sandbox.
   #
   # @param {Hash} args optional arguments to control the how the app is launched
   def relaunch(args={})
-    #TODO stopping is currently broken, but this works anyway because instruments stop the process before relaunching
-    RunLoop.stop(run_loop) if run_loop
 
     # @todo Don't overwrite the _args_ parameter!
     args = default_launch_args.merge(args)

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -279,44 +279,20 @@ class Calabash::Cucumber::Launcher
     sim_control = opts.fetch(:sim_control, RunLoop::SimControl.new)
     xcode = sim_control.xcode
 
-    if sim_control.xcode_version_gte_6?
-      default_sim = RunLoop::Core.default_simulator(xcode)
-      name_or_udid = merged_opts[:udid] || ENV['DEVICE_TARGET'] || default_sim
+    default_sim = RunLoop::Core.default_simulator(xcode)
+    name_or_udid = merged_opts[:udid] || ENV['DEVICE_TARGET'] || default_sim
 
-      target_simulator = sim_control.simulators.find do |sim|
-        [name_or_udid == sim.instruments_identifier(xcode),
-         name_or_udid == sim.udid,
-         name_or_udid == sim.name].any?
-      end
-
-      if target_simulator.nil?
-        raise "Could not find a simulator that matches '#{name_or_udid}'"
-      end
-
-      sim_control.reset_sim_content_and_settings({:sim_udid => target_simulator.udid})
-    else
-      sdk ||= merged_opts[:sdk] || sdk_version || self.simulator_launcher.sdk_detector.latest_sdk_version
-      path ||= merged_opts[:path] || self.simulator_launcher.app_bundle_or_raise(app_path)
-
-      app = File.basename(path)
-
-      directories_for_sdk_prefix(sdk).each do |sdk_dir|
-        app_dir = File.expand_path("#{sdk_dir}/Applications")
-        next unless File.exists?(app_dir)
-
-        bundle = `find "#{app_dir}" -type d -depth 2 -name "#{app}" | head -n 1`
-
-        next if bundle.empty? # Assuming we're already clean
-
-        if debug_logging?
-          puts "Reset app state for #{bundle}"
-        end
-        sandbox = File.dirname(bundle)
-        ['Library', 'Documents', 'tmp'].each do |content_dir|
-          FileUtils.rm_rf(File.join(sandbox, content_dir))
-        end
-      end
+    target_simulator = sim_control.simulators.find do |sim|
+      [name_or_udid == sim.instruments_identifier(xcode),
+       name_or_udid == sim.udid,
+       name_or_udid == sim.name].any?
     end
+
+    if target_simulator.nil?
+      raise "Could not find a simulator that matches '#{name_or_udid}'"
+    end
+
+    sim_control.reset_sim_content_and_settings({:sim_udid => target_simulator.udid})
   end
 
   # Erases the contents and setting for every available simulator.


### PR DESCRIPTION
### Motivation

Fixes **RESET_APP_BETWEEN_SCENARIOS is still resetting the simulator not just the app sandbox** #878

This also resolves the problem of "double launching" that users can experience when using resetting applications.

Resetting has consistently been one of the problematic features of Calabash iOS.  This PR is a first step toward applying the lessons learned from Calabash 2.0.

This PR deprecates the `reset_app_sandbox` method.  The method has been turned into a no-op.

Backward compatibility is achieved by passing the :reset option to run-loop; something that is already happening.
