### PR TITLE
Move http methods out of launcher

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber.rb
+++ b/calabash-cucumber/lib/calabash-cucumber.rb
@@ -4,6 +4,7 @@ require "calabash-cucumber/dot_dir"
 require "calabash-cucumber/store/preferences"
 require "calabash-cucumber/usage_tracker.rb"
 require "calabash-cucumber/dylibs"
+require "calabash-cucumber/http/http"
 require 'calabash-cucumber/core'
 require 'calabash-cucumber/tests_helpers'
 require 'calabash-cucumber/keyboard_helpers'

--- a/calabash-cucumber/lib/calabash-cucumber/actions/instruments_actions.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/actions/instruments_actions.rb
@@ -116,17 +116,16 @@ class Calabash::Cucumber::InstrumentsActions
   def normalize_rect_for_orientation!(orientation, rect)
     orientation = orientation.to_sym
     launcher = Calabash::Cucumber::Launcher.launcher
+    device = launcher.device
 
     # Coordinate translations for orientation is handled in the server for iOS 8+
-    # https://developer.apple.com/library/ios/documentation/UIKit/Reference/UICoordinateSpace_protocol/index.html
-    if launcher.ios_major_version.to_i >= 8
+    if device.ios_major_version.to_i >= 8
       return
     end
 
     # We cannot use Device#screen_dimensions here because on iPads the height
     # and width are the opposite of what we expect.
     # @todo Move all coordinate/orientation translation into the server.
-    device = launcher.device
     if device.ipad?
       screen_size = { :width => 768, :height => 1024 }
     elsif device.iphone_4in?

--- a/calabash-cucumber/lib/calabash-cucumber/http/http.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/http/http.rb
@@ -1,0 +1,91 @@
+module Calabash
+  module Cucumber
+
+    # Raised when a connection to the embedded server cannot be made.
+    class ServerNotRespondingError < RuntimeError; end
+
+    # @!visibility private
+    class HTTP
+
+      require "calabash-cucumber/environment"
+      require "run_loop"
+
+      # @!visibility private
+      def self.ping_app
+        endpoint = Calabash::Cucumber::Environment.device_endpoint
+        url = URI.parse(endpoint)
+
+        http = Net::HTTP.new(url.host, url.port)
+        response = http.start do |sess|
+          sess.request(Net::HTTP::Get.new("version"))
+        end
+
+        body = nil
+        success = response.is_a?(Net::HTTPSuccess)
+        if success
+          body = response.body
+        end
+
+        http.finish if http and http.started?
+
+        return success, body
+      end
+
+      # @!visibility private
+      def self.ensure_connectivity(options={})
+
+        default_options = {
+          :http_connection_retry => Calabash::Cucumber::Environment.http_connection_retries,
+          :http_connection_timeout => Calabash::Cucumber::Environment.http_connection_timeout
+        }
+
+        merged_options = default_options.merge(options)
+
+        max_retry_count = merged_options[:http_connection_retry]
+        timeout = merged_options[:http_connection_timeout]
+
+        start_time = Time.now
+
+        max_retry_count.times do |try|
+          RunLoop.log_debug("Trying to connect to Calabash Server: #{try + 1} of #{max_retry_count}")
+
+          # Subtract the aggregate time we've spent thus far to make sure we're
+          # not exceeding the request timeout across retries.
+          time_diff = start_time + timeout - Time.now
+
+          if time_diff <= 0
+            break
+          end
+
+          begin
+            success, body = self.ping_app
+            return success, body if success
+          rescue => _
+
+          ensure
+            sleep(1)
+          end
+        end
+
+        endpoint = Calabash::Cucumber::Environment.device_endpoint
+
+        raise Calabash::Cucumber::ServerNotRespondingError,
+              %Q[Could not connect to the Calabash Server @ #{endpoint}.
+
+See these two guides for help.
+
+* https://github.com/calabash/calabash-ios/wiki/Testing-on-Physical-Devices
+* https://github.com/calabash/calabash-ios/wiki/Testing-on-iOS-Simulators
+
+1. Make sure your application is linked with Calabash.
+2. Make sure there is not a firewall blocking traffic on #{endpoint}.
+3. Make sure #{endpoint} is correct.
+
+If your app is crashing at launch, find a crash report to determine the cause.
+
+]
+      end
+    end
+  end
+end
+

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -238,23 +238,6 @@ Queries will work, but gestures will not.
         @@launcher
       end
 
-      # "Major" component of the current iOS version of the device
-      # @return {String} the "major" component, e.g., "7" for "7.1.1"
-      def ios_major_version
-        # pinging the app will set self.device
-        ping_app if self.device.nil?
-        # guard against Runtime errors
-        return nil if device.nil? or device.ios_version.nil?
-        device.ios_major_version
-      end
-
-      # the current iOS version of the device
-      # @return {String} the current iOS version of the device
-      def ios_version
-        return nil if device.nil?
-        device.ios_version
-      end
-
       # Erases a simulator. This is the same as touching the Simulator
       # "Reset Content & Settings" menu item.
       #

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -64,9 +64,6 @@ module Calabash
       attr_accessor :run_loop
 
       # @!visibility private
-      attr_accessor :device
-
-      # @!visibility private
       attr_accessor :actions
 
       # @!visibility private
@@ -109,6 +106,31 @@ module Calabash
       # @raise Raises an error if the server does not respond.
       def ping_app
         Calabash::Cucumber::HTTP.ping_app
+      end
+
+      # @!visibility private
+      #
+      # This Calabash::Cucumber::Device instance is required because we cannot
+      # determine the iOS version of physical devices.
+      #
+      # This device instance can only be created _if the server is running_.
+      #
+      # We need this instance because we need to know at runtime whether or
+      # not to translate touch coordinates in the client or on the server. For
+      # iOS >= 8.0 translation is done on the server.  Further, we need a
+      # Device instance for iOS < 8 so we can perform the necessary
+      # coordinate normalization - based on the device attributes.
+      #
+      # We also need this information to determine the default uia strategy.
+      #
+      # +1 for tools to ask physical devices about attributes.
+      def device
+        @device ||= lambda do
+          _, body = Calabash::Cucumber::HTTP.ensure_connectivity
+          response = JSON.parse(body)
+          endpoint = Calabash::Cucumber::Environment.device_endpoint
+          Calabash::Cucumber::Device.new(endpoint, response)
+        end.call
       end
 
       # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -18,9 +18,6 @@ module Calabash
     # Raised when Calabash cannot find a device based on DEVICE_TARGET
     class DeviceNotFoundError < RuntimeError ; end
 
-    # Raised when a connection to the embedded server cannot be made.
-    class ServerNotRespondingError < RuntimeError; end
-
     # Launch apps on iOS Simulators and physical devices.
     #
     # ###  Accessing the current launcher from ruby.
@@ -46,6 +43,7 @@ module Calabash
       require "calabash-cucumber/usage_tracker"
       require "calabash-cucumber/dylibs"
       require "calabash-cucumber/environment"
+      require "calabash-cucumber/http/http"
       require "run_loop"
 
       # @!visibility private
@@ -81,9 +79,6 @@ module Calabash
       attr_reader :usage_tracker
 
       # @!visibility private
-      attr_reader :device_endpoint
-
-      # @!visibility private
       def initialize
         @@launcher = self
       end
@@ -107,6 +102,16 @@ module Calabash
       end
 
       # @!visibility private
+      #
+      # Use this method to see if your app is already running.  This is helpful
+      # if you have Scenarios that don't require an app relaunch.
+      #
+      # @raise Raises an error if the server does not respond.
+      def ping_app
+        Calabash::Cucumber::HTTP.ping_app
+      end
+
+      # @!visibility private
       def xcode
         @xcode ||= RunLoop::Xcode.new
       end
@@ -114,11 +119,6 @@ module Calabash
       # @!visibility private
       def usage_tracker
         @usage_tracker ||= Calabash::Cucumber::UsageTracker.new
-      end
-
-      # @!visibility private
-      def device_endpoint
-        @device_endpoint ||= Calabash::Cucumber::Environment.device_endpoint
       end
 
       # @!visibility private
@@ -146,10 +146,10 @@ module Calabash
 
         set_device_target_after_attach(self.run_loop)
 
-        # Sets this Launcher#device attribute.
         begin
-          ensure_connectivity(merged_options)
+          Calabash::Cucumber::HTTP.ensure_connectivity(merged_options)
         rescue Calabash::Cucumber::ServerNotRespondingError => _
+          device_endpoint = Calabash::Cucumber::Environment.device_endpoint
           RunLoop.log_warn(
 %Q[
 
@@ -430,7 +430,7 @@ Resetting physical devices is not supported.
         self.launch_args = args
 
         unless args[:calabash_lite]
-          ensure_connectivity
+          Calabash::Cucumber::HTTP.ensure_connectivity
           # skip compatibility check if injecting dylib
           unless args.fetch(:inject_dylib, false)
             check_server_gem_compatibility
@@ -514,79 +514,6 @@ Resetting physical devices is not supported.
           puts "Unable to launch app on physical device"
         end
         raise Calabash::Cucumber::LaunchError.new(last_err)
-      end
-
-      # @!visibility private
-      def ensure_connectivity(options={})
-
-        default_options = {
-          :http_connection_retry => Calabash::Cucumber::Environment.http_connection_retries,
-          :http_connection_timeout => Calabash::Cucumber::Environment.http_connection_timeout
-        }
-
-        merged_options = default_options.merge(options)
-
-        max_retry_count = merged_options[:http_connection_retry]
-        timeout = merged_options[:http_connection_timeout]
-
-        start_time = Time.now
-
-        max_retry_count.times do |try|
-          RunLoop.log_debug("Trying to connect to Calabash Server: #{try + 1} of #{max_retry_count}")
-
-          # Subtract the aggregate time we've spent thus far to make sure we're
-          # not exceeding the request timeout across retries.
-          time_diff = start_time + timeout - Time.now
-
-          if time_diff <= 0
-            break
-          end
-
-          begin
-            http_status = ping_app
-            return true if http_status == "200"
-          rescue => _
-
-          ensure
-            sleep(1)
-          end
-        end
-
-        raise Calabash::Cucumber::ServerNotRespondingError,
-%Q[Could not connect to the Calabash Server @ #{device_endpoint}.
-
-See these two guides for help.
-
-* https://github.com/calabash/calabash-ios/wiki/Testing-on-Physical-Devices
-* https://github.com/calabash/calabash-ios/wiki/Testing-on-iOS-Simulators
-
-1. Make sure your application is linked with Calabash.
-2. Make sure there is not a firewall blocking traffic on #{device_endpoint}.
-3. Make sure #{device_endpoint} is correct.
-
-If your app is crashing at launch, find a crash report to determine the cause.
-
-]
-      end
-
-      # @!visibility private
-      def ping_app
-        url = URI.parse(device_endpoint)
-
-        http = Net::HTTP.new(url.host, url.port)
-        res = http.start do |sess|
-          sess.request Net::HTTP::Get.new("version")
-        end
-        status = res.code
-
-        http.finish if http and http.started?
-
-        if status == '200'
-          version_body = JSON.parse(res.body)
-          self.device = Calabash::Cucumber::Device.new(url, version_body)
-        end
-
-        status
       end
 
       # @!visibility private

--- a/calabash-cucumber/spec/integration/launcher/console_attach_spec.rb
+++ b/calabash-cucumber/spec/integration/launcher/console_attach_spec.rb
@@ -56,11 +56,10 @@ describe 'Launcher:  #console_attach' do
           stdin.puts "raise 'Launcher run_loop is nil' if launcher.run_loop.nil?"
           stdin.puts "raise 'Launcher pid is nil' if launcher.run_loop[:pid].nil?"
           stdin.puts "raise 'Launcher index is not 1' if launcher.run_loop[:index] != 1"
-        else
-          stdin.puts "touch 'textField'"
         end
+        stdin.puts "touch 'textField'"
         stdin.close
-        yield stdout, stderr
+        yield stdout.read.strip, stderr.read.strip
       end
     end
 
@@ -90,8 +89,10 @@ describe 'Launcher:  #console_attach' do
           expect(other_launcher.run_loop[:uia_strategy]).to be == strategy
 
           calabash_console_with_strategy(strategy) do |stdout, stderr|
-            expect(stdout.read.strip[/Error/,0]).to be == nil
-            expect(stderr.read.strip).to be == ''
+            puts "stdout => #{stdout}"
+            puts "stderr => #{stderr}"
+            expect(stdout[/Error/,0]).to be == nil
+            expect(stderr).to be == ''
           end
         end
       end

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -433,7 +433,7 @@ describe 'Calabash Launcher' do
         # We can't stand up the server, so we'll create a device and ask for
         # its version.  It is the best we can do for now.
         device = Resources.shared.device_for_mocking
-        launcher.device = device
+        launcher.instance_variable_set(:@device, device)
         actual = launcher.server_version_from_server
         expect(actual).not_to be == nil
         expect(RunLoop::Version.new(actual).to_s).to be == '0.10.0'

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -20,13 +20,6 @@ describe 'Calabash Launcher' do
     RunLoop::SimControl.terminate_all_sims
   }
 
-  it "#device_endpoint" do
-    expect(Calabash::Cucumber::Environment).to receive(:device_endpoint).and_return("endpoint")
-
-    expect(launcher.device_endpoint).to be == "endpoint"
-    expect(launcher.instance_variable_get(:@device_endpoint)).to be == "endpoint"
-  end
-
   it "#usage_tracker" do
     actual = launcher.usage_tracker
     expect(actual).to be_a_kind_of(Calabash::Cucumber::UsageTracker)
@@ -120,7 +113,7 @@ describe 'Calabash Launcher' do
     end
 
     it "the happy path" do
-      expect(launcher).to receive(:ensure_connectivity).and_return(true)
+      expect(Calabash::Cucumber::HTTP).to receive(:ensure_connectivity).and_return(true)
 
       actual = launcher.attach
 
@@ -129,7 +122,7 @@ describe 'Calabash Launcher' do
     end
 
     it "cannot connect to http server" do
-      expect(launcher).to receive(:ensure_connectivity).and_raise(Calabash::Cucumber::ServerNotRespondingError)
+      expect(Calabash::Cucumber::HTTP).to receive(:ensure_connectivity).and_raise(Calabash::Cucumber::ServerNotRespondingError)
 
       actual = launcher.attach
 
@@ -140,7 +133,7 @@ describe 'Calabash Launcher' do
     it "cannot establish communication with instruments" do
       run_loop[:pid] = nil
 
-      expect(launcher).to receive(:ensure_connectivity).and_return(true)
+      expect(Calabash::Cucumber::HTTP).to receive(:ensure_connectivity).and_return(true)
 
       actual = launcher.attach
 


### PR DESCRIPTION
### Motivation

Trying to make space for handling launching with CBXDriver/XCUITest.

Removed:

* ensure_connectivity
* ios_version
* ios_major_version

Reimplemented how we create Calabash::Cucumber::Device instances.