### PR TITLE
Use UIAutomation JavaScript to touch keyboard Delete key

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -323,7 +323,12 @@ module Calabash
             #           on numeric keyboards, it is actually a button on the
             #           keyboard and not a key
             if code.eql?(UIA_SUPPORTED_CHARS['Delete'])
-              uia("uia.keyboard().elements().firstWithName('Delete').tap()")
+              js_tap_delete = "(function() {"\
+                  "var deleteElement = uia.keyboard().elements().firstWithName('Delete');"\
+                  "deleteElement = deleteElement.isValid() ? deleteElement : uia.keyboard().elements().firstWithName('delete');"\
+                  "deleteElement.tap();"\
+                "})();"
+              uia(js_tap_delete)
             else
               uia_type_string_raw(code)
             end


### PR DESCRIPTION
### Motivation

In some cases `uia.keyboard().elements().firstWithName('Delete')` will return `UIAElementNil`.  In those instances using `uia.keyboard().elements().firstWithName('delete')` instead (with "delete" in lowercase) has worked for me, I've tested in iOS 9.1 and 8.4 simulators and devices.

Resolves **keyboard_enter_char 'Delete' is failing on iOS 9.1 Simulators** #913