### PR TITLE
Tracker: catch errors and log them to a file

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/logging.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/logging.rb
@@ -38,10 +38,23 @@ module Calabash
     def self.log_to_file(message)
       timestamp = self.timestamp
 
-      File.open(self.calabash_log_file, "a:UTF-8") do |file|
-        message.split($-0).each do |line|
-          file.write("#{timestamp} #{line}#{$-0}")
+      begin
+        File.open(self.calabash_log_file, "a:UTF-8") do |file|
+          message.split($-0).each do |line|
+            file.write("#{timestamp} #{line}#{$-0}")
+          end
         end
+      rescue => e
+        message =
+%Q{Could not write:
+
+#{message}
+
+to calabash.log because:
+
+#{e}
+}
+        self.log_debug(message)
       end
     end
 

--- a/calabash-cucumber/lib/calabash-cucumber/logging.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/logging.rb
@@ -1,6 +1,8 @@
 module Calabash
   module Cucumber
+    require "fileutils"
     require "run_loop"
+    require "calabash-cucumber/dot_dir"
 
     # These methods are not part of the API.
     #
@@ -30,6 +32,17 @@ module Calabash
     # red
     def self.log_error(msg)
       puts self.red("ERROR: #{msg}") if msg
+    end
+
+    # !@visibility private
+    def self.log_to_file(message)
+      timestamp = self.timestamp
+
+      File.open(self.calabash_log_file, "a:UTF-8") do |file|
+        message.split($-0).each do |line|
+          file.write("#{timestamp} #{line}#{$-0}")
+        end
+      end
     end
 
     private
@@ -73,6 +86,27 @@ module Calabash
     # @!visibility private
     def self.green(string)
       colorize(string, 32)
+    end
+
+    # @!visibility private
+    def self.timestamp
+      Time.now.strftime("%Y-%m-%d_%H-%M-%S")
+    end
+
+    # @!visibility private
+    def self.logs_directory
+      path = File.join(Calabash::Cucumber::DotDir.directory, "logs")
+      FileUtils.mkdir_p(path)
+      path
+    end
+
+    # @!visibility private
+    def self.calabash_log_file
+      path = File.join(self.logs_directory, "calabash.log")
+      if !File.exist?(path)
+        FileUtils.touch(path)
+      end
+      path
     end
   end
 end

--- a/calabash-cucumber/lib/calabash-cucumber/usage_tracker.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/usage_tracker.rb
@@ -2,6 +2,7 @@ module Calabash
   module Cucumber
     class UsageTracker
       require "calabash-cucumber/store/preferences"
+      require "calabash-cucumber/logging"
 
       require "httpclient"
       require "run_loop"
@@ -25,9 +26,9 @@ module Calabash
             info_we_are_allowed_to_track != "none"
           begin
             HTTPClient.post(ROUTE, info)
-          rescue => _
-            # do nothing
-            # Perhaps we should log?
+          rescue => e
+            message = %Q{ERROR: Could not post usage tracking information:#{$-0}#{e}}
+            Calabash::Cucumber::log_to_file(message)
           end
         end
       end

--- a/calabash-cucumber/spec/lib/logging_spec.rb
+++ b/calabash-cucumber/spec/lib/logging_spec.rb
@@ -163,6 +163,29 @@ describe Calabash::Cucumber do
           expect(lines[0]).to be == "stamp Pushing mid"
           expect(lines[1]).to be == "stamp Get over here!"
         end
+
+        it "handles errors by logging when debugging" do
+          allow(RunLoop::Environment).to receive(:debug?).and_return true
+          expect(File).to receive(:open).and_raise StandardError, "Did not get the last hit"
+
+           actual = capture_stdout do
+             Calabash::Cucumber.log_to_file("message")
+           end.string.gsub(/\e\[(\d+)m/, "")
+
+           expected = "DEBUG: Could not write:\n\nmessage\n\nto calabash.log because:\n\nDid not get the last hit\n\n"
+           expect(actual).to be == expected
+        end
+
+        it "handles errors by ignoring them when not debugging" do
+          allow(RunLoop::Environment).to receive(:debug?).and_return false
+          expect(File).to receive(:open).and_raise StandardError, "Did not get the last hit"
+
+           actual = capture_stdout do
+             Calabash::Cucumber.log_to_file("message")
+           end.string.gsub(/\e\[(\d+)m/, "")
+
+           expect(actual).to be == ""
+        end
       end
     end
 

--- a/calabash-cucumber/spec/lib/logging_spec.rb
+++ b/calabash-cucumber/spec/lib/logging_spec.rb
@@ -82,4 +82,99 @@ describe Calabash::Cucumber do
       Calabash::Cucumber.log_info("info")
     end
   end
+
+  describe "file logging" do
+    let(:now) { Time.now }
+
+    it ".timestamp" do
+      expected = now.strftime("%Y-%m-%d_%H-%M-%S")
+      expect(Time).to receive(:now).and_return(now)
+
+      actual = Calabash::Cucumber.send(:timestamp)
+      expect(actual).to be == expected
+    end
+
+    describe "logs directory and calabash.log" do
+      let(:tmp_dir) { File.expand_path("tmp") }
+      let(:log_file) { File.join(tmp_dir, "logs", "calabash.log") }
+
+      before do
+        FileUtils.rm_rf(tmp_dir)
+        allow(Calabash::Cucumber::DotDir).to receive(:directory).and_return(tmp_dir)
+      end
+
+      it ".logs_directory" do
+        actual = Calabash::Cucumber.send(:logs_directory)
+        expect(actual).to be == File.join(tmp_dir, "logs")
+        expect(File.exist?(actual)).to be_truthy
+      end
+
+      describe ".calabash_log_file" do
+        it "creates the log file if it does not exist" do
+          expect(FileUtils).to receive(:touch).and_call_original
+
+          actual = Calabash::Cucumber.send(:calabash_log_file)
+          expect(actual).to be == log_file
+          expect(File.exist?(actual)).to be_truthy
+        end
+
+        it "returns the log file if it does exist" do
+          FileUtils.mkdir_p(File.join(tmp_dir, "logs"))
+          FileUtils.touch(log_file)
+          expect(FileUtils).not_to receive(:touch).with(log_file)
+
+          actual = Calabash::Cucumber.send(:calabash_log_file)
+          expect(actual).to be == log_file
+          expect(File.exist?(actual)).to be_truthy
+        end
+      end
+
+      describe ".log_to_file" do
+
+        before do
+          allow(Calabash::Cucumber).to receive(:timestamp).and_return("stamp")
+        end
+
+        it "appends message to log file" do
+          Calabash::Cucumber.log_to_file("Pushing mid")
+          lines = File.read(log_file).force_encoding("utf-8").split($-0)
+
+          expect(lines.count).to be == 1
+          expect(lines[0]).to be == "stamp Pushing mid"
+
+          Calabash::Cucumber.log_to_file("Get over here!")
+          lines = File.read(log_file).force_encoding("utf-8").split($-0)
+
+          expect(lines.count).to be == 2
+          expect(lines[0]).to be == "stamp Pushing mid"
+          expect(lines[1]).to be == "stamp Get over here!"
+        end
+
+        it "splits multiline messages into lines" do
+          lines = [
+            "Pushing mid",
+            "Get over here!"
+          ].join($-0)
+
+          Calabash::Cucumber.log_to_file(lines)
+          lines = File.read(log_file).force_encoding("utf-8").split($-0)
+
+          expect(lines.count).to be == 2
+          expect(lines[0]).to be == "stamp Pushing mid"
+          expect(lines[1]).to be == "stamp Get over here!"
+        end
+      end
+    end
+
+    describe ".log_to_file" do
+      it "appends log file" do
+
+      end
+
+      it "does not fail when errors are raised" do
+
+      end
+    end
+  end
 end
+

--- a/calabash-cucumber/spec/lib/usage_tracker_spec.rb
+++ b/calabash-cucumber/spec/lib/usage_tracker_spec.rb
@@ -41,7 +41,6 @@ describe Calabash::Cucumber::UsageTracker do
     expect(tracker.send(:info_we_are_allowed_to_track)).to be == "allowed"
   end
 
-
   describe ".xtc?" do
     it "truthy" do
       stub_env({"XAMARIN_TEST_CLOUD" => "1"})
@@ -60,8 +59,23 @@ describe Calabash::Cucumber::UsageTracker do
       expect(tracker).to receive(:info).and_return({})
       expect(HTTPClient).to receive(:post)
       expect(Calabash::Cucumber::UsageTracker).to receive(:track_usage?).and_return true
-      expect(tracker).to receive(:info_we_are_allowed_to_track).and_return "anything by 'none'"
+      expect(tracker).to receive(:info_we_are_allowed_to_track).and_return "anything but 'none'"
       tracker.post_usage
+    end
+
+    it "logs to calabash.log when error is raised" do
+      expect(HTTPClient).to receive(:post).and_raise StandardError
+      expect(tracker).to receive(:info).and_return({})
+      expect(tracker).to receive(:info_we_are_allowed_to_track).and_return "anything but 'none'"
+      expect(Calabash::Cucumber::UsageTracker).to receive(:track_usage?).and_return true
+
+      expect(Calabash::Cucumber).to receive(:timestamp).and_return("stamp")
+      tracker.post_usage
+      log_file = Calabash::Cucumber.send(:calabash_log_file)
+
+      lines = File.read(log_file).force_encoding("utf-8").split($-0).reverse
+      expect(lines[0]).to be == "stamp StandardError"
+      expect(lines[1]).to be == "stamp ERROR: Could not post usage tracking information:"
     end
 
     describe "does not post" do


### PR DESCRIPTION
### Motivation

If the usage tracker `post` raises an exception, log it to ~/.calabash/logs/calabash.log

Related to **Tracker: add missing requires to avoid throwing errors** #952

