### PR TITLE
irb interface for disabling/enabling usage tracking

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
@@ -14,6 +14,15 @@ module Calabash
         @path = File.join(dot_dir, "preferences", "preferences.json")
       end
 
+      def to_s
+        puts "Preferences:"
+        ap read
+      end
+
+      def inspect
+        to_s
+      end
+
       # !@visibility private
       def usage_tracking
         preferences = read

--- a/calabash-cucumber/scripts/.irbrc
+++ b/calabash-cucumber/scripts/.irbrc
@@ -47,7 +47,7 @@ end
 require "calabash-cucumber"
 
 def preferences
-  @preferences ||= Calabash::Cucumber::Preferences.new
+  Calabash::Cucumber::Preferences.new
 end
 
 def disable_usage_tracking

--- a/calabash-cucumber/scripts/.irbrc
+++ b/calabash-cucumber/scripts/.irbrc
@@ -27,10 +27,7 @@ ARGV.concat [ '--readline',
               '--prompt-mode',
               'simple']
 
-# 25 entries in the list
 IRB.conf[:SAVE_HISTORY] = 50
-
-# Store results in home directory with specified file name
 IRB.conf[:HISTORY_FILE] = '.irb-history'
 
 require 'calabash-cucumber/operations'
@@ -38,7 +35,6 @@ require 'calabash-cucumber/operations'
 # legacy support - module was deprecated 0.9.169
 # and replaced with simulator_launcher
 require 'calabash-cucumber/launch/simulator_helper'
-
 require 'calabash-cucumber/launch/simulator_launcher'
 SIM=Calabash::Cucumber::SimulatorLauncher.new()
 
@@ -47,3 +43,22 @@ extend Calabash::Cucumber::Operations
 def embed(x,y=nil,z=nil)
   puts "Screenshot at #{x}"
 end
+
+require "calabash-cucumber"
+
+def preferences
+  @preferences ||= Calabash::Cucumber::Preferences.new
+end
+
+def disable_usage_tracking
+  preferences.usage_tracking = "none"
+  puts "Calabash will not collect usage information."
+  "none"
+end
+
+def enable_usage_tracking(level="system_info")
+  preferences.usage_tracking = level
+  puts "Calabash will collect statistics using the '#{level}' rule."
+  level
+end
+


### PR DESCRIPTION
### Motivation

Progress on **Collect information about Calabash sessions** #908

```ruby
$ IRBRC=scripts/.irbrc be irb
> disable_usage_tracking
Calabash will not collect usage information.
"none"

> enable_usage_tracking
Calabash will collect statistics based on system_info
"system_info"

> enable_usage_tracking("events")
Calabash will collect statistics based on events
"events"

> enable_usage_tracking("invalid")
ArgumentError: Expected 'invalid' to be one of none, events, system_info
        from /Users/moody/git/calabash/calabash-ios/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb:42:in `usage_tracking='
        from scripts/.irbrc:60:in `enable_usage_tracking'
        from (irb):3

> preferences
Preferences:
{
           :version => "1.0",
    :usage_tracking => "system_info",
           :user_id => "1320096c-b3f7-496e-995c-091e639f5d28"
}
```