### PR TITLE
Remove calabash-common dependency

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -54,7 +54,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0'
 
   s.add_dependency("cucumber")
-  s.add_dependency('calabash-common', '~> 0.0.2')
   # Avoid 1.0.5 release; has an errant 'binding.pry'.
   s.add_dependency('edn', '>= 1.0.6', '< 2.0')
   # Avoid 0.5 release because it does not contain ios-sim binary.

--- a/calabash-cucumber/features-skeleton/support/env.rb
+++ b/calabash-cucumber/features-skeleton/support/env.rb
@@ -1,9 +1,15 @@
-# Requiring this file will import Calabash and the Calabash predefined Steps.
-require 'calabash-cucumber/cucumber'
+# Requiring this file will import:
+# * the Calabash Cucumber API,
+# * the Calabash Cucumber predefined Steps,
+# * and the Calabash::Formatters::Html cucumber formatter.
+require "calabash-cucumber/cucumber"
 
 # To use Calabash without the predefined Calabash Steps, uncomment these
 # three lines and delete the require above.
-# require 'calabash-cucumber/wait_helpers'
-# require 'calabash-cucumber/operations'
+# require "calabash-cucumber/wait_helpers"
+# require "calabash-cucumber/operations"
 # World(Calabash::Cucumber::Operations)
+
+# Uncomment this line if you want the Calabash::Formatters::Html formatter.
+# require "calabash-cucumber/formatters/html"
 

--- a/calabash-cucumber/lib/calabash-cucumber/cucumber.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/cucumber.rb
@@ -1,5 +1,6 @@
 require 'calabash-cucumber/wait_helpers'
 require 'calabash-cucumber/operations'
+require "calabash-cucumber/formatters/html"
 
 World(Calabash::Cucumber::Operations)
 

--- a/calabash-cucumber/lib/calabash-cucumber/formatters/html.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/formatters/html.rb
@@ -1,0 +1,35 @@
+require "cucumber/formatter/html"
+require "uri"
+require "pathname"
+
+module Calabash
+  module Formatters
+    class Html < ::Cucumber::Formatter::Html
+      def embed_image(src, label)
+        if _output_relative? && _relative_uri?(src)
+          output_dir = Pathname.new(File.dirname(@io.path))
+          src_path = Pathname.new(src)
+          embed_relative_path = src_path.relative_path_from(output_dir)
+          super(embed_relative_path.to_s, label)
+        else
+          super(src, label)
+        end
+      end
+
+      def _relative_uri?(src)
+        uri = URI.parse(src)
+        return false if uri.scheme
+        not Pathname.new(src).absolute?
+      end
+
+
+      def _output_relative?
+        if @io.is_a?(File)
+          path = @io.path
+          _relative_uri?(path)
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
**MILESTONE** 0.18.0

Do not merge before 0.18.0.

### Motivation

We don't need the calabash-common gem - all it contains is a formatter.

This is a backward incompatible change for users who do not import predefined steps.

Resolves **remove calabash-common dependency** #922

I started working on this and then realized it was _out of scope_ for 0.17.1.