### PR TITLE
Launcher: use RunLoop 2.1.0 APIs where possible

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -305,11 +305,6 @@ Resetting physical devices is not supported.
         options[:instruments] = instruments || Calabash::Cucumber::Environment.instruments
         options[:xcode] = xcode || Calabash::Cucumber::Environment.xcode
 
-        # Patch until RunLoop >= 2.1.0 is released
-        if !options[:uia_strategy]
-          options[:uia_strategy] = :host
-        end
-
         self.launch_args = options
 
         self.run_loop = new_run_loop(options)

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -254,17 +254,10 @@ Queries will work, but gestures will not.
       # @raise RuntimeError If the simulator cannot be shutdown
       # @raise RuntimeError If the simulator cannot be erased
       def reset_simulator(device=nil)
-        if device.nil? || device == ""
-          # TODO Replace this call with RunLoop::Device.detect_device
-          device_target = ensure_device_target
-        elsif device.is_a?(RunLoop::Device)
+        if device.is_a?(RunLoop::Device)
           device_target = device
         else
-          options = {
-            :sim_control => Calabash::Cucumber::Environment.simctl,
-            :instruments => Calabash::Cucumber::Environment.instruments
-          }
-          device_target = RunLoop::Device.device_with_identifier(device, options)
+          device_target = detect_device(:device => device)
         end
 
         if device_target.physical_device?

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -581,6 +581,16 @@ true.  Please remove this method call from your hooks.
       private
 
       # @!visibility private
+      #
+      # A convenience wrapper around RunLoop::Device.detect_device
+      def detect_device(options)
+        xcode = Calabash::Cucumber::Environment.xcode
+        simctl = Calabash::Cucumber::Environment.simctl
+        instruments = Calabash::Cucumber::Environment.instruments
+        RunLoop::Device.detect_device(options, xcode, simctl, instruments)
+      end
+
+      # @!visibility private
       # @return [RunLoop::Device] A RunLoop::Device instance.
       # TODO Remove
       def ensure_device_target

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -522,18 +522,16 @@ true.  Please remove this method call from your hooks.
 
       # @!visibility private
       # @deprecated 0.19.0 - no replacement
-      # TODO Call out to RunLoop::Device.detect_device
-      def device_target?
+      def device_target?(options={})
         RunLoop.deprecated("0.19.0", "No replacement")
-        false
+        detect_device(options).physical_device?
       end
 
       # @!visibility private
       # @deprecated 0.19.0 - no replacement
-      # TODO Call out to RunLoop::Device.detect_device
-      def simulator_target?(launch_args={})
+      def simulator_target?(options={})
         RunLoop.deprecated("0.19.0", "No replacement")
-        false
+        detect_device(options).simulator?
       end
 
       # @!visibility private

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -152,52 +152,34 @@ describe 'Calabash Launcher' do
   end
 
   describe "#reset_simulator" do
-    let(:options) do
-      {
-        :sim_control => Calabash::Cucumber::Environment.simctl,
-        :instruments => Calabash::Cucumber::Environment.instruments
-      }
-    end
-    describe "happy path" do
-      before do
-        allow(RunLoop::CoreSimulator).to receive(:erase).and_return(true)
-      end
 
-      describe "arg is nil or empty string" do
-        it "nil" do
-          expect(launcher).to receive(:ensure_device_target).and_return(simulator)
-
-          actual = launcher.reset_simulator
-          expect(actual).to be == simulator
-        end
-
-        it "empty string" do
-          expect(launcher).to receive(:ensure_device_target).and_return(simulator)
-
-          actual = launcher.reset_simulator("")
-          expect(actual).to be == simulator
-        end
-      end
-
-      it "arg is a RunLoop::Device" do
-        actual = launcher.reset_simulator(simulator)
-        expect(actual).to be == simulator
-      end
-
-      it "args is an simulator identifier" do
-        identifier = simulator.udid
-        expect(RunLoop::Device).to receive(:device_with_identifier).with(identifier, options).and_return(simulator)
-
-        actual = launcher.reset_simulator(identifier)
-        expect(actual).to be == simulator
-      end
+    before do
+      allow(RunLoop::CoreSimulator).to receive(:erase).and_return(true)
     end
 
-    it "a physical device is detected or passed" do
-      identifier = device.name
-      expect(RunLoop::Device).to receive(:device_with_identifier).with(identifier, options).and_return(device)
+    it "device arg is a RunLoop::Device (simulator)" do
+      actual = launcher.reset_simulator(simulator)
+      expect(actual).to be == simulator
+    end
 
+    it "device arg is a RunLoop::Device (physical device)" do
+      expect do
+        launcher.reset_simulator(device)
+      end.to raise_error ArgumentError, /Resetting physical devices is not supported/
+    end
 
+    it "device arg is something else (simulator)" do
+      identifier = simulator.udid
+      options = { :device => identifier }
+      expect(launcher).to receive(:detect_device).with(options).and_return(simulator)
+      actual = launcher.reset_simulator(identifier)
+      expect(actual).to be == simulator
+    end
+
+    it "device arg is something else (physical device)" do
+      identifier = device.udid
+      options = { :device => identifier }
+      expect(launcher).to receive(:detect_device).with(options).and_return(device)
       expect do
         launcher.reset_simulator(identifier)
       end.to raise_error ArgumentError, /Resetting physical devices is not supported/

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -393,4 +393,19 @@ describe 'Calabash Launcher' do
   it "#detect_connected_device? - deprecated" do
     expect(launcher.detect_connected_device?).to be_falsey
   end
+
+  it "#detect_device" do
+    simctl = Resources.shared.sim_control
+    xcode = Resources.shared.xcode
+    instruments = Resources.shared.instruments
+    expect(Calabash::Cucumber::Environment).to receive(:simctl).and_return(simctl)
+    expect(Calabash::Cucumber::Environment).to receive(:xcode).and_return(xcode)
+    expect(Calabash::Cucumber::Environment).to receive(:instruments).and_return(instruments)
+
+    options = { :device => simulator.udid }
+    args = [options, xcode, simctl, instruments]
+    expect(RunLoop::Device).to receive(:detect_device).with(*args).and_return(simulator)
+
+    expect(launcher.send(:detect_device, options)).to be == simulator
+  end
 end

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -195,7 +195,11 @@ describe 'Calabash Launcher' do
   end
 
   it "#simulator_target? - deprecated" do
-    expect(launcher.simulator_target?).to be == false
+    expect(launcher).to receive(:detect_device).with({}).and_return(simulator)
+    expect(launcher.simulator_target?).to be_truthy
+
+    expect(launcher).to receive(:detect_device).with({}).and_return(device)
+    expect(launcher.simulator_target?).to be_falsey
   end
 
   it "#calabash_no_launch? - deprecated" do
@@ -203,7 +207,11 @@ describe 'Calabash Launcher' do
   end
 
   it "#device_target? - deprecated" do
-    expect(launcher.device_target?).to be == false
+    expect(launcher).to receive(:detect_device).with({}).and_return(simulator)
+    expect(launcher.device_target?).to be_falsey
+
+    expect(launcher).to receive(:detect_device).with({}).and_return(device)
+    expect(launcher.device_target?).to be_truthy
   end
 
   it "#app_path - deprecated" do


### PR DESCRIPTION
### Motivation

These methods need to call RunLoop::Device.detect_device

```
* #reset_simulator
* #simulator_target?  - deprecated
* #device_target?  - deprecated
```