### PR TITLE
Launcher: legacy APIs need device attr_accessor

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -1177,7 +1177,13 @@ arguments => '#{arguments}'
       #   when starting the console.
       # @return [Calabash::Cucumber::Launcher,nil] the currently active
       #  calabash launcher
+      #
+      # @raise [RuntimeError] This method is not available on the Xamarin Test
+      #  Cloud
       def console_attach(uia_strategy = nil)
+        if Calabash::Cucumber::Environment.xtc?
+          raise "This method is not available on the Xamarin Test Cloud"
+        end
         # setting the @calabash_launcher here for backward compatibility
         @calabash_launcher = launcher.attach({:uia_strategy => uia_strategy})
       end

--- a/calabash-cucumber/lib/calabash-cucumber/http/http.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/http/http.rb
@@ -51,6 +51,7 @@ module Calabash
         timeout = merged_options[:http_connection_timeout]
 
         start_time = Time.now
+        last_error = nil
 
         max_retry_count.times do |try|
           RunLoop.log_debug("Trying to connect to Calabash Server: #{try + 1} of #{max_retry_count}")
@@ -66,17 +67,31 @@ module Calabash
           begin
             success, body = self.ping_app
             return success, body if success
-          rescue => _
-
+          rescue => e
+            last_error = e
           ensure
             sleep(1)
           end
         end
 
-        endpoint = Calabash::Cucumber::Environment.device_endpoint
+        self.raise_on_no_connectivity(last_error)
+      end
 
-        raise Calabash::Cucumber::ServerNotRespondingError,
-              %Q[Could not connect to the Calabash Server @ #{endpoint}.
+      private
+
+      def self.raise_on_no_connectivity(last_error)
+        if Calabash::Cucumber::Environment.xtc?
+          raise Calabash::Cucumber::ServerNotRespondingError,
+%Q[Could not connect to the Calabash Server.
+
+#{last_error}
+
+Please contact: testcloud-support@xamarin.com
+]
+        else
+          endpoint = Calabash::Cucumber::Environment.device_endpoint
+          raise Calabash::Cucumber::ServerNotRespondingError,
+%Q[Could not connect to the Calabash Server @ #{endpoint}.
 
 See these two guides for help.
 
@@ -90,6 +105,8 @@ See these two guides for help.
 If your app is crashing at launch, find a crash report to determine the cause.
 
 ]
+        end
+
       end
     end
   end

--- a/calabash-cucumber/lib/calabash-cucumber/http/http.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/http/http.rb
@@ -7,6 +7,7 @@ module Calabash
     # @!visibility private
     class HTTP
 
+      require "json"
       require "calabash-cucumber/environment"
       require "run_loop"
 
@@ -23,7 +24,12 @@ module Calabash
         body = nil
         success = response.is_a?(Net::HTTPSuccess)
         if success
-          body = response.body
+          json = response.body
+          begin
+            body = JSON.parse(json)
+          rescue TypeError, JSON::ParserError => _
+            success = false
+          end
         end
 
         http.finish if http and http.started?

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -127,9 +127,8 @@ module Calabash
       def device
         @device ||= lambda do
           _, body = Calabash::Cucumber::HTTP.ensure_connectivity
-          response = JSON.parse(body)
           endpoint = Calabash::Cucumber::Environment.device_endpoint
-          Calabash::Cucumber::Device.new(endpoint, response)
+          Calabash::Cucumber::Device.new(endpoint, body)
         end.call
       end
 

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -166,6 +166,10 @@ module Calabash
       # @!visibility private
       # @see Calabash::Cucumber::Core#console_attach
       def attach(options={})
+        if Calabash::Cucumber::Environment.xtc?
+          raise "This method is not available on the Xamarin Test Cloud"
+        end
+
         default_options = {:http_connection_retry => 1,
                            :http_connection_timeout => 10}
         merged_options = default_options.merge(options)

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -133,6 +133,13 @@ module Calabash
       end
 
       # @!visibility private
+      #
+      # Legacy API. This is a required method.  Do not remove
+      def device=(new_device)
+        @device = new_device
+      end
+
+      # @!visibility private
       def xcode
         @xcode ||= RunLoop::Xcode.new
       end

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -121,7 +121,7 @@ module Calabash
       # Device instance for iOS < 8 so we can perform the necessary
       # coordinate normalization - based on the device attributes.
       #
-      # We also need this information to determine the default uia strategy.
+      # We also need this instance to determine the default uia strategy.
       #
       # +1 for tools to ask physical devices about attributes.
       def device

--- a/calabash-cucumber/spec/lib/core_spec.rb
+++ b/calabash-cucumber/spec/lib/core_spec.rb
@@ -304,6 +304,28 @@ describe Calabash::Cucumber::Core do
     end
   end
 
+  describe "console_attach" do
+    it "raises an error on the XTC" do
+      expect(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(true)
+
+      expect do
+        world.console_attach
+      end.to raise_error RuntimeError,
+      /This method is not available on the Xamarin Test Cloud/
+    end
+
+    it "calls launcher#attach" do
+      launcher = Calabash::Cucumber::Launcher.new
+      strategy = :host
+      options = { :uia_strategy => strategy }
+      expect(launcher).to receive(:attach).with(options).and_return(launcher)
+      expect(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(false)
+
+      actual = world.console_attach(strategy)
+      expect(actual).to be == launcher
+    end
+  end
+
   describe "shake" do
     describe "raises errors" do
 

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -20,6 +20,35 @@ describe 'Calabash Launcher' do
     RunLoop::SimControl.terminate_all_sims
   }
 
+  describe "device attribute" do
+
+    # Legacy API. This is a required method.  Do not remove.
+    it "#device=" do
+      launcher.device = :device
+      expect(launcher.device).to be == :device
+      expect(launcher.instance_variable_get(:@device)).to be == :device
+    end
+
+    describe "#device" do
+      it "is lazy eval'd" do
+        launcher.instance_variable_set(:@device, :device)
+        expect(launcher.device).to be == :device
+      end
+
+      it "calls out to the LPServer" do
+        connected = [
+          true,
+          {"device_name"  => "denis" }
+          ]
+        expect(Calabash::Cucumber::HTTP).to receive(:ensure_connectivity).and_return(connected)
+        device = launcher.device
+
+        expect(device).to be_a_kind_of(Calabash::Cucumber::Device)
+        expect(device.device_name).to be == "denis"
+      end
+    end
+  end
+
   it "#usage_tracker" do
     actual = launcher.usage_tracker
     expect(actual).to be_a_kind_of(Calabash::Cucumber::UsageTracker)

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -169,6 +169,15 @@ describe 'Calabash Launcher' do
       expect(launcher.instance_variable_get(:@actions)).to be == nil
       expect(actual).to be == launcher
     end
+
+    it "raises an error on the XTC" do
+      expect(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(true)
+
+      expect do
+        launcher.attach
+      end.to raise_error RuntimeError,
+        /This method is not available on the Xamarin Test Cloud/
+    end
   end
 
   describe "#reset_simulator" do


### PR DESCRIPTION
### Motivation

Launcher needs `device=`.