### PR TITLE
Keyboard: log that #done is going to be removed

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -469,6 +469,11 @@ module Calabash
       #
       # @raise [RuntimeError] if the text cannot be typed.
       def done
+        _deprecated("0.10.0",
+%Q{Use tap_keyboard_action_key
+
+The `done` method will be removed in 0.19.0
+}, :warn)
         tap_keyboard_action_key
       end
 

--- a/calabash-cucumber/spec/lib/keyboard_helper_spec.rb
+++ b/calabash-cucumber/spec/lib/keyboard_helper_spec.rb
@@ -1,0 +1,19 @@
+
+describe Calabash::Cucumber::KeyboardHelpers do
+
+  let(:world) do
+    Class.new do
+      include Calabash::Cucumber::KeyboardHelpers
+    end.new
+  end
+
+  it "#done is deprecated" do
+    expect(world).to receive(:tap_keyboard_action_key).and_return(true)
+
+    err = capture_stderr do
+      world.done
+    end.string
+
+    expect(err[/Use tap_keyboard_action_key/, 0]).to be_truthy
+  end
+end


### PR DESCRIPTION
### Motivation

Resolves **add `deprecation` logging to KeyboardHelpers.done** #1003

Cucumber 2.0 adds a `done` method which is clobbered by KeyboardHelpers#done.

The #done method has been deprecated since 0.10.0.

I will be removed in 0.19.0.