### PR TITLE
Core: remove references to @calabash_launcher Cucumber World variable

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -951,9 +951,9 @@ arguments => '#{arguments}'
       # @return {Calabash::Cucumber::Launcher} the launcher object in use
       def start_test_server_in_background(args={})
         stop_test_server
-        @calabash_launcher = Calabash::Cucumber::Launcher.new()
-        @calabash_launcher.relaunch(args)
-        @calabash_launcher
+        launcher = Calabash::Cucumber::Launcher.new
+        launcher.relaunch(args)
+        launcher
       end
 
       # Helper method to easily create page object instances from a cucumber execution context.
@@ -1148,8 +1148,8 @@ arguments => '#{arguments}'
       # @!visibility private
       # @todo broken currently
       def stop_test_server
-        l = @calabash_launcher || Calabash::Cucumber::Launcher.launcher_if_used
-        l.stop if l
+        launcher = Calabash::Cucumber::Launcher.launcher_if_used
+        launcher.stop if launcher
       end
 
       # @!visibility private
@@ -1184,14 +1184,12 @@ arguments => '#{arguments}'
         if Calabash::Cucumber::Environment.xtc?
           raise "This method is not available on the Xamarin Test Cloud"
         end
-        # setting the @calabash_launcher here for backward compatibility
-        @calabash_launcher = launcher.attach({:uia_strategy => uia_strategy})
+        launcher.attach({:uia_strategy => uia_strategy})
       end
 
       # @!visibility private
       def launcher
-        # setting the @calabash_launcher here for backward compatibility
-        @calabash_launcher = Calabash::Cucumber::Launcher.launcher
+        Calabash::Cucumber::Launcher.launcher
       end
 
       # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/ipad_1x_2x.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/ipad_1x_2x.rb
@@ -206,13 +206,11 @@ module Calabash
       #
       # @example Here is an example of how to use this function in your `Before` launch hooks.
       #  Before do |scenario|
-      #    @calabash_launcher = Calabash::Cucumber::Launcher.new
-      #    unless @calabash_launcher.calabash_no_launch?
-      #      @calabash_launcher.relaunch
-      #      @calabash_launcher.calabash_notify(self)
-      #      # ensure emulated apps are at 1x
-      #      ensure_ipad_emulation_1x
-      #    end
+      #    launcher = Calabash::Cucumber::Launcher.new
+      #    launcher.relaunch
+      #    # ensure emulated apps are at 1x
+      #    ensure_ipad_emulation_1x
+      #
       #    # do other stuff to prepare the test environment
       #  end
       #


### PR DESCRIPTION
## Motivation

`@calabash_launcher` was used by the Playback API that has been removed (broken since iOS 7).

If you need a reference to the current launcher, call `launcher`.