### PR TITLE
Remove more deprecated Device behaviors

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -273,19 +273,6 @@ module Calabash
         ios_version_object.major == 5
       end
 
-      # @deprecated 0.11.2 Replaced with screen_dimensions.
-      #
-      # The screen size of the device.
-      #
-      # @return [Hash] representation of the screen size
-      def screen_size
-        _deprecated('0.11.2', 'Replaced with screen_dimensions', :warn)
-        return screen_dimensions if screen_dimensions
-        return { :width => 768, :height => 1024 } if ipad?
-        return { :width => 320, :height => 568 } if iphone_4in?
-        { :width => 320, :height => 480 }
-      end
-
       # Is the app that is running an iPhone-only app emulated on an iPad?
       #
       # @note If the app is running in emulation mode, there will be a 1x or 2x

--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -166,27 +166,10 @@ module Calabash
           end
         end
 
-        # Deprecated 0.16.2 server
-        @system = version_data['system']
-
-        # 0.16.2 server adds 'device_family' key.
-        unless @device_family
-          # Deprecated 0.16.2 server
-          simulator_device = version_data['simulator_device']
-          if @system == GESTALT_SIM_SYS
-            @device_family = simulator_device
-          else
-            @device_family = @system.split(/[\d,.]/).first
-          end
-        end
-
         # 0.16.2 server adds 'ios_version' key
         unless @ios_version
           @ios_version = version_data['iOS_version']
         end
-
-        # Deprecated 0.13.0
-        @iphone_4in = version_data['4inch']
       end
 
       # Is this device a simulator or physical device?

--- a/calabash-cucumber/spec/integration/device_spec.rb
+++ b/calabash-cucumber/spec/integration/device_spec.rb
@@ -31,9 +31,6 @@ unless Luffa::Environment.travis_ci?
       expect(device.form_factor).to be == 'iphone 4in'
       expect(device.device_name).to be == 'iPhone Simulator'
       expect(device.screen_dimensions.count).to be == 4
-
-      # deprecated
-      expect(device.system).to be_truthy
     end
 
     describe '#form_factor' do
@@ -55,71 +52,45 @@ unless Luffa::Environment.travis_ci?
       subject { device.form_factor }
 
       context 'device is an ipad' do
-        let(:device_target) {
-          if xcode.version_gte_6?
-            Resources.shared.simulator_identifier_with_name('iPad Retina')
-          else
-            'iPad Retina (64-bit) - Simulator - iOS 7.1'
-          end
-        }
+        let(:device_target) do
+          Resources.shared.simulator_identifier_with_name('iPad Retina')
+        end
         it { is_expected.to be == 'ipad' }
       end
 
       context 'iPhone 5 is an 4in iphone' do
-        let(:device_target) {
-          if xcode.version_gte_6?
-            Resources.shared.simulator_identifier_with_name('iPhone 5')
-          else
-            'iPhone Retina (4-inch) - Simulator - iOS 7.1'
-          end
-        }
+        let(:device_target) do
+          Resources.shared.simulator_identifier_with_name('iPhone 5')
+        end
         it { is_expected.to be == 'iphone 4in' }
       end
 
       context 'iPhone 5s is an 4in iphone' do
-        let(:device_target) {
-          if xcode.version_gte_6?
-            Resources.shared.simulator_identifier_with_name('iPhone 5s')
-          else
-            'iPhone Retina (4-inch) - Simulator - iOS 7.1'
-          end
-        }
+        let(:device_target) do
+          Resources.shared.simulator_identifier_with_name('iPhone 5s')
+        end
         it { is_expected.to be == 'iphone 4in' }
       end
 
       context 'device is a 3.5" iphone' do
-        let(:device_target) {
-          if xcode.version_gte_6?
-            Resources.shared.simulator_identifier_with_name('iPhone 4s')
-          else
-            'iPhone Retina (3.5-inch) - Simulator - iOS 7.1'
-          end
-        }
+        let(:device_target) do
+          Resources.shared.simulator_identifier_with_name('iPhone 4s')
+        end
         it { is_expected.to be == 'iphone 3.5in' }
       end
 
       context 'device is an iphone 6' do
-        let(:device_target) {
-          if xcode.version_gte_6?
-            Resources.shared.simulator_identifier_with_name('iPhone 6')
-          else
-            # iPhone 6 does not exist on Xcode < 6
-            nil
-          end
-        }
-        it { is_expected.to be == 'iphone 6' if device_target }
+        let(:device_target) do
+          Resources.shared.simulator_identifier_with_name('iPhone 6')
+        end
+        it { is_expected.to be == 'iphone 6' }
       end
 
       context 'device is an iphone 6+' do
-        let(:device_target) {
-          if xcode.version_gte_6?
-            Resources.shared.simulator_identifier_with_name('iPhone 6 Plus')
-          else
-            # iPhone 6 does not exist on Xcode < 6
-            nil
-          end
-        }
-        it { is_expected.to be == 'iphone 6+' if device_target }
+        let(:device_target) do
+          Resources.shared.simulator_identifier_with_name('iPhone 6 Plus')
+        end
+        it { is_expected.to be == 'iphone 6+' }
       end
     end
   end

--- a/calabash-cucumber/spec/lib/device_spec.rb
+++ b/calabash-cucumber/spec/lib/device_spec.rb
@@ -70,16 +70,6 @@ describe Calabash::Cucumber::Device do
       expect(device.instance_variable_get(:@form_factor)).to be == 'form'
     end
 
-    it 'sets @system # deprecated' do
-      expect(device.instance_variable_get(:@system)).to be == ''
-    end
-
-    it 'sets @iphone_4in # deprecated' do
-      version_data['4inch'] = 'deprecated'
-
-      expect(device.instance_variable_get(:@iphone_4in)).to be == 'deprecated'
-    end
-
     describe 'sets @device_family' do
       it "uses 'device_family' if it is available" do
         version_data['device_family'] = 'first element only'
@@ -87,28 +77,6 @@ describe Calabash::Cucumber::Device do
 
         expect(device.device_family).to be == 'first'
         expect(device.instance_variable_get(:@device_family)).to be == 'first'
-      end
-
-      describe "parses 'system' if it is not available # deprecated" do
-        it 'is a simulator' do
-          # deprecated key
-          version_data['simulator_device'] = 'iPhone'
-          version_data['device_family'] = nil
-          version_data['system'] = 'x86_64'
-
-          expect(device.device_family).to be == 'iPhone'
-          expect(device.instance_variable_get(:@device_family)).to be == 'iPhone'
-        end
-
-        it 'is a device' do
-          # deprecated key
-          version_data['simulator_device'] = nil
-          version_data['device_family'] = nil
-          version_data['system'] = 'iPad5,4'
-
-          expect(device.device_family).to be == 'iPad'
-          expect(device.instance_variable_get(:@device_family)).to be == 'iPad'
-        end
       end
     end
 

--- a/script/ci/jenkins/rspec.sh
+++ b/script/ci/jenkins/rspec.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 cd calabash-cucumber
-rbenv local 2.2.3
-gem uninstall -Vax --force --no-abort-on-dependent run_loop
 bundle update
 rm -rf spec/reports
+
 rbenv exec \
   bundle exec \
   rspec \
@@ -14,4 +13,9 @@ rbenv exec \
   bundle exec \
   rspec \
   spec/bin/calabash_ios_sim_spec.rb
+
+rbenv exec \
+  bundle exec \
+  rspec \
+  spec/integration/device_spec.rb
 


### PR DESCRIPTION
### Motivation

While trying to decide if `Calabash::Cucumber::Device` should be a subclass of `RunLoop::Device`, I came across more deprecated methods.