### PR TITLE
Tracker: requires are needed for cucumber loading

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
@@ -8,6 +8,7 @@ module Calabash
     #
     # ~/.calabash/preferences/preferences.json
     class Preferences
+      require "calabash-cucumber/dot_dir"
 
       def initialize
         dot_dir = Calabash::Cucumber::DotDir.directory

--- a/calabash-cucumber/lib/calabash-cucumber/usage_tracker.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/usage_tracker.rb
@@ -1,6 +1,7 @@
 module Calabash
   module Cucumber
     class UsageTracker
+      require "calabash-cucumber/store/preferences"
 
       require "httpclient"
       require "run_loop"


### PR DESCRIPTION
### Motivation

My PR of shame. 

In cucumber environments, the usage tracker and preferences classes raise errors because of missing requires.

This solves the immediate problem; I visually confirmed that events are hitting the relay server.  Subsequent pull requests will add logging and testing.