### PR TITLE
Fix `sim locale` command line tool

### DIFF
--- a/calabash-cucumber/bin/calabash-ios-sim.rb
+++ b/calabash-cucumber/bin/calabash-ios-sim.rb
@@ -1,5 +1,6 @@
 require 'calabash-cucumber/utils/simulator_accessibility'
 require 'calabash-cucumber/utils/logging'
+require "calabash-cucumber/environment"
 require 'run_loop'
 
 include Calabash::Cucumber::Logging
@@ -62,46 +63,99 @@ end
 
 def calabash_sim_locale(args)
 
-  prefs_path = File.expand_path("#{@script_dir}/data/.GlobalPreferences.plist")
-  plist = CFPropertyList::List.new(:file => prefs_path)
-  hash = CFPropertyList.native_types(plist.value)
+  if args.length != 2
+   puts %Q{
+Usage:
 
+$ calabash-ios sim locale < language code > < locale code >
 
-  if args.length == 0
-    print_usage
-    puts "Options: \n"
-    puts hash['AppleLanguages'].join("\n")
-    exit 0
-  end
-  lang = args.shift
-  reg = nil
-  if args.length == 1
-    reg = args.shift
-  end
+Examples:
 
-  langs = hash['AppleLanguages']
-  lang_index = langs.find_index { |l| l == lang }
+# French language and locale
+$ calabash-ios sim locale fr fr
 
-  if lang_index.nil?
-    puts "Unable to find #{lang}..."
-    puts "Options:\n#{langs.join("\n")}"
-    exit 0
-  end
+# Swiss French with Swiss German locale
+$ calabash-ios sim locale fr-CH de_CH
 
-  langs[0], langs[lang_index] = langs[lang_index], langs[0]
+By default, this method will change the default simulator for the active
+Xcode version.  If you want to target an alternative simulator, set the
+DEVICE_TARGET environment variable.
 
+$ DEVICE_TARGET="iPhone 6 (9.2)" calabash-ios sim locale en-US en_US
+$ DEVICE_TARGET=B9BCAD64-1624-4277-9361-40EFFBD7C67F calabash-ios sim locale de de
 
-  if reg
-    hash['AppleLocale'] = reg
-  end
-  res_plist = CFPropertyList::List.new
-  res_plist.value = CFPropertyList.guess(hash)
-  dirs = Dir.glob(File.join(File.expand_path("~/Library"), "Application Support", "iPhone Simulator", "*.*", "Library", "Preferences"))
-  dirs.each do |sim_pref_dir|
-    res_plist.save("#{sim_pref_dir}/.GlobalPreferences.plist", CFPropertyList::List::FORMAT_BINARY)
+This operation will quit and reset the simulator.
+}
+   return false
   end
 
+  language = args[0]
+  locale = args[1]
 
+  device_target = Calabash::Cucumber::Environment.device_target
+  default_target = RunLoop::Core.default_simulator
+
+  target = device_target || default_target
+
+  device = RunLoop::Device.device_with_identifier(target)
+
+  if device.nil?
+    if target == device_target
+      puts %Q{
+Could not find simulator matching:
+
+DEVICE_TARGET=#{device_target}
+
+Check the output of:
+
+$ xcrun instruments -s devices
+
+for a list of available simulators.
+}
+    else
+      puts %Q{
+Could not find the default simulator.  Make sure that you have
+the right version of run_loop installed for your Xcode version.
+}
+    end
+
+    return false
+  end
+
+  if device.physical_device?
+    puts %Q{
+This tool is for simulators only.
+
+#{target} is a physical device.
+}
+    return false
+  end
+
+  RunLoop::CoreSimulator.set_language(device, language)
+  RunLoop::CoreSimulator.set_locale(device, locale)
+
+  puts %Q{
+Set langauge to: '#{language}' and locale to: '#{locale}'.
+
+Don't forget to launch your app with these options:
+
+options = {
+  args = [
+           "-AppleLanguages", "(#{language})",
+           "-AppleLocale", "#{locale}"
+         ]
+}
+
+to ensure that your app launches with the correct primary langauge.
+
+Examples:
+
+* https://github.com/calabash/calabash-ios/wiki/Changing-Locale-and-Language
+* https://github.com/calabash/Permissions/blob/master/features/0x/support/01_launch.rb
+
+SUCCESS!
+}
+  true
 end
 
 

--- a/calabash-cucumber/spec/bin/calabash_ios_sim_spec.rb
+++ b/calabash-cucumber/spec/bin/calabash_ios_sim_spec.rb
@@ -16,13 +16,90 @@ unless Luffa::Environment.travis_ci?
     end
 
     it '#calabash_sim_reset' do
-      # @todo figure out how and if this can/should be tested
       calabash_sim_reset
     end
 
     it '#calabash_sim_accessibility' do
-      # @todo figure out how and if this can/should be tested
       calabash_sim_accessibility
+    end
+
+    describe "#calabash_sim_locale" do
+      it "prints a helpful message with no args" do
+        actual = true
+        out = capture_stdout do
+           actual = calabash_sim_locale([])
+        end.string
+
+        expect(actual).to be_falsey
+        expect(out[/Usage:/, 0]).to be_truthy
+      end
+
+      it "prints a helpful message with one arg" do
+        actual = true
+        out = capture_stdout do
+           actual = calabash_sim_locale(["de"])
+        end.string
+
+        expect(actual).to be_falsey
+        expect(out[/Usage:/, 0]).to be_truthy
+      end
+
+      it "fails when it cannot find DEVICE_TARGET" do
+        udid = "Unknown Simulator"
+        expect(Calabash::Cucumber::Environment).to receive(:device_target).and_return(udid)
+        expect(RunLoop::Device).to receive(:device_with_identifier).and_return(nil)
+
+        actual = true
+        out = capture_stdout do
+           actual = calabash_sim_locale(["de", "de"])
+        end.string
+
+        expect(actual).to be_falsey
+        expect(out[/DEVICE_TARGET/, 0]).to be_truthy
+      end
+
+      it "fails when default simulator cannot be found" do
+        expect(Calabash::Cucumber::Environment).to receive(:device_target).and_return(nil)
+        expect(RunLoop::Core).to receive(:default_simulator).and_return("iPhone 2s")
+        expect(RunLoop::Device).to receive(:device_with_identifier).and_return(nil)
+
+        actual = true
+        out = capture_stdout do
+          actual = calabash_sim_locale(["de", "de"])
+        end.string
+
+        expect(actual).to be_falsey
+        expect(out[/Could not find the default simulator/, 0]).to be_truthy
+      end
+
+      it "fails when passed a physical device target" do
+        udid = "133688929205de7fb18d603c158ede219ae8dd1d"
+        device = RunLoop::Device.new("denis", "8.0", udid)
+
+        expect(Calabash::Cucumber::Environment).to receive(:device_target).and_return(udid)
+        expect(RunLoop::Device).to receive(:device_with_identifier).with(udid).and_return(device)
+
+        actual = true
+        out = capture_stdout do
+          actual = calabash_sim_locale(["de", "de"])
+        end.string
+        expect(actual).to be_falsey
+        expect(out[/This tool is for simulators only/, 0]).to be_truthy
+      end
+
+      it "sets the local and language for default simulator" do
+        actual = false
+
+        out = capture_stdout do
+          actual = calabash_sim_locale(["de", "de"])
+        end.string
+
+        expect(out[/-AppleLanguages/]).to be_truthy
+        expect(out[/-AppleLocale/]).to be_truthy
+        expect(out[/SUCCESS/]).to be_truthy
+        expect(actual).to be_truthy
+      end
     end
   end
 end
+

--- a/script/ci/jenkins/rspec.sh
+++ b/script/ci/jenkins/rspec.sh
@@ -10,3 +10,8 @@ rbenv exec \
   rspec \
   spec/lib
 
+rbenv exec \
+  bundle exec \
+  rspec \
+  spec/bin/calabash_ios_sim_spec.rb
+


### PR DESCRIPTION
### Motivation

Fixes **".GlobalPreferences.plist not readable! (IOError)" error when executing 'calabash-ios sim locale en fi_FI' (0.11.1, Xcode 5.1.1, iOS7.1)** #564

