### PR TITLE
Replace NO_STOP with QUIT_APP_AFTER_SCENARIO

### DIFF
--- a/calabash-cucumber/ENVIRONMENT_VARIABLES.md
+++ b/calabash-cucumber/ENVIRONMENT_VARIABLES.md
@@ -25,6 +25,10 @@ The following variables are no longer used by Calabash.
 * `http_proxy`
 * `CALABASH_VERSION_PATH`
 
+### 0.19.0
+
+* `NO_STOP` - replaced with QUIT_APP_AFTER_SCENARIO
+
 ## Conventions
 
 Variables that take boolean values should be passed as `0` or `1`, _not_ as `true` or `false`.
@@ -264,7 +268,7 @@ instruments -s devices
 
 Device UDIDs should be private.  When posting debug output on the web, do not post un-obscured device UDIDs.
 
-### `NO_STOP`
+### `QUIT_APP_AFTER_SCENARIO`
 
 Use this to control whether or not calabash will exit your application after the cucumber tests have completed.
 
@@ -273,23 +277,22 @@ Here is an example Cucumber After hook.
 ```
 After do |scenario|
   launcher = Calabash::Cucumber::Launcher.new
-  unless launcher.calabash_no_stop?
+  unless launcher.quit_app_after_scenario?
     calabash_exit
-    launcher.stop
   end
 end
 ```
 
-If `NO_STOP=1`, then `calabash_exit` and `launcher.stop` will _not_ be called and your application will remain running after Cucumber finishes.  This variable is commonly used with {Calabash::Cucumber::Core#console_attach} to debug failing Scenarios.
+If `QUIT_APP_AFTER_SCENARIO=0`, then `calabash_exit` will _not_ be called and your application will remain running after Cucumber finishes.  This variable is commonly used with {Calabash::Cucumber::Core#console_attach} to debug failing Scenarios.
 
-#### Pro Tip:  Use NO_STOP=1, console_attach, and the @wip tag to debug failing Scenarios.
+#### Pro Tip:  Use QUIT_APP_AFTER_SCENARIO=0, console_attach, and the @wip tag to debug failing Scenarios.
 
-When debugging a failing Scenario, use `NO_STOP=1` to prohibit calabash from exiting your application, open a console, call `console_attach`, and explore your application from the command line.
+When debugging a failing Scenario, use `QUIT_APP_AFTER_SCENARIO=1` to prohibit calabash from exiting your application, open a console, call `console_attach`, and explore your application from the command line.
 
 ```
 1. Tag your failing Scenario with @wip (Work in Progress).
 2. Run just that Scenario.
-   $ NO_STOP=1 bundle exec cucumber -t @wip
+   $ QUIT_APP_AFTER_SCENARIO=0 bundle exec cucumber -t @wip
 3. When it fails, the application will remain open.
 4. Open a console and call console_attach
    $ bundle exec calabash-ios console

--- a/calabash-cucumber/features-skeleton/support/01_launch.rb
+++ b/calabash-cucumber/features-skeleton/support/01_launch.rb
@@ -37,7 +37,7 @@ After do |scenario|
   #
   # http://calabashapi.xamarin.com/ios/file.ENVIRONMENT_VARIABLES.html#label-QUIT_APP_AFTER_SCENARIO
   # http://calabashapi.xamarin.com/ios/Calabash/Cucumber/Core.html#console_attach-instance_method
-  unless launcher.quit_app_after_scenario?
+  if launcher.quit_app_after_scenario?
     calabash_exit
   end
 end

--- a/calabash-cucumber/features-skeleton/support/01_launch.rb
+++ b/calabash-cucumber/features-skeleton/support/01_launch.rb
@@ -33,11 +33,11 @@ After do |scenario|
   # in the UIApplicationDelegate.  This is really nice for CI environments, but
   # not so good for local development.
   #
-  # See the documentation for NO_STOP for a nice debugging workflow
+  # See the documentation for QUIT_APP_AFTER_SCENARIO for a nice debugging workflow
   #
-  # http://calabashapi.xamarin.com/ios/file.ENVIRONMENT_VARIABLES.html#label-NO_STOP
+  # http://calabashapi.xamarin.com/ios/file.ENVIRONMENT_VARIABLES.html#label-QUIT_APP_AFTER_SCENARIO
   # http://calabashapi.xamarin.com/ios/Calabash/Cucumber/Core.html#console_attach-instance_method
-  unless launcher.calabash_no_stop?
+  unless launcher.quit_app_after_scenario?
     calabash_exit
   end
 end

--- a/calabash-cucumber/lib/calabash-cucumber/environment.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment.rb
@@ -2,6 +2,8 @@ module Calabash
   module Cucumber
     module Environment
 
+      require "run_loop"
+
       # @!visibility private
       DEFAULTS = {
         # The endpoint of the app under test
@@ -97,6 +99,49 @@ module Calabash
       # @!visibility private
       def self.reset_between_scenarios?
         ENV["RESET_BETWEEN_SCENARIOS"] == "1"
+      end
+
+      # @!visibility private
+      def self.quit_app_after_scenario?
+        value = ENV["QUIT_APP_AFTER_SCENARIO"]
+
+        if value == "0"
+          false
+        elsif value == "1"
+          true
+        else
+          !self.no_stop?
+        end
+      end
+
+      private
+
+      # @visibility private
+      # @deprecated 0.19.0 - replaced with QUIT_APP_AFTER_SCENARIO
+      def self.no_stop?
+        value = ENV["NO_STOP"]
+        if value
+          return_value = value == "1"
+
+          if return_value
+            replacement = "$ QUIT_APP_AFTER_SCENARIO=0"
+          else
+            replacement = "$ QUIT_APP_AFTER_SCENARIO=1"
+          end
+          RunLoop.deprecated("0.19.0",
+%Q{The 'NO_STOP' env variable has been been replaced with: QUIT_APP_AFTER_SCENARIO
+
+Please replace NO_STOP with QUIT_APP_AFTER_SCENARIO.
+
+#{replacement}
+
+The default behavior is to quit the app after each scenario.
+})
+
+          return_value
+        else
+          false
+        end
       end
     end
   end

--- a/calabash-cucumber/lib/calabash-cucumber/environment.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment.rb
@@ -118,11 +118,14 @@ module Calabash
 
       # @visibility private
       # @deprecated 0.19.0 - replaced with QUIT_APP_AFTER_SCENARIO
+      #
+      # Silently deprecated.  Deprecate in 0.20.0.
       def self.no_stop?
         value = ENV["NO_STOP"]
         if value
           return_value = value == "1"
 
+=begin
           if return_value
             replacement = "$ QUIT_APP_AFTER_SCENARIO=0"
           else
@@ -137,7 +140,7 @@ Please replace NO_STOP with QUIT_APP_AFTER_SCENARIO.
 
 The default behavior is to quit the app after each scenario.
 })
-
+=end
           return_value
         else
           false

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -19,8 +19,8 @@ require "calabash-cucumber/usage_tracker"
 # use `console_attach`.  This is useful when a cucumber Scenario has failed and
 # you want to query the current state of the app.
 #
-# * **Pro Tip:** set the `NO_STOP` environmental variable to 1 so calabash does
-#  not exit the simulator when a Scenario fails.
+# * **Pro Tip:** Set the `QUIT_APP_AFTER_SCENARIO=0` env variable so calabash
+# does not quit your application after a failed Scenario.
 class Calabash::Cucumber::Launcher
 
   require "calabash-cucumber/dylibs"
@@ -253,7 +253,7 @@ Resetting physical devices is not supported.
     # DEVICE_TARGET
     # RESET_BETWEEN_SCENARIOS
     # DEVICE
-    # NO_STOP
+    # QUIT_APP_AFTER_SCENARIO
 
     args = {
         :reset => Calabash::Cucumber::Environment.reset_between_scenarios?,

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -582,7 +582,7 @@ If your app is crashing at launch, find a crash report to determine the cause.
   def calabash_no_stop?
     # Not yet.  Save for 0.20.0.
     # RunLoop.deprecated("0.19.0", "replaced with quit_app_after_scenario")
-    quit_app_after_scenario?
+    !quit_app_after_scenario?
   end
 
   # Should Calabash quit the app under test after each Scenario?

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -580,7 +580,8 @@ If your app is crashing at launch, find a crash report to determine the cause.
   # @deprecated 0.19.0 - replaced with #quit_app_after_scenario?
   # @!visibility private
   def calabash_no_stop?
-    RunLoop.deprecated("0.19.0", "replaced with quit_app_after_scenario")
+    # Not yet.  Save for 0.20.0.
+    # RunLoop.deprecated("0.19.0", "replaced with quit_app_after_scenario")
     quit_app_after_scenario?
   end
 

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -258,7 +258,8 @@ Resetting physical devices is not supported.
     args = {
         :reset => Calabash::Cucumber::Environment.reset_between_scenarios?,
         :bundle_id => ENV['BUNDLE_ID'],
-        :no_stop => calabash_no_stop?,
+        # TODO: Deprecate this key.  Use :quit_app_after_scenario.
+        :no_stop => quit_app_after_scenario?,
         :relaunch_simulator => true,
         # Do not advertise this to users!
         # For example, don't include documentation about this option.
@@ -576,9 +577,18 @@ If your app is crashing at launch, find a crash report to determine the cause.
     end
   end
 
+  # @deprecated 0.19.0 - replaced with #quit_app_after_scenario?
   # @!visibility private
   def calabash_no_stop?
-    ENV['NO_STOP']=="1"
+    RunLoop.deprecated("0.19.0", "replaced with quit_app_after_scenario")
+    quit_app_after_scenario?
+  end
+
+  # Should Calabash quit the app under test after each Scenario?
+  #
+  # Control this behavior using the QUIT_APP_AFTER_SCENARIO variable.
+  def quit_app_after_scenario?
+    Calabash::Cucumber::Environment.quit_app_after_scenario?
   end
 
   # @deprecated 0.19.0

--- a/calabash-cucumber/spec/lib/environment_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_spec.rb
@@ -189,4 +189,70 @@ describe Calabash::Cucumber::Environment do
       expect(actual).to be == :device
     end
   end
+
+  describe "Quitting the app after each Scenario" do
+    describe ".quit_app_after_scenario?" do
+      it "QUIT_APP_AFTER_SCENARIO=0" do
+        stub_env({"QUIT_APP_AFTER_SCENARIO" => "0"})
+
+        expect(Calabash::Cucumber::Environment.quit_app_after_scenario?).to be_falsey
+      end
+
+      it "QUIT_APP_AFTER_SCENARIO=1" do
+        stub_env({"QUIT_APP_AFTER_SCENARIO" => "1"})
+
+        expect(Calabash::Cucumber::Environment.quit_app_after_scenario?).to be_truthy
+      end
+
+      describe "QUIT_APP_AFTER_SCENARIO vs NO_STOP" do
+        before do
+          stub_env({"QUIT_APP_AFTER_SCENARIO" => nil})
+        end
+
+        it "NO_STOP=1" do
+          stub_env({"NO_STOP" => "1"})
+
+          expect(Calabash::Cucumber::Environment.quit_app_after_scenario?).to be_falsey
+        end
+
+        it "NO_STOP=0" do
+          stub_env({"NO_STOP" => "0"})
+
+          expect(Calabash::Cucumber::Environment.quit_app_after_scenario?).to be_truthy
+        end
+
+        it "NO_STOP is undefined" do
+          stub_env({"NO_STOP" => ""})
+          expect(Calabash::Cucumber::Environment.quit_app_after_scenario?).to be_truthy
+
+          stub_env({"NO_STOP" => nil})
+          expect(Calabash::Cucumber::Environment.quit_app_after_scenario?).to be_truthy
+        end
+      end
+    end
+    describe ".no_stop?" do
+      describe "NO_STOP is defined" do
+        it "is 1" do
+          stub_env({"NO_STOP" => "1"})
+          expect(RunLoop).to receive(:deprecated).and_call_original
+
+          expect(Calabash::Cucumber::Environment.send(:no_stop?)).to be_truthy
+        end
+
+        it "is not 1" do
+          stub_env({"NO_STOP" => "0"})
+          expect(RunLoop).to receive(:deprecated).and_call_original
+
+          expect(Calabash::Cucumber::Environment.send(:no_stop?)).to be_falsey
+        end
+      end
+
+      it "NO_STOP is undefined" do
+        stub_env({"NO_STOP" => nil})
+        expect(RunLoop).not_to receive(:deprecated)
+
+        expect(Calabash::Cucumber::Environment.send(:no_stop?)).to be_falsey
+      end
+    end
+  end
 end

--- a/calabash-cucumber/spec/lib/environment_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_spec.rb
@@ -235,14 +235,14 @@ describe Calabash::Cucumber::Environment do
       describe "NO_STOP is defined" do
         it "is 1" do
           stub_env({"NO_STOP" => "1"})
-          expect(RunLoop).to receive(:deprecated).and_call_original
+          expect(RunLoop).not_to receive(:deprecated).and_call_original
 
           expect(Calabash::Cucumber::Environment.send(:no_stop?)).to be_truthy
         end
 
         it "is not 1" do
           stub_env({"NO_STOP" => "0"})
-          expect(RunLoop).to receive(:deprecated).and_call_original
+          expect(RunLoop).not_to receive(:deprecated).and_call_original
 
           expect(Calabash::Cucumber::Environment.send(:no_stop?)).to be_falsey
         end

--- a/calabash-cucumber/spec/lib/environment_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_spec.rb
@@ -230,6 +230,7 @@ describe Calabash::Cucumber::Environment do
         end
       end
     end
+
     describe ".no_stop?" do
       describe "NO_STOP is defined" do
         it "is 1" do

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -37,7 +37,7 @@ describe 'Calabash Launcher' do
     it "#calabash_no_stop?" do
       expect(launcher).to receive(:quit_app_after_scenario?).and_return(:value)
 
-      expect(RunLoop).to receive(:deprecated).and_call_original
+      expect(RunLoop).not_to receive(:deprecated).and_call_original
       expect(launcher.calabash_no_stop?).to be == :value
     end
 

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -35,10 +35,13 @@ describe 'Calabash Launcher' do
 
   describe "#quit_app_after_scenario?" do
     it "#calabash_no_stop?" do
-      expect(launcher).to receive(:quit_app_after_scenario?).and_return(:value)
-
+      expect(launcher).to receive(:quit_app_after_scenario?).and_return(false)
       expect(RunLoop).not_to receive(:deprecated).and_call_original
-      expect(launcher.calabash_no_stop?).to be == :value
+      expect(launcher.calabash_no_stop?).to be_truthy
+
+      expect(launcher).to receive(:quit_app_after_scenario?).and_return(true)
+      expect(RunLoop).not_to receive(:deprecated).and_call_original
+      expect(launcher.calabash_no_stop?).to be_falsey
     end
 
     it "calls out to Environment" do

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -33,6 +33,21 @@ describe 'Calabash Launcher' do
     expect(launcher.instance_variable_get(:@usage_tracker)).to be == actual
   end
 
+  describe "#quit_app_after_scenario?" do
+    it "#calabash_no_stop?" do
+      expect(launcher).to receive(:quit_app_after_scenario?).and_return(:value)
+
+      expect(RunLoop).to receive(:deprecated).and_call_original
+      expect(launcher.calabash_no_stop?).to be == :value
+    end
+
+    it "calls out to Environment" do
+      expect(Calabash::Cucumber::Environment).to receive(:quit_app_after_scenario?).and_return(:value)
+
+      expect(launcher.quit_app_after_scenario?).to be == :value
+    end
+  end
+
   describe "#reset_simulator" do
     describe "raises an error when" do
       it "DEVICE_TARGET is a device UDID" do


### PR DESCRIPTION
### Motivation

The `NO_STOP` variable has long and troubled past. It has meant:

* don't quit the simulator after each scenario
* don't quit the app after each scenario

The double-negative semantics have always been confusing:  

* `NO_STOP=1` means Don't stop something
* `NO_STOP=0` means Do stop something
* `NO_STOP` undefined means Do stop something

`QUIT_APP_AFTER_SCENARIO`, on the other hand, is unambiguous.

* `QUIT_APP_AFTER_SCENARIO=0` - Don't quit the app after each Scenario
* `QUIT_APP_AFTER_SCENARIO=1` -  Do quit the app after each Scenario
* `QUIT_APP_AFTER_SCENARIO` undefined - Do quit the app after each Scenario

I have added support for the new ENV var and updated the hooks and docs.

I am not generating deprecated warnings yet - there is a lot to swallow in 0.19.0.  The plan is to add the the deprecated warnings in 0.20.0 and to remove support sometime after a 0.21.0 release.

**NO_STOP and associated methods should generate deprecation warnings** #1037

This is all part of my effort to trim the launcher down to a manageable size before adding XCUITest launch support.