### PR TITLE
Track GitLab CI

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/usage_tracker.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/usage_tracker.rb
@@ -180,7 +180,8 @@ module Calabash
               :jenkins => RunLoop::Environment.jenkins?,
               :travis => RunLoop::Environment.travis?,
               :circle_ci => RunLoop::Environment.circle_ci?,
-              :teamcity => RunLoop::Environment.teamcity?
+              :teamcity => RunLoop::Environment.teamcity?,
+              :gitlab => RunLoop::Environment.gitlab?
             }
           )
         end

--- a/calabash-cucumber/lib/calabash-cucumber/usage_tracker.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/usage_tracker.rb
@@ -83,7 +83,7 @@ module Calabash
       end
 
       # @!visibility private
-      DATA_VERSION = "1.0"
+      DATA_VERSION = "1.1"
 
       # @!visibility private
       WINDOWS = "Windows"

--- a/calabash-cucumber/spec/lib/usage_tracker_spec.rb
+++ b/calabash-cucumber/spec/lib/usage_tracker_spec.rb
@@ -41,7 +41,6 @@ describe Calabash::Cucumber::UsageTracker do
     expect(tracker.send(:info_we_are_allowed_to_track)).to be == "allowed"
   end
 
-
   describe ".xtc?" do
     it "truthy" do
       stub_env({"XAMARIN_TEST_CLOUD" => "1"})
@@ -133,11 +132,11 @@ describe Calabash::Cucumber::UsageTracker do
       expect(hash.has_key?(:used_bundle_exec)).to be_truthy
       expect(hash[:used_cucumber]).to be == false
       expect(hash[:version]).to be_truthy
-      expect(hash.has_key?(:ci)).to be_truthy
-      expect(hash.has_key?(:jenkins)).to be_truthy
-      expect(hash.has_key?(:travis)).to be_truthy
-      expect(hash.has_key?(:circle_ci)).to be_truthy
-      expect(hash.has_key?(:teamcity)).to be_truthy
+      expect(hash.has_key?(:ci)).to be == true
+      expect(hash.has_key?(:jenkins)).to be == true
+      expect(hash.has_key?(:travis)).to be == true
+      expect(hash.has_key?(:circle_ci)).to be == true
+      expect(hash.has_key?(:teamcity)).to be == true
     end
   end
 

--- a/calabash-cucumber/spec/lib/usage_tracker_spec.rb
+++ b/calabash-cucumber/spec/lib/usage_tracker_spec.rb
@@ -119,7 +119,7 @@ describe Calabash::Cucumber::UsageTracker do
 
       hash = tracker.send(:info)
 
-      expect(hash.count).to be == 16
+      expect(hash.count).to be == 17
       expect(hash[:event_name]).to be == "session"
       expect(hash[:data_version]).to be_truthy
       expect(hash[:user_id]).to be == "user id"


### PR DESCRIPTION
Requires run-loop >= 2.0.2

CI will fail until then.