### PR TITLE
Remove deprecated methods for 0.19.0

### DIFF
--- a/calabash-cucumber/features/step_definitions/calabash_steps.rb
+++ b/calabash-cucumber/features/step_definitions/calabash_steps.rb
@@ -138,12 +138,6 @@ Then /^I use the native keyboard to enter "([^\"]*)" into (?:input|text) field n
   sleep(STEP_PAUSE)
 end
 
-When /^I clear "([^\"]*)"$/ do |name|
-  msg = "When I clear <name>' will be deprecated because it is ambiguous - what should be cleared?"
-  _deprecated('0.9.151', msg, :warn)
-  clear_text("textField marked: '#{name}'")
-end
-
 Then /^I clear (?:input|text) field number (\d+)$/ do |index|
   index = index.to_i
   screenshot_and_raise("Index should be positive (was: #{index})") if index <= 0

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -980,23 +980,6 @@ arguments => '#{arguments}'
         tap_mark(label, *args)
       end
 
-      # taps a view with mark `hash_or_string`
-      # @deprecated In later Calabash versions we will change the semantics of `tap` to take a general query
-      #   (instead of a 'mark' now). We're deprecating this now to prepare people for a breaking change.
-      # @param {String} hash_or_string mark to pass to call `tap_mark(hash_or_string)`.
-      # @return {Array<Hash>} array containing the serialized version of the tapped view.
-      def tap(hash_or_string, *args)
-        deprecation_msg = 'Use tap_mark instead. In later Calabash versions we will change the semantics of `tap` to take a general query.'
-        _deprecated('0.10.0', deprecation_msg, :warn)
-        if hash_or_string.is_a?(String)
-          tap_mark(hash_or_string, *args)
-        elsif hash_or_string.respond_to?(:[])
-          wait_tap(hash_or_string[:query], hash_or_string)
-        else
-          raise(ArgumentError, "first parameter to tap must be a string or a hash. Was: #{hash_or_string.class}, #{hash_or_string}")
-        end
-      end
-
       # taps a view with mark `label`. Equivalent to `touch("* marked:'#{label}'")`
       # @param {String} label the mark of the view to tap
       # @param {Array} args optional additional arguments to pass to `touch`.

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -138,16 +138,6 @@ module Calabash
         Calabash::Cucumber::VERSION
       end
 
-      # Queries all views in view hierarchy, even if not visible.
-      # @deprecated use the 'all' or 'visible' modifier in query syntax
-      def query_all(uiquery, *args)
-        msg0 = "use the 'all' or 'visible' query language feature"
-        msg1 = 'see: https://github.com/calabash/calabash-ios/wiki/05-Query-syntax'
-        msg = "#{msg0}\n#{msg1}"
-        _deprecated('0.9.133', msg, :warn)
-        map("all #{uiquery}", :query, *args)
-      end
-
       # Performs the `tap` gesture on the (first) view that matches
       # query `uiquery`. Note that `touch` assumes the view is visible and not animating.
       # If the view is not visible `touch` will fail. If the view is animating

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -192,18 +192,18 @@ module Calabash
       # Is this device a simulator or physical device?
       # @return [Boolean] true if this device is a simulator
       def simulator?
-        # Post 0.16.2 server
-        unless simulator_details.nil? || simulator_details.empty?
-          true
+        details = simulator_details
+        if details
+          details != ""
         else
-          system == GESTALT_SIM_SYS
+          false
         end
       end
 
       # Is this device a device or simulator?
       # @return [Boolean] true if this device is a physical device
       def device?
-        not simulator?
+        !simulator?
       end
 
       # Is this device an iPhone?

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -314,19 +314,6 @@ module Calabash
         iphone_app_emulated_on_ipad
       end
 
-      # @deprecated 0.9.169 replaced with `server_version`
-      #
-      # @see #server_version
-      #
-      # The version of the embedded Calabash server running in the app under
-      # test on this device.
-      # @see #server_version
-      # @return [String] the version of the embedded Calabash server
-      def framework_version
-        _deprecated('0.9.169', "use 'server_version', instead", :warn)
-        @server_version
-      end
-
       # @deprecated 0.10.0 no replacement
       def udid
         _deprecated('0.10.0', 'no replacement', :warn)

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -314,18 +314,6 @@ module Calabash
         iphone_app_emulated_on_ipad
       end
 
-      # @deprecated 0.10.0 no replacement
-      def udid
-        _deprecated('0.10.0', 'no replacement', :warn)
-        @udid
-      end
-
-      # @deprecated 0.10.0 no replacement
-      def udid=(value)
-        _deprecated('0.10.0', 'no replacement', :warn)
-        @udid = value
-      end
-
       # @deprecated 0.9.168 replaced with iphone_4in?
       #
       # @see #iphone_4in?

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -314,17 +314,6 @@ module Calabash
         iphone_app_emulated_on_ipad
       end
 
-      # @deprecated 0.13.1 - Call `iphone_4in?` instead.
-      #
-      # @see #iphone_4in?
-      #
-      # @note Deprecated after introducing new `form_factor` behavior.
-      # @return [Boolean] true if this device is an iPhone 5 or 5s
-      def iphone_4in
-        _deprecated('0.13.1', "use 'iphone_4in?' instead", :warn)
-        @iphone_4in
-      end
-
       # @deprecated 0.16.2 No replacement.
       #
       # @example
@@ -341,13 +330,6 @@ module Calabash
       # @return [String] The model of this device.
       #  this device.
       attr_reader :system
-
-      # @deprecated 0.13.1 no replacement
-      #
-      # Indicates whether or not this device has a 4in screen.
-      # @attribute [r] iphone_4in
-      # @return [Boolean] `true` if this device has a 4in screen.
-      attr_reader :iphone_4in
 
       # @deprecated 0.10.0 no replacement
       #

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -314,12 +314,6 @@ module Calabash
         iphone_app_emulated_on_ipad
       end
 
-      # @deprecated 0.10.0 no replacement
-      #
-      # @!attribute [rw] udid
-      # @return [String] The udid of this device.
-      attr_accessor :udid
-
       private
 
       # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -314,18 +314,6 @@ module Calabash
         iphone_app_emulated_on_ipad
       end
 
-      # @deprecated 0.9.168 replaced with iphone_4in?
-      #
-      # @see #iphone_4in?
-      #
-      # Is this device an iPhone 5?
-      # @note Deprecated because the iPhone 5S reports as an iPhone6,*.
-      # @return [Boolean] true if this device is an iPhone 5
-      def iphone_5?
-        _deprecated('0.9.168', "use 'iphone_4in?' instead", :warn)
-        iphone_4in?
-      end
-
       # @deprecated 0.13.1 - Call `iphone_4in?` instead.
       #
       # @see #iphone_4in?

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -314,23 +314,6 @@ module Calabash
         iphone_app_emulated_on_ipad
       end
 
-      # @deprecated 0.16.2 No replacement.
-      #
-      # @example
-      #  # simulator
-      #  i386
-      #  x86_64
-      #
-      # @example
-      #  # examples from physical devices
-      #  iPhone7,1
-      #  iPhone5,2
-      #
-      # @attribute [r] system
-      # @return [String] The model of this device.
-      #  this device.
-      attr_reader :system
-
       # @deprecated 0.10.0 no replacement
       #
       # @!attribute [rw] udid

--- a/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
@@ -204,13 +204,6 @@ module Calabash
         _default_device_or_create.iphone_app_emulated_on_ipad?
       end
 
-      # @deprecated 0.9.168 replaced with `iphone_4in?`
-      # @see #iphone_4in?
-      def iphone_5?
-        _deprecated('0.9.168', "use 'iphone_4in?' instead", :warn)
-        iphone_4in?
-      end
-
       private
       # @!visibility private
       # Returns the device that is currently being tested against.

--- a/calabash-cucumber/spec/lib/device_spec.rb
+++ b/calabash-cucumber/spec/lib/device_spec.rb
@@ -138,28 +138,27 @@ describe Calabash::Cucumber::Device do
     end
   end
 
-  describe '#simulator?' do
-    it '@simulator_details are available' do
-      expect(device).to receive(:simulator_details).at_least(:once).and_return 'Core Simulator'
+  describe "#simulator?" do
+    it "returns true" do
+      expect(device).to receive(:simulator_details).and_return("Core Simulator")
 
       expect(device.simulator?).to be_truthy
     end
 
-    describe '@simulator_details are not available' do
-      it 'true if system is x86_64' do
-        version_data['system'] = 'x86_64'
-        expect(device).to receive(:simulator_details).and_return nil
+    describe "returns false" do
+      it "simulator_details are nil" do
+        expect(device).to receive(:simulator_details).and_return(nil)
 
-        expect(device.simulator?).to be_truthy
+        expect(device.simulator?).to be_falsey
       end
 
-      it 'false if system is not x86_64' do
-        version_data['system'] = 'anything else'
-        expect(device).to receive(:simulator_details).and_return nil
+      it "simulator_details are the empty string" do
+        expect(device).to receive(:simulator_details).and_return("")
 
         expect(device.simulator?).to be_falsey
       end
     end
+
   end
 
   describe 'iOS version' do


### PR DESCRIPTION
### Motivation

Spring is in the air and I am in the mood for removing deprecated behaviors from Calabash iOS.

* Core: remove query_all - since 0.9.133
* Core: remove tap - since 0.10.0
* Device: framework_version - since 0.9.169
* Device: remove udid - since 0.10.0
* Device: remove iphone_4in? - since 0.9.168
* Device: remove iphone_4in - since 0.13.1
* Device: system - since 0.16.2
* Environment: remove iphone_5? - since 0.9.168
* Pre-defined: remove 'I clear .' - since 0.9.151
