### PR TITLE
Track user preferences in ~/.calabash

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber.rb
+++ b/calabash-cucumber/lib/calabash-cucumber.rb
@@ -1,4 +1,5 @@
 require "calabash-cucumber/dot_dir"
+require "calabash-cucumber/cache/cache.rb"
 require 'calabash-cucumber/core'
 require 'calabash-cucumber/tests_helpers'
 require 'calabash-cucumber/keyboard_helpers'

--- a/calabash-cucumber/lib/calabash-cucumber.rb
+++ b/calabash-cucumber/lib/calabash-cucumber.rb
@@ -1,5 +1,6 @@
 require "calabash-cucumber/dot_dir"
 require "calabash-cucumber/cache/cache.rb"
+require "calabash-cucumber/cache/preferences.rb"
 require 'calabash-cucumber/core'
 require 'calabash-cucumber/tests_helpers'
 require 'calabash-cucumber/keyboard_helpers'

--- a/calabash-cucumber/lib/calabash-cucumber/cache/cache.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/cache/cache.rb
@@ -1,0 +1,91 @@
+module Calabash
+  module Cucumber
+
+    # @!visibility private
+    # A class for managing an on-disk cache.
+    class Cache
+
+      require 'fileutils'
+
+      # Creates a new cache backed by file at `path`.
+      #
+      # @param [String] path The file to store the cache. If this
+      #  path does not exist, it and any subdirectories will be created
+      #  when the first call to `write` is made.
+      def initialize(path)
+        @path = path
+      end
+
+      # @!visibility private
+      def to_s
+        "Cache: #{path}"
+      end
+
+      # @!visibility private
+      #
+      # Clears the current cache and writes the `default_cache`.
+      def clear
+        write(default_cache)
+      end
+
+      # Reads the current cache.
+      #
+      # If the cache does not exist it will be created.
+      #
+      # @return [Hash] A hash representation of the cache on disk.
+      def read
+        if File.exist?(path)
+          File.open(path, "r:UTF-8") do |file|
+            Marshal.load(file)
+          end
+        else
+          write(default_cache)
+        end
+      end
+
+      # @!visibility private
+      #
+      # If no cache exists or the cache is cleared, this will be the default
+      # hash that is written.
+      def default_cache
+        {}
+      end
+
+      private
+
+      attr_reader :path
+
+      # @!visibility private
+      #
+      # Writes `hash` as a serial object.  The existing data is overwritten.
+      #
+      # @param [Hash] hash The hash to write.
+      # @raise [ArgumentError] The `hash` parameter must not be nil and it must
+      #  be a Hash.
+      # @raise [TypeError] If the hash contains objects that cannot be written
+      #  by Marshal.dump.
+      #
+      # @return [Hash] Returns the `hash` argument.
+      def write(hash)
+        if hash.nil?
+          raise ArgumentError, 'Expected the hash parameter to be non-nil'
+        end
+
+        unless hash.is_a?(Hash)
+          raise ArgumentError, "Expected #{hash} to a Hash, but it is a #{hash.class}"
+        end
+
+        directory = File.dirname(path)
+        unless File.exist?(directory)
+          FileUtils.mkdir_p(directory)
+        end
+
+        File.open(path, "w:UTF-8") do |file|
+          Marshal.dump(hash, file)
+        end
+        hash
+      end
+    end
+  end
+end
+

--- a/calabash-cucumber/lib/calabash-cucumber/cache/preferences.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/cache/preferences.rb
@@ -1,0 +1,21 @@
+module Calabash
+  module Cucumber
+    class Preferences < Calabash::Cucumber::Cache
+
+      private
+
+      # @!visibility private
+      PATH = File.join(Calabash::Cucumber::DotDir.directory,
+                       "preferences", "preferences.hash")
+
+      # @!visibility private
+      @@preferences = nil
+
+      # @!visibility private
+      def self.preferences
+        @@preferences ||= Calabash::Cucumber::Preferences.new(PATH)
+      end
+    end
+  end
+end
+

--- a/calabash-cucumber/lib/calabash-cucumber/dot_dir.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/dot_dir.rb
@@ -1,13 +1,17 @@
-# A module for managing the ~/.calabash directory.
 module Calabash
-  module DotDir
-    def self.directory
-      home = RunLoop::Environment.user_home_directory
-      dir = File.join(home, ".calabash")
-      if !File.exist?(dir)
-        FileUtils.mkdir_p(dir)
+  module Cucumber
+    # A module for managing the ~/.calabash directory.
+    module DotDir
+      require "run_loop"
+
+      def self.directory
+        home = RunLoop::Environment.user_home_directory
+        dir = File.join(home, ".calabash")
+        if !File.exist?(dir)
+          FileUtils.mkdir_p(dir)
+        end
+        dir
       end
-      dir
     end
   end
 end

--- a/calabash-cucumber/spec/lib/cache/cache_spec.rb
+++ b/calabash-cucumber/spec/lib/cache/cache_spec.rb
@@ -1,0 +1,87 @@
+describe Calabash::Cucumber::Cache do
+
+  let(:tmp_dir) { Dir.mktmpdir }
+  let(:path) { File.join(tmp_dir, "cache.file") }
+  let(:cache) { Calabash::Cucumber::Cache.new(path) }
+  let(:default) { { a: 1, b:2 } }
+
+  before do
+    allow(cache).to receive(:default_cache).and_return(default)
+  end
+
+  it ".new" do
+    expect(cache.instance_variable_get(:@path)).to be == path
+  end
+
+  it "#clear" do
+    expect(cache).to receive(:write).with(default).and_return(default)
+
+    expect(cache.clear).to be == default
+  end
+
+  it "#to_s" do
+    puts cache
+  end
+
+  describe "#read" do
+    it "reads cache if it exists" do
+      FileUtils.touch(path)
+      expect(Marshal).to receive(:load).and_return({})
+
+      expect(cache.read).to be == {}
+    end
+
+    it "creates a new cache if one does not exist" do
+      FileUtils.rm_rf(path)
+      expect(cache).to receive(:write).with(default).and_call_original
+
+      expect(cache.read).to be == default
+    end
+  end
+
+  # private
+
+  it "#path" do
+    expect(cache.send(:path)).to be == path
+  end
+
+  describe "#write" do
+    describe "raises error when" do
+      it "is passed nil" do
+        expect do
+          cache.send(:write, nil)
+        end.to raise_error ArgumentError
+      end
+
+      it "is passed a non-Hash object" do
+        expect do
+          cache.send(:write, [])
+        end.to raise_error ArgumentError
+      end
+    end
+
+    it "overwrites the existing cache" do
+      File.open(path, "w") { |file| Marshal.dump({a: :a}, file) }
+      old_sha = Digest::SHA1.hexdigest(path)
+      expect(cache.send(:write, {b: :b})).to be_truthy
+      new_sha = Digest::SHA1.hexdigest(path)
+
+      expect(new_sha).not_to be old_sha
+    end
+
+    it "returns the hash argument" do
+      hash = {a: :a}
+      expect(cache.send(:write, hash)).to be(hash)
+    end
+
+    it "creates a new cache if one does not exist" do
+      FileUtils.rm_rf(path)
+      FileUtils.rm_rf(tmp_dir)
+      expect(FileUtils).to receive(:mkdir_p).with(tmp_dir).and_call_original
+
+      expect(cache.send(:write, {a: :a})).to be_truthy
+      expect(File.exist?(path)).to be == true
+    end
+  end
+end
+

--- a/calabash-cucumber/spec/lib/cache/preferences_spec.rb
+++ b/calabash-cucumber/spec/lib/cache/preferences_spec.rb
@@ -1,0 +1,15 @@
+describe Calabash::Cucumber::Preferences do
+
+  before do
+    path = Dir.mktmpdir
+    allow(Calabash::Cucumber::DotDir).to receive(:directory).and_return(path)
+  end
+
+  it ".preferences" do
+    prefs = Calabash::Cucumber::Preferences.send(:preferences)
+
+    expect(prefs).to be_a_kind_of(Calabash::Cucumber::Preferences)
+    expect(Calabash::Cucumber::Preferences.class_variable_get(:@@preferences)).to be == prefs
+  end
+end
+

--- a/calabash-cucumber/spec/lib/dot_dir_spec.rb
+++ b/calabash-cucumber/spec/lib/dot_dir_spec.rb
@@ -1,6 +1,6 @@
-describe Calabash::DotDir do
+describe Calabash::Cucumber::DotDir do
 
-  let(:home_dir) { "./tmp/dot-calaash-examples" }
+  let(:home_dir) { "./tmp/dot-calabash-examples" }
   let(:dot_dir) { File.join(home_dir, ".calabash") }
 
   before do
@@ -9,7 +9,7 @@ describe Calabash::DotDir do
   end
 
   it ".directory" do
-    path = Calabash::DotDir.directory
+    path = Calabash::Cucumber::DotDir.directory
 
     expect(File.exist?(path)).to be_truthy
   end


### PR DESCRIPTION
### Motivation

Users should be able to opt in and opt out of usage tracking.  We'll do this using a preferences file.

Progress on: **Collect information about Calabash sessions** #908