### PR TITLE
Replace automatic .app detection with RunLoop implementation

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
   s.add_dependency('httpclient', '>= 2.3.2', '< 3.0')
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
-  s.add_dependency("run_loop", ">= 2.0.8", "< 3.0")
+  s.add_dependency("run_loop", ">= 2.0.9", "< 3.0")
 
   # Shared with run-loop.
   s.add_dependency('json')

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -330,7 +330,6 @@ Resetting physical devices is not supported.
         :launch_method => default_launch_method,
         :reset => reset_between_scenarios?,
         :bundle_id => ENV['BUNDLE_ID'],
-        :device => device_env,
         :no_stop => calabash_no_stop?,
         :no_launch => calabash_no_launch?,
         :sdk_version => sdk_version,
@@ -821,11 +820,6 @@ Resetting physical devices is not supported.
   # @!visibility private
   def reset_between_scenarios?
     ENV['RESET_BETWEEN_SCENARIOS']=="1"
-  end
-
-  # @!visibility private
-  def device_env
-    ENV['DEVICE']
   end
 
   # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -753,7 +753,7 @@ Resetting physical devices is not supported.
 
   # @!visibility private
   def app_path
-    ENV['APP_BUNDLE_PATH'] || (defined?(APP_BUNDLE_PATH) && APP_BUNDLE_PATH) || ENV['APP']
+    RunLoop::Environment.path_to_app_bundle || (defined?(APP_BUNDLE_PATH) && APP_BUNDLE_PATH)
   end
 
   # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -571,57 +571,6 @@ Resetting physical devices is not supported.
   end
 
   # @!visibility private
-  def detect_device_from_args(args)
-    if args[:app] && File.directory?(args[:app])
-      # Derive bundle id from bundle_dir
-      plist_as_hash = info_plist_from_bundle_path(args[:app])
-      if plist_as_hash
-        device_family = plist_as_hash['UIDeviceFamily']
-        if device_family
-          first_device = device_family.first
-          if first_device == 2
-            return 'ipad'
-          else
-            return 'iphone'
-          end
-        end
-      end
-    else
-      args[:app]
-    end
-  end
-
-  # @!visibility private
-  def detect_app_bundle_from_args(args)
-    if simulator_target?(args)
-      device_xamarin_build_dir = 'iPhoneSimulator'
-    else
-      device_xamarin_build_dir = 'iPhone'
-    end
-    # is this really only applicable to the Xamarin IDE?
-    self.simulator_launcher.detect_app_bundle(nil, device_xamarin_build_dir)
-  end
-
-  # @!visibility private
-  def detect_bundle_id_from_app_bundle(args)
-    if args[:app] && File.directory?(args[:app])
-      # Derive bundle id from bundle_dir
-      plist_as_hash = info_plist_from_bundle_path(args[:app])
-      if plist_as_hash
-        plist_as_hash['CFBundleIdentifier']
-      end
-    else
-      args[:app]
-    end
-  end
-
-  # @!visibility private
-  def info_plist_from_bundle_path(bundle_path)
-    plist_path = File.join(bundle_path, 'Info.plist')
-    info_plist_as_hash(plist_path) if File.exist?(plist_path)
-  end
-
-  # @!visibility private
   def new_run_loop(args)
 
     last_err = nil
@@ -719,26 +668,6 @@ Resetting physical devices is not supported.
   def calabash_notify(world)
     if world.respond_to?(:on_launch)
       world.on_launch
-    end
-  end
-
-  # @!visibility private
-  def info_plist_as_hash(plist_path)
-    unless File.exist?(plist_path)
-      raise "Unable to find Info.plist: #{plist_path}"
-    end
-    parsedplist = CFPropertyList::List.new(:file => plist_path)
-    CFPropertyList.native_types(parsedplist.value)
-  end
-
-  # @!visibility private
-  def detect_bundle_id
-    begin
-      bundle_path = self.simulator_launcher.app_bundle_or_raise(app_path)
-      plist_path = File.join(bundle_path, 'Info.plist')
-      info_plist_as_hash(plist_path)['CFBundleIdentifier']
-    rescue => e
-      raise "Unable to automatically find bundle id. Please set BUNDLE_ID environment variable. #{e}"
     end
   end
 


### PR DESCRIPTION
### Motivation

Progress on **0.18.1 Cannot automatically detect .app** #1008

The `Launcher#relaunch` method resists unit tests.

This PR removes many public Launcher methods:

* detect_device_from_args
* detect_app_bundle_from_args
* info_plist_from_bundle_path
* info_plist_as_hash
* detect_bundle_id
* device_env

These were all documented as private, but were `public`.  I don't think it is necessary to do the normal deprecation cycle of: document, deprecate, announce, and finally remove in a minor release.