### PR TITLE
Don't immediately return true for simulator? if simulator_details is empty

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -193,7 +193,7 @@ module Calabash
       # @return [Boolean] true if this device is a simulator
       def simulator?
         # Post 0.16.2 server
-        if simulator_details
+        unless simulator_details.nil? || simulator_details.empty?
           true
         else
           system == GESTALT_SIM_SYS

--- a/calabash-cucumber/spec/lib/device_spec.rb
+++ b/calabash-cucumber/spec/lib/device_spec.rb
@@ -140,7 +140,7 @@ describe Calabash::Cucumber::Device do
 
   describe '#simulator?' do
     it '@simulator_details are available' do
-      expect(device).to receive(:simulator_details).and_return 'Core Simulator'
+      expect(device).to receive(:simulator_details).at_least(:once).and_return 'Core Simulator'
 
       expect(device.simulator?).to be_truthy
     end


### PR DESCRIPTION
`simulator_details` on a physical device may be an empty string, in which case `simulator?` should not immediately return true.