### PR TITLE
Update skeleton support/dry_run to load predefined steps

### DIFF
--- a/calabash-cucumber/features-skeleton/support/dry_run.rb
+++ b/calabash-cucumber/features-skeleton/support/dry_run.rb
@@ -1,2 +1,19 @@
-require 'calabash-cucumber'
+require "calabash-cucumber"
 
+# Cucumber -d must pass, but support/env.rb is not eval'd on dry runs.
+# We must detect that the user wants to use pre-defined steps.
+dir = File.expand_path(File.dirname(__FILE__))
+env = File.join(dir, "env.rb")
+
+contents = File.read(env).force_encoding("UTF-8")
+
+contents.split($-0).each do |line|
+
+  # Skip comments.
+  next if line.chars[0] == "#"
+
+  if line[/calabash-cucumber\/cucumber/, 0]
+    require "calabash-cucumber/calabash_steps"
+    break
+  end
+end


### PR DESCRIPTION
### Motivation

Resolves: **Pre-defined cucumbers not found when running `cucumber -d`** #986

@krukow @sapieneptus @TobiasRoikjer 

I have tested locally and this works.  Standing up an integration test for this seems like too much work.  We have a work-around (mentioned in the issue) for users who have legacy support/ files.

- [x] Needs review Anyone with cucumber experience can review.