### PR TITLE
Trim Launcher class to bare essentials - Part 1

### DIFF
--- a/calabash-cucumber/ENVIRONMENT_VARIABLES.md
+++ b/calabash-cucumber/ENVIRONMENT_VARIABLES.md
@@ -23,6 +23,7 @@ The following variables are no longer used by Calabash.
 * `NO_GEN`
 * `SUBMIT_URL`
 * `http_proxy`
+* `CALABASH_VERSION_PATH`
 
 ## Conventions
 
@@ -448,14 +449,6 @@ $ cd calabash-ios/calabash-cucumber
 $ tree -d -L 1 ../../calabash-ios-server
 ../../calabash-ios-server
 ```
-
-### `CALABASH_VERSION_PATH`
-
-This variable should be deprecated.
-
-The http 'version' route.
-
-Unless you are gem or server dev, don't set this.
 
 ### `CONNECT_TIMEOUT` and `MAX_CONNECT_RETRY`
 

--- a/calabash-cucumber/lib/calabash-cucumber/environment.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment.rb
@@ -18,6 +18,18 @@ module Calabash
 
         identifier
       end
+
+      def self.device_endpoint
+        value = RunLoop::Environment.device_endpoint
+        if value
+          value
+        else
+          DEFAULT_AUT_ENDPOINT
+        end
+      end
+
+      # @!visibility private
+      DEFAULT_AUT_ENDPOINT = "http://127.0.0.1:37265/"
     end
   end
 end

--- a/calabash-cucumber/lib/calabash-cucumber/environment.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment.rb
@@ -3,6 +3,29 @@ module Calabash
     module Environment
 
       # @!visibility private
+      def self.xtc?
+        RunLoop::Environment.xtc?
+      end
+
+      # @!visibility private
+      def self.xcode
+        return nil if self.xtc?
+        @@xcode ||= RunLoop::Xcode.new
+      end
+
+      # @!visibility private
+      def self.simctl
+        return nil if self.xtc?
+        @@simctl ||= RunLoop::SimControl.new
+      end
+
+      # @!visibility private
+      def self.instruments
+        return nil if self.xtc?
+        @@instruments ||= RunLoop::Instruments.new
+      end
+
+      # @!visibility private
       def self.device_target
         value = RunLoop::Environment.device_target
         if value

--- a/calabash-cucumber/lib/calabash-cucumber/environment.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment.rb
@@ -2,6 +2,7 @@ module Calabash
   module Cucumber
     module Environment
 
+      # @!visibility private
       def self.device_target
         value = RunLoop::Environment.device_target
         if value
@@ -19,6 +20,7 @@ module Calabash
         identifier
       end
 
+      # @!visibility private
       def self.device_endpoint
         value = RunLoop::Environment.device_endpoint
         if value

--- a/calabash-cucumber/lib/calabash-cucumber/environment.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment.rb
@@ -3,13 +3,20 @@ module Calabash
     module Environment
 
       def self.device_target
-        value = ENV["DEVICE_TARGET"]
-
-        if value.nil? || value == ""
-          nil
+        value = RunLoop::Environment.device_target
+        if value
+          if value == "simulator"
+            identifier = RunLoop::Core.default_simulator
+          elsif value == "device"
+            identifier = RunLoop::Core.detect_connected_device
+          else
+            identifier = value
+          end
         else
-          value
+          identifier = RunLoop::Core.default_simulator
         end
+
+        identifier
       end
     end
   end

--- a/calabash-cucumber/lib/calabash-cucumber/environment.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment.rb
@@ -3,6 +3,14 @@ module Calabash
     module Environment
 
       # @!visibility private
+      DEFAULTS = {
+        # The endpoint of the app under test
+        :aut_endpoint => "http://127.0.0.1:37265/",
+        :http_connection_retries => 10,
+        :http_connection_timeout => 30
+      }
+
+      # @!visibility private
       def self.xtc?
         RunLoop::Environment.xtc?
       end
@@ -49,12 +57,27 @@ module Calabash
         if value
           value
         else
-          DEFAULT_AUT_ENDPOINT
+          DEFAULTS[:aut_endpoint]
         end
       end
 
-      # @!visibility private
-      DEFAULT_AUT_ENDPOINT = "http://127.0.0.1:37265/"
+      def self.http_connection_retries
+        value = ENV["MAX_CONNECT_RETRIES"]
+        if value && value != ""
+          value.to_i
+        else
+          DEFAULTS[:http_connection_retries]
+        end
+      end
+
+      def self.http_connection_timeout
+        value = ENV["CONNECTION_TIMEOUT"]
+        if value && value != ""
+          value.to_i
+        else
+          DEFAULTS[:http_connection_timeout]
+        end
+      end
     end
   end
 end

--- a/calabash-cucumber/lib/calabash-cucumber/environment.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment.rb
@@ -61,6 +61,7 @@ module Calabash
         end
       end
 
+      # @!visibility private
       def self.http_connection_retries
         value = ENV["MAX_CONNECT_RETRIES"]
         if value && value != ""
@@ -70,6 +71,7 @@ module Calabash
         end
       end
 
+      # @!visibility private
       def self.http_connection_timeout
         value = ENV["CONNECTION_TIMEOUT"]
         if value && value != ""
@@ -77,6 +79,11 @@ module Calabash
         else
           DEFAULTS[:http_connection_timeout]
         end
+      end
+
+      # @!visibility private
+      def self.reset_between_scenarios?
+        ENV["RESET_BETWEEN_SCENARIOS"] == "1"
       end
     end
   end

--- a/calabash-cucumber/lib/calabash-cucumber/environment.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment.rb
@@ -52,6 +52,19 @@ module Calabash
       end
 
       # @!visibility private
+      def self.run_loop_device
+        return nil if self.xtc?
+
+        identifier = self.device_target
+
+        options = {
+          :sim_control => self.simctl,
+          :instruments => self.instruments
+        }
+        RunLoop::Device.device_with_identifier(identifier, options)
+      end
+
+      # @!visibility private
       def self.device_endpoint
         value = RunLoop::Environment.device_endpoint
         if value

--- a/calabash-cucumber/lib/calabash-cucumber/environment.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment.rb
@@ -7,7 +7,7 @@ module Calabash
         # The endpoint of the app under test
         :aut_endpoint => "http://127.0.0.1:37265/",
         :http_connection_retries => 10,
-        :http_connection_timeout => 30
+        :http_connection_timeout => 60
       }
 
       # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/http_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/http_helpers.rb
@@ -6,6 +6,8 @@ module Calabash
     # @!visibility private
     module HTTPHelpers
 
+      require "calabash-cucumber/environment"
+
       # @!visibility private
       CAL_HTTP_RETRY_COUNT=3
 
@@ -33,7 +35,7 @@ module Calabash
 
       # @!visibility private
       def url_for(verb)
-        url = URI.parse(ENV['DEVICE_ENDPOINT']|| "http://localhost:37265")
+        url = URI.parse(Calabash::Cucumber::Environment.device_endpoint)
         path = url.path
         if path.end_with? "/"
           path = "#{path}#{verb}"

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -58,33 +58,24 @@ class Calabash::Cucumber::Launcher
 
   # @!visibility private
   attr_accessor :run_loop
+
   # @!visibility private
   attr_accessor :device
+
   # @!visibility private
   attr_accessor :actions
+
   # @!visibility private
   attr_accessor :launch_args
+
   # @!visibility private
   attr_reader :xcode
+
   # @!visibility private
   attr_reader :usage_tracker
+
   # @!visibility private
   attr_reader :device_endpoint
-
-  # @!visibility private
-  def xcode
-    @xcode ||= RunLoop::Xcode.new
-  end
-
-  # @!visibility private
-  def usage_tracker
-    @usage_tracker ||= Calabash::Cucumber::UsageTracker.new
-  end
-
-  # @!visibility private
-  def device_endpoint
-    @device_endpoint ||= Calabash::Cucumber::Environment.device_endpoint
-  end
 
   # @!visibility private
   def initialize
@@ -107,6 +98,21 @@ class Calabash::Cucumber::Launcher
   # @!visibility private
   def inspect
     to_s
+  end
+
+  # @!visibility private
+  def xcode
+    @xcode ||= RunLoop::Xcode.new
+  end
+
+  # @!visibility private
+  def usage_tracker
+    @usage_tracker ||= Calabash::Cucumber::UsageTracker.new
+  end
+
+  # @!visibility private
+  def device_endpoint
+    @device_endpoint ||= Calabash::Cucumber::Environment.device_endpoint
   end
 
   # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -259,7 +259,7 @@ Resetting physical devices is not supported.
     # NO_STOP
 
     args = {
-        :reset => reset_between_scenarios?,
+        :reset => Calabash::Cucumber::Environment.reset_between_scenarios?,
         :bundle_id => ENV['BUNDLE_ID'],
         :no_stop => calabash_no_stop?,
         :relaunch_simulator => true,
@@ -626,11 +626,6 @@ true.  Please remove this method call from your hooks.
     else
       false
     end
-  end
-
-  # @!visibility private
-  def reset_between_scenarios?
-    ENV['RESET_BETWEEN_SCENARIOS']=="1"
   end
 
   # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -30,7 +30,25 @@ class Calabash::Cucumber::Launcher
 
   include Calabash::Cucumber::Logging
 
-  # noinspection RubyClassVariableUsageInspection
+  # @!visibility private
+  # Generated when calabash cannot launch the app.
+  class StartError < RuntimeError
+    attr_accessor :error
+
+    def initialize(err)
+      self.error= err
+    end
+
+    # @!visibility private
+    def to_s
+      "#{super.to_s}: #{error}"
+    end
+  end
+
+  # @!visibility private
+  # Generated when calabash cannot communicate with the app.
+  class CalabashLauncherTimeoutErr < Timeout::Error
+  end
 
   # @!visibility private
   @@launcher = nil
@@ -51,25 +69,6 @@ class Calabash::Cucumber::Launcher
   attr_reader :xcode
   attr_reader :usage_tracker
 
-  # @!visibility private
-  # Generated when calabash cannot launch the app.
-  class StartError < RuntimeError
-    attr_accessor :error
-
-    def initialize(err)
-      self.error= err
-    end
-
-    # @!visibility private
-    def to_s
-      "#{super.to_s}: #{error}"
-    end
-  end
-
-  # @!visibility private
-  # Generated when calabash cannot communicate with the app.
-  class CalabashLauncherTimeoutErr < Timeout::Error
-  end
 
   def xcode
     @xcode ||= RunLoop::Xcode.new

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -46,16 +46,10 @@ class Calabash::Cucumber::Launcher
   end
 
   # @!visibility private
-  # Generated when calabash cannot communicate with the app.
-  class CalabashLauncherTimeoutErr < Timeout::Error
-  end
-
-  # @!visibility private
   @@launcher = nil
 
   # @!visibility private
   SERVER_VERSION_NOT_AVAILABLE = '0.0.0'
-  # noinspection RubyClassVariableUsageInspection
 
   # @!visibility private
   # Class variable for caching the embedded server version so we only need to

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -130,14 +130,14 @@ class Calabash::Cucumber::Launcher
 
   # @see Calabash::Cucumber::Core#console_attach
   def attach(options={})
-    default_options = {:max_retry => 1,
-                       :timeout => 10}
+    default_options = {:http_connection_retry => 1,
+                       :http_connection_timeout => 10}
     merged_options = default_options.merge(options)
 
     self.run_loop = RunLoop::HostCache.default.read
 
-    # Sets the device attribute.
-    ensure_connectivity(merged_options[:max_retry], merged_options[:timeout])
+    # Sets this Launcher#device attribute.
+    ensure_connectivity(merged_options)
 
     if self.run_loop[:pid]
       self.actions = Calabash::Cucumber::InstrumentsActions.new
@@ -495,43 +495,56 @@ Resetting physical devices is not supported.
   end
 
   # @!visibility private
-  def ensure_connectivity(max_retry=10, timeout=30)
-    begin
-      max_retry_count = (ENV['MAX_CONNECT_RETRY'] || max_retry).to_i
-      timeout = (ENV['CONNECT_TIMEOUT'] || timeout).to_i
-      retry_count = 0
-      connected = false
+  def ensure_connectivity(options={})
 
-      until connected do
-        if retry_count == max_retry_count
-          raise "Timed out connecting to Calabash server after #{max_retry_count} retries. Make sure it is linked and App isn't crashing"
-        end
-        retry_count += 1
-        begin
-          Timeout::timeout(timeout, CalabashLauncherTimeoutErr) do
-            until connected
-              begin
-                connected = (ping_app == '200')
-                break if connected
-              rescue StandardError => e
-                RunLoop.log_debug("Could not connect. #{e.message}")
-                RunLoop.log_debug("Will retry ...")
-              ensure
-                sleep 1 unless connected
-              end
-            end
-          end
-        rescue CalabashLauncherTimeoutErr => e
-          RunLoop.log_debug("Timed out after #{timeout} secs, trying to connect to Calabash server...")
-          RunLoop.log_debug("Will retry #{max_retry_count - retry_count}")
-        end
+    default_options = {
+      :http_connection_retry => Calabash::Cucumber::Environment.http_connection_retries,
+      :http_connection_timeout => Calabash::Cucumber::Environment.http_connection_timeout
+    }
+
+    merged_options = default_options.merge(options)
+
+    max_retry_count = merged_options[:http_connection_retry]
+    timeout = merged_options[:http_connection_timeout]
+
+    start_time = Time.now
+
+    max_retry_count.times do |try|
+      RunLoop.log_debug("Trying to connect to Calabash Server: #{try + 1} of #{max_retry_count}")
+
+      # Subtract the aggregate time we've spent thus far to make sure we're
+      # not exceeding the request timeout across retries.
+      time_diff = start_time + timeout - Time.now
+
+      if time_diff <= 0
+        break
       end
-    rescue RuntimeError => e
-      p e
-      msg = "Unable to make connection to Calabash Server at #{device_endpoint}\n"
-      msg << "Make sure you don't have a firewall blocking traffic to #{device_endpoint}.\n"
-      raise msg
+
+      begin
+        http_status = ping_app
+        return true if http_status == "200"
+      rescue => _
+
+      ensure
+        sleep(1)
+      end
     end
+
+    raise RuntimeError,
+%Q[Could not connect to the Calabash Server @ #{device_endpoint}.
+
+See these two guides for help.
+
+* https://github.com/calabash/calabash-ios/wiki/Testing-on-Physical-Devices
+* https://github.com/calabash/calabash-ios/wiki/Testing-on-iOS-Simulators
+
+1. Make sure your application is linked with Calabash.
+2. Make sure there is not a firewall blocking traffic on #{device_endpoint}.
+3. Make sure #{device_endpoint} is correct.
+
+If your app is crashing at launch, find a crash report to determine the cause.
+
+]
   end
 
   # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -68,6 +68,7 @@ class Calabash::Cucumber::Launcher
   attr_accessor :launch_args
   attr_reader :xcode
   attr_reader :usage_tracker
+  attr_reader :device_endpoint
 
 
   def xcode
@@ -76,6 +77,10 @@ class Calabash::Cucumber::Launcher
 
   def usage_tracker
     @usage_tracker ||= Calabash::Cucumber::UsageTracker.new
+  end
+
+  def device_endpoint
+    @device_endpoint ||= Calabash::Cucumber::Environment.device_endpoint
   end
 
   # @!visibility private
@@ -514,15 +519,15 @@ Resetting physical devices is not supported.
       end
     rescue RuntimeError => e
       p e
-      msg = "Unable to make connection to Calabash Server at #{ENV['DEVICE_ENDPOINT']|| "http://localhost:37265/"}\n"
-      msg << "Make sure you don't have a firewall blocking traffic to #{ENV['DEVICE_ENDPOINT']|| "http://localhost:37265/"}.\n"
+      msg = "Unable to make connection to Calabash Server at #{device_endpoint}\n"
+      msg << "Make sure you don't have a firewall blocking traffic to #{device_endpoint}.\n"
       raise msg
     end
   end
 
   # @!visibility private
   def ping_app
-    url = URI.parse(ENV['DEVICE_ENDPOINT']|| "http://localhost:37265/")
+    url = URI.parse(device_endpoint)
 
     http = Net::HTTP.new(url.host, url.port)
     res = http.start do |sess|

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -62,23 +62,32 @@ class Calabash::Cucumber::Launcher
   # check the server version one time.
   @@server_version = nil
 
+  # @!visibility private
   attr_accessor :run_loop
+  # @!visibility private
   attr_accessor :device
+  # @!visibility private
   attr_accessor :actions
+  # @!visibility private
   attr_accessor :launch_args
+  # @!visibility private
   attr_reader :xcode
+  # @!visibility private
   attr_reader :usage_tracker
+  # @!visibility private
   attr_reader :device_endpoint
 
-
+  # @!visibility private
   def xcode
     @xcode ||= RunLoop::Xcode.new
   end
 
+  # @!visibility private
   def usage_tracker
     @usage_tracker ||= Calabash::Cucumber::UsageTracker.new
   end
 
+  # @!visibility private
   def device_endpoint
     @device_endpoint ||= Calabash::Cucumber::Environment.device_endpoint
   end
@@ -88,7 +97,7 @@ class Calabash::Cucumber::Launcher
     @@launcher = self
   end
 
-  # @!visibilit private
+  # @!visibility private
   def to_s
     msg = ["#{self.class}"]
     if self.run_loop

--- a/calabash-cucumber/spec/lib/environment_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_spec.rb
@@ -1,6 +1,62 @@
 
 describe Calabash::Cucumber::Environment do
 
+  describe ".xcode" do
+    it "XTC returns nil" do
+      expect(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(true)
+
+      expect(Calabash::Cucumber::Environment.xcode).to be == nil
+    end
+
+    it "set class variable" do
+      expect(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(false)
+
+      actual = Calabash::Cucumber::Environment.xcode
+      expect(actual).to be_a_kind_of(RunLoop::Xcode)
+      expect(Calabash::Cucumber::Environment.class_variable_get(:@@xcode)).to be == actual
+    end
+  end
+
+  describe ".simctl" do
+    it "XTC returns nil" do
+      expect(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(true)
+
+      expect(Calabash::Cucumber::Environment.simctl).to be == nil
+    end
+
+    it "set class variable" do
+      expect(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(false)
+
+      actual = Calabash::Cucumber::Environment.simctl
+      expect(actual).to be_a_kind_of(RunLoop::SimControl)
+      expect(Calabash::Cucumber::Environment.class_variable_get(:@@simctl)).to be == actual
+    end
+  end
+
+  describe ".instruments" do
+    it "XTC returns nil" do
+      expect(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(true)
+
+      expect(Calabash::Cucumber::Environment.instruments).to be == nil
+    end
+
+    it "set class variable" do
+      expect(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(false)
+
+      actual = Calabash::Cucumber::Environment.instruments
+      expect(actual).to be_a_kind_of(RunLoop::Instruments)
+      expect(Calabash::Cucumber::Environment.class_variable_get(:@@instruments)).to be == actual
+    end
+  end
+
+  it ".xtc?" do
+    expect(RunLoop::Environment).to receive(:xtc?).and_return(true)
+    expect(Calabash::Cucumber::Environment.xtc?).to be_truthy
+
+    expect(RunLoop::Environment).to receive(:xtc?).and_return(false)
+    expect(Calabash::Cucumber::Environment.xtc?).to be_falsey
+  end
+
   describe ".device_target" do
     describe "DEVICE_TARGET is defined" do
       it "simulator" do

--- a/calabash-cucumber/spec/lib/environment_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_spec.rb
@@ -161,4 +161,32 @@ describe Calabash::Cucumber::Environment do
       expect(Calabash::Cucumber::Environment.reset_between_scenarios?).to be_falsey
     end
   end
+
+  describe ".run_loop_device" do
+    let(:identifier) { "some device id" }
+
+    before do
+      allow(Calabash::Cucumber::Environment).to receive(:device_target).and_return(identifier)
+    end
+
+    it "returns nil on the XTC" do
+      expect(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(true)
+
+      actual = Calabash::Cucumber::Environment.run_loop_device
+      expect(actual).to be == nil
+    end
+
+    it "returns a RunLoop::Device instance" do
+      allow(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(false)
+      options = {
+        :sim_control => Calabash::Cucumber::Environment.simctl,
+        :instruments => Calabash::Cucumber::Environment.instruments
+      }
+      expect(RunLoop::Device).to receive(:device_with_identifier).with(identifier, options).and_return(:device)
+
+
+      actual = Calabash::Cucumber::Environment.run_loop_device
+      expect(actual).to be == :device
+    end
+  end
 end

--- a/calabash-cucumber/spec/lib/environment_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_spec.rb
@@ -1,6 +1,8 @@
 
 describe Calabash::Cucumber::Environment do
 
+  let(:defaults) { Calabash::Cucumber::Environment::DEFAULTS }
+
   describe ".xcode" do
     it "XTC returns nil" do
       expect(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(true)
@@ -102,7 +104,45 @@ describe Calabash::Cucumber::Environment do
       expect(RunLoop::Environment).to receive(:device_endpoint).and_return(nil)
 
       actual = Calabash::Cucumber::Environment.device_endpoint
-      expect(actual).to be == Calabash::Cucumber::Environment::DEFAULT_AUT_ENDPOINT
+      expect(actual).to be == defaults[:aut_endpoint]
+    end
+  end
+
+  describe ".http_connection_retries" do
+    it "respects MAX_CONNECT_RETRIES" do
+      stub_env({"MAX_CONNECT_RETRIES" => 5})
+
+      actual = Calabash::Cucumber::Environment.http_connection_retries
+      expect(actual).to be == 5
+    end
+
+    it "fails back to the defaults" do
+      stub_env({"MAX_CONNECT_RETRIES" => nil})
+      actual = Calabash::Cucumber::Environment.http_connection_retries
+      expect(actual).to be == defaults[:http_connection_retries]
+
+      stub_env({"MAX_CONNECT_RETRIES" => ""})
+      actual = Calabash::Cucumber::Environment.http_connection_retries
+      expect(actual).to be == defaults[:http_connection_retries]
+    end
+  end
+
+  describe ".http_connection_timeout" do
+    it "respects CONNECTION_TIMEOUT" do
+      stub_env({"CONNECTION_TIMEOUT" => 5})
+
+      actual = Calabash::Cucumber::Environment.http_connection_timeout
+      expect(actual).to be == 5
+    end
+
+    it "falls back to defaults" do
+      stub_env({"CONNECTION_TIMEOUT" => nil})
+      actual = Calabash::Cucumber::Environment.http_connection_timeout
+      expect(actual).to be == defaults[:http_connection_timeout]
+
+      stub_env({"CONNECTION_TIMEOUT" => ""})
+      actual = Calabash::Cucumber::Environment.http_connection_timeout
+      expect(actual).to be == defaults[:http_connection_timeout]
     end
   end
 end

--- a/calabash-cucumber/spec/lib/environment_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_spec.rb
@@ -145,4 +145,20 @@ describe Calabash::Cucumber::Environment do
       expect(actual).to be == defaults[:http_connection_timeout]
     end
   end
+
+  describe ".reset_between_scenarios?" do
+    it "returns true" do
+      stub_env({"RESET_BETWEEN_SCENARIOS" => "1"})
+
+      expect(Calabash::Cucumber::Environment.reset_between_scenarios?).to be_truthy
+    end
+
+    it "returns false" do
+      stub_env({"RESET_BETWEEN_SCENARIOS" => nil})
+      expect(Calabash::Cucumber::Environment.reset_between_scenarios?).to be_falsey
+
+      stub_env({"RESET_BETWEEN_SCENARIOS" => 1})
+      expect(Calabash::Cucumber::Environment.reset_between_scenarios?).to be_falsey
+    end
+  end
 end

--- a/calabash-cucumber/spec/lib/environment_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_spec.rb
@@ -2,7 +2,6 @@
 describe Calabash::Cucumber::Environment do
 
   describe ".device_target" do
-
     describe "DEVICE_TARGET is defined" do
       it "simulator" do
         expect(RunLoop::Environment).to receive(:device_target).and_return("simulator")
@@ -32,6 +31,22 @@ describe Calabash::Cucumber::Environment do
 
       actual = Calabash::Cucumber::Environment.device_target
       expect(actual).to be == "Default Simulator"
+    end
+  end
+
+  describe ".device_endpoint" do
+    it "DEVICE_ENDPOINT is defined" do
+      expect(RunLoop::Environment).to receive(:device_endpoint).and_return("endpoint")
+
+      actual = Calabash::Cucumber::Environment.device_endpoint
+      expect(actual).to be == "endpoint"
+    end
+
+    it "DEVICE_ENDPOINT is not defined" do
+      expect(RunLoop::Environment).to receive(:device_endpoint).and_return(nil)
+
+      actual = Calabash::Cucumber::Environment.device_endpoint
+      expect(actual).to be == Calabash::Cucumber::Environment::DEFAULT_AUT_ENDPOINT
     end
   end
 end

--- a/calabash-cucumber/spec/lib/environment_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_spec.rb
@@ -2,24 +2,36 @@
 describe Calabash::Cucumber::Environment do
 
   describe ".device_target" do
-    describe "returns nil" do
-      it "DEVICE_TARGET is not defined" do
-        stub_env({"DEVICE_TARGET" => nil})
 
-        expect(Calabash::Cucumber::Environment.device_target).to be_falsey
+    describe "DEVICE_TARGET is defined" do
+      it "simulator" do
+        expect(RunLoop::Environment).to receive(:device_target).and_return("simulator")
+        expect(RunLoop::Core).to receive(:default_simulator).and_return("Default Simulator")
+
+        actual = Calabash::Cucumber::Environment.device_target
+        expect(actual).to be == "Default Simulator"
       end
 
-      it "DEVICE_TARGET is the empty string" do
-        stub_env({"DEVICE_TARGET" => ""})
+      it "device" do
+        expect(RunLoop::Environment).to receive(:device_target).and_return("device")
+        expect(RunLoop::Core).to receive(:detect_connected_device).and_return("a udid")
 
-        expect(Calabash::Cucumber::Environment.device_target).to be_falsey
+        actual = Calabash::Cucumber::Environment.device_target
+        expect(actual).to be == "a udid"
+      end
+
+      it "anything else" do
+        expect(RunLoop::Environment).to receive(:device_target).and_return("a")
+        expect(Calabash::Cucumber::Environment.device_target).to be == "a"
       end
     end
 
-    it "returns the value of DEVICE_TARGET" do
-      stub_env({"DEVICE_TARGET" => "anything"})
+    it "DEVICE_TARGET is not defined" do
+      expect(RunLoop::Environment).to receive(:device_target).and_return(nil)
+      expect(RunLoop::Core).to receive(:default_simulator).and_return("Default Simulator")
 
-      expect(Calabash::Cucumber::Environment.device_target).to be == "anything"
+      actual = Calabash::Cucumber::Environment.device_target
+      expect(actual).to be == "Default Simulator"
     end
   end
 end

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -20,6 +20,19 @@ describe 'Calabash Launcher' do
     RunLoop::SimControl.terminate_all_sims
   }
 
+  it "#device_endpoint" do
+    expect(Calabash::Cucumber::Environment).to receive(:device_endpoint).and_return("endpoint")
+
+    expect(launcher.device_endpoint).to be == "endpoint"
+    expect(launcher.instance_variable_get(:@device_endpoint)).to be == "endpoint"
+  end
+
+  it "#usage_tracker" do
+    actual = launcher.usage_tracker
+    expect(actual).to be_a_kind_of(Calabash::Cucumber::UsageTracker)
+    expect(launcher.instance_variable_get(:@usage_tracker)).to be == actual
+  end
+
   describe "#reset_simulator" do
     describe "raises an error when" do
       it "DEVICE_TARGET is a device UDID" do


### PR DESCRIPTION
### Motivation

I am preparing the Launcher class to be able to launch apps with the CBXDriver.

The purpose of this PR is to:

* remove dead code
* provide an sane interface to the ENV

Along the way I rewrote the `ensure_connectivity` method because it was incredibly confusing.