### PR TITLE
Gem: pin rake to ~> 10.5; rspec 3.4 is not compatible

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -77,7 +77,8 @@ Gem::Specification.new do |s|
   # Shared with run-loop.
   s.add_development_dependency("rspec_junit_formatter")
   s.add_development_dependency 'luffa', '>= 1.1.0' # Remove ASAP.
-  s.add_development_dependency 'rake'
+  # Rake 11.0 is not compatible with rspec 3.4.* or 3.5.0.beta1
+  s.add_development_dependency 'rake', "~> 10.0"
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-nav'


### PR DESCRIPTION
### Motivation

Rake 11.* is not compatible with rspec 3.4.* or rspec 3.5.0.beta1

```
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x007fad0a1ed980>
/Users/travis/.rvm/gems/ruby-2.0.0-p576/gems/rspec-core-3.4.3/lib/rspec/core/rake_task.rb:91:in `define'
/Users/travis/.rvm/gems/ruby-2.0.0-p576/gems/rspec-core-3.4.3/lib/rspec/core/rake_task.rb:71:in `initialize'
/Users/travis/build/calabash/calabash-ios/calabash-cucumber/Rakefile:7:in `new'
/Users/travis/build/calabash/calabash-ios/calabash-cucumber/Rakefile:7:in `<top (required)>'
/Users/travis/.rvm/gems/ruby-2.0.0-p576/bin/ruby_executable_hooks:15:in `eval'
/Users/travis/.rvm/gems/ruby-2.0.0-p576/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
```

Tests failing in Travis.