### PR TITLE
Remove CALABASH_VERSION_PATH

### DIFF
--- a/calabash-cucumber/bin/frank-calabash
+++ b/calabash-cucumber/bin/frank-calabash
@@ -67,7 +67,6 @@ def console
   require 'frank-calabash'
   require 'calabash-cucumber/operations'
   require 'pry'
-  ENV['CALABASH_VERSION_PATH']='calabash_version'
   console = Frank::Console.new
   console.extend ::Frank::Calabash
 

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -553,7 +553,7 @@ If your app is crashing at launch, find a crash report to determine the cause.
 
         http = Net::HTTP.new(url.host, url.port)
         res = http.start do |sess|
-          sess.request Net::HTTP::Get.new(ENV['CALABASH_VERSION_PATH'] || "version")
+          sess.request Net::HTTP::Get.new("version")
         end
         status = res.code
 


### PR DESCRIPTION
### Motivation

Companion pull request for **LPVersionRoute: remove reference to calabash_version** [#342](https://github.com/calabash/calabash-ios-server/pull/342)

I am trying to simplify the Launcher code to make space for the XCUITest action interface.