### PR TITLE
Add usage tracking keys to preferences

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
@@ -40,10 +40,19 @@ module Calabash
       def defaults
         {
           :version => VERSION,
-          :usage_tracking =>
-          {
 
-          }
+          # Controls what information we are allowed to track.
+          #
+          # If this is "none", then no information is sent.
+          #
+          # Allowed values:
+          #
+          # 1. "none"
+          # 2. "events"  Events only.
+          # 3. "system_info"  Events and system info
+          #
+          # The value must be string and it must respond nicely to .to_sym
+          :usage_tracking => "system_info"
         }
       end
 

--- a/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
@@ -25,6 +25,17 @@ module Calabash
 
         preferences[:usage_tracking]
       end
+
+      # !@visibility private
+      def usage_tracking=(value)
+        if !valid_user_tracking_value?(value)
+          raise ArgumentError,
+            "Expected '#{value}' to be one of #{VALID_USAGE_TRACKING_VALUES.join(", ")}"
+        end
+
+        preferences = read
+        preferences[:usage_tracking] = value
+        write(preferences)
       end
 
       private
@@ -35,15 +46,6 @@ module Calabash
       end
 
       # @!visibility private
-      def ensure_valid_user_tracking_value?(value)
-        unless valid_user_tracking_value?(value)
-          log_defaults_reset
-          preferences[:usage_tracking] = defaults[:usage_tracking]
-          write(preferences)
-        end
-      end
-
-      # @!visibility private
       #
       # The preferences version
       VERSION = "1.0"
@@ -51,6 +53,8 @@ module Calabash
       # @!visibility private
       #
       # Ordered by permissiveness left to right ascending.
+      #
+      # "system_info" implies that "events" are also allowed.
       VALID_USAGE_TRACKING_VALUES = ["none", "events", "system_info"]
 
       # @!visibility private
@@ -73,18 +77,6 @@ module Calabash
       def defaults
         {
           :version => VERSION,
-
-          # Controls what information we are allowed to track.
-          #
-          # If this is "none", then no information is sent.
-          #
-          # Allowed values:
-          #
-          # 1. "none"
-          # 2. "events"  Events only.
-          # 3. "system_info"  Events and system info
-          #
-          # The value must be string and it must respond nicely to .to_sym
           :usage_tracking => "system_info"
         }
       end

--- a/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
@@ -13,12 +13,45 @@ module Calabash
         @path = File.join(dot_dir, "preferences", "preferences.json")
       end
 
+      # !@visibility private
+      def usage_tracking
+        preferences = read
+
+        unless valid_user_tracking_value?(preferences[:usage_tracking])
+          log_defaults_reset
+          preferences[:usage_tracking] = defaults[:usage_tracking]
+          write(preferences)
+        end
+
+        preferences[:usage_tracking]
+      end
+      end
+
       private
+
+      # @!visibility private
+      def valid_user_tracking_value?(value)
+        VALID_USAGE_TRACKING_VALUES.include?(value)
+      end
+
+      # @!visibility private
+      def ensure_valid_user_tracking_value?(value)
+        unless valid_user_tracking_value?(value)
+          log_defaults_reset
+          preferences[:usage_tracking] = defaults[:usage_tracking]
+          write(preferences)
+        end
+      end
 
       # @!visibility private
       #
       # The preferences version
       VERSION = "1.0"
+
+      # @!visibility private
+      #
+      # Ordered by permissiveness left to right ascending.
+      VALID_USAGE_TRACKING_VALUES = ["none", "events", "system_info"]
 
       # @!visibility private
       def version

--- a/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
@@ -39,11 +39,40 @@ module Calabash
         write(preferences)
       end
 
+      # !@visibility private
+      def user_id
+        preferences = read
+
+        unless valid_user_id?(preferences[:user_id])
+          preferences[:user_id] = SecureRandom.uuid
+          write(preferences)
+        end
+
+        preferences[:user_id]
+      end
+
+      # !@visibility private
+      def user_id=(value)
+        if !valid_user_id?(value)
+          raise ArgumentError,
+            "Expected '#{value}' to not be nil and not an empty string"
+        end
+
+        preferences = read
+        preferences[:user_id] = value
+        write(preferences)
+      end
+
       private
 
       # @!visibility private
       def valid_user_tracking_value?(value)
         VALID_USAGE_TRACKING_VALUES.include?(value)
+      end
+
+      # @!visibility private
+      def valid_user_id?(value)
+        !value.nil? && value != "" && value.is_a?(String)
       end
 
       # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
@@ -2,6 +2,7 @@ module Calabash
   module Cucumber
 
     require "fileutils"
+    require "securerandom"
 
     # Users preferences persisted across runs:
     #
@@ -77,7 +78,8 @@ module Calabash
       def defaults
         {
           :version => VERSION,
-          :usage_tracking => "system_info"
+          :usage_tracking => "system_info",
+          :user_id => SecureRandom.uuid
         }
       end
 

--- a/calabash-cucumber/spec/lib/store/preferences_spec.rb
+++ b/calabash-cucumber/spec/lib/store/preferences_spec.rb
@@ -38,6 +38,24 @@ describe Calabash::Cucumber::Preferences do
     end
   end
 
+  describe "#usage_tracking=" do
+    it "raises an error if value is invalid" do
+      expect do
+        store.usage_tracking = "invalid"
+      end.to raise_error ArgumentError, /Expected 'invalid' to be one of/
+    end
+
+    it "persists the change to disk" do
+      old = store.usage_tracking
+      expect(old).to be == store.send(:defaults)[:usage_tracking]
+      expect(old).not_to be == "none"
+
+      store.usage_tracking = "none"
+
+      expect(store.usage_tracking).to be == "none"
+    end
+  end
+
   describe "#valid_user_tracking_value?" do
     it "false if not an allowed value" do
       expect(store.send(:valid_user_tracking_value?, nil)).to be_falsey

--- a/calabash-cucumber/spec/lib/store/preferences_spec.rb
+++ b/calabash-cucumber/spec/lib/store/preferences_spec.rb
@@ -28,6 +28,7 @@ describe Calabash::Cucumber::Preferences do
     end
 
     it "returns default value and resets the store if invalid value" do
+      allow(SecureRandom).to receive(:uuid).and_return("uuid")
       expect(store).to receive(:valid_user_tracking_value?).and_return false
 
       defaults = store.send(:defaults)
@@ -149,6 +150,7 @@ describe Calabash::Cucumber::Preferences do
 
   describe "#read" do
     it "calls write with defaults if file does not exist" do
+      allow(SecureRandom).to receive(:uuid).and_return("uuid")
       expect(File).to receive(:exist?).with(File.dirname(path)).and_return false
       expect(File).to receive(:exist?).with(path).and_return false
       expect(store).to receive(:write).and_call_original
@@ -171,6 +173,8 @@ describe Calabash::Cucumber::Preferences do
 
   describe "#parse_json" do
     it "can always parse JSON generated from defaults" do
+      allow(SecureRandom).to receive(:uuid).and_return("uuid")
+
       string = JSON.pretty_generate(store.send(:defaults))
 
       expect(store).not_to receive(:write_to_log)

--- a/calabash-cucumber/spec/lib/store/preferences_spec.rb
+++ b/calabash-cucumber/spec/lib/store/preferences_spec.rb
@@ -20,6 +20,37 @@ describe Calabash::Cucumber::Preferences do
     expect(store.send(:version)).to be_truthy
   end
 
+  describe "#usage_tracking" do
+    it "returns valid value as a symbol" do
+      expect(store).to receive(:read).and_return({:usage_tracking => "none"})
+
+      expect(store.usage_tracking).to be == "none"
+    end
+
+    it "returns default value and resets the store if invalid value" do
+      expect(store).to receive(:valid_user_tracking_value?).and_return false
+
+      defaults = store.send(:defaults)
+      expect(store).to receive(:log_defaults_reset).and_call_original
+      expect(store).to receive(:write).at_least(:once).with(defaults).and_call_original
+
+      expect(store.usage_tracking).to be == defaults[:usage_tracking]
+    end
+  end
+
+  describe "#valid_user_tracking_value?" do
+    it "false if not an allowed value" do
+      expect(store.send(:valid_user_tracking_value?, nil)).to be_falsey
+      expect(store.send(:valid_user_tracking_value?, "")).to be_falsey
+      expect(store.send(:valid_user_tracking_value?, "unknown")).to be_falsey
+    end
+
+    it "true if an allowed value" do
+      expect(store.send(:valid_user_tracking_value?, "none")).to be_truthy
+      expect(store.send(:valid_user_tracking_value?, "events")).to be_truthy
+    end
+  end
+
   describe "#write" do
     describe "raises error when" do
       it "is passed nil" do


### PR DESCRIPTION
### Motivation

Progress on **Collect information about Calabash sessions** #908

Preferences stores usage tracking settings under the `:usage_tracking` key.  The valid values for this key are:

* "none" Track nothing
* "events" Track only events
* "system_info" Track events and include system information.

"system_info" is the default value.

If were were to add a new valid value, say "ip", then "ip" would allow send events, system_info, and the IP address of the user.  I believe this good enough for a first pass at this problem.

Preferences stores a `:user_id` key.  Anything but `nil` and `""` is allowed.  We might want to restrict this to an email address later on.  The default value is a `SecureRandom.uuid`.