### PR TITLE
Use run loop cache for all strategies when attaching

### DIFF
--- a/script/ci/travis/rspec-ci.rb
+++ b/script/ci/travis/rspec-ci.rb
@@ -10,4 +10,7 @@ Dir.chdir working_directory do
             {:pass_msg => 'rspec tests passed',
              :fail_msg => 'rspec tests failed'})
 
+  do_system("bundle exec rspec spec/integration/launcher/console_attach_spec.rb",
+            {:pass_msg => 'Console integration rspec tests passed',
+             :fail_msg => 'Console integration rspec tests failed'})
 end


### PR DESCRIPTION
**REBASED** Fri Dec 18 15:22
### Motivation

Completes **`console_attach` needs some love; run-loop should cache runtime info for all strategies** #828

Requires run-loop 2.0.2 - expect some failures.