### PR TITLE
Launcher#check_server_gem_compatibility should be a post-launch check

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -304,12 +304,7 @@ Resetting physical devices is not supported.
 
         if !options[:calabash_lite]
           Calabash::Cucumber::HTTP.ensure_connectivity
-          # skip compatibility check if injecting dylib
-          if !options[:inject_dylib]
-            # Don't check until method is rewritten.
-            # TODO Enable
-            # check_server_gem_compatibility
-          end
+          check_server_gem_compatibility
         end
 
         usage_tracker.post_usage_async

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -402,7 +402,6 @@ Resetting physical devices is not supported.
         @@server_version = server_version
       end
 
-
       # @!visibility private
       # Checks the server and gem version compatibility and generates a warning if
       # the server and gem are not compatible.
@@ -412,33 +411,26 @@ Resetting physical devices is not supported.
       #
       # @return [nil] nothing to return
       def check_server_gem_compatibility
-        app_bundle_path = self.launch_args[:app]
-        if File.directory?(app_bundle_path)
-          server_version = server_version_from_bundle(app_bundle_path)
-        else
-          server_version = server_version_from_server
-        end
+        # Only check once.
+        return server_version if server_version
 
-        if server_version == SERVER_VERSION_NOT_AVAILABLE
-          RunLoop.log_warn("Server version could not be found - skipping compatibility check")
-          return nil
-        end
+        version_string = self.device.server_version
 
-        server_version = RunLoop::Version.new(server_version)
+        @server_version = RunLoop::Version.new(version_string)
         gem_version = RunLoop::Version.new(Calabash::Cucumber::VERSION)
         min_server_version = RunLoop::Version.new(Calabash::Cucumber::MIN_SERVER_VERSION)
 
-        if server_version < min_server_version
+        if @server_version < min_server_version
           msgs = [
-            'The server version is not compatible with gem version.',
-            'Please update your server.',
-            'https://github.com/calabash/calabash-ios/wiki/Updating-your-Calabash-iOS-version',
+            "The server version is not compatible with gem version.",
+            "Please update your server.",
+            "https://github.com/calabash/calabash-ios/wiki/Updating-your-Calabash-iOS-version",
             "       gem version: '#{gem_version}'",
             "min server version: '#{min_server_version}'",
-            "    server version: '#{server_version}'"]
+            "    server version: '#{@server_version}'"]
           RunLoop.log_warn("#{msgs.join("\n")}")
         end
-        nil
+        @server_version
       end
 
       # @deprecated 0.19.0 - replaced with #quit_app_after_scenario?
@@ -533,7 +525,7 @@ true.  Please remove this method call from your hooks.
       end
 
       # @!visibility private
-      # @deprecated 0.19.0
+      # @deprecated 0.19.0  - no replacement.
       def server_version_from_server
         RunLoop.deprecated("0.19.0", "No replacement")
         server_version
@@ -552,6 +544,7 @@ true.  Please remove this method call from your hooks.
       end
 
       # The version of the embedded LPServer
+      # @return RunLoop::Version
       attr_reader :server_version
 
       # @!visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -58,14 +58,6 @@ module Calabash
       @@launcher = nil
 
       # @!visibility private
-      SERVER_VERSION_NOT_AVAILABLE = '0.0.0'
-
-      # @!visibility private
-      # Class variable for caching the embedded server version so we only need to
-      # check the server version one time.
-      @@server_version = nil
-
-      # @!visibility private
       attr_accessor :run_loop
 
       # @!visibility private
@@ -563,6 +555,9 @@ true.  Please remove this method call from your hooks.
         instruments = Calabash::Cucumber::Environment.instruments
         RunLoop::Device.detect_device(options, xcode, simctl, instruments)
       end
+
+      # The version of the embedded LPServer
+      attr_reader :server_version
 
       # @!visibility private
       # @return [RunLoop::Device] A RunLoop::Device instance.

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -402,18 +402,6 @@ Resetting physical devices is not supported.
         @@server_version = server_version
       end
 
-      # queries the server for its version.
-      #
-      # SPECIAL: sets the +@@server_version+ class variable to cache the server
-      # version because the server version will never change during runtime.
-      #
-      # @return [String] the server version
-      # @raise [RuntimeError] if the server cannot be reached
-      def server_version_from_server
-        return @@server_version unless @@server_version.nil?
-        ensure_connectivity if self.device == nil
-        @@server_version = self.device.server_version
-      end
 
       # @!visibility private
       # Checks the server and gem version compatibility and generates a warning if
@@ -542,6 +530,13 @@ true.  Please remove this method call from your hooks.
       # * Cucumber responds to :on_launch.
       def calabash_notify(_)
         false
+      end
+
+      # @!visibility private
+      # @deprecated 0.19.0
+      def server_version_from_server
+        RunLoop.deprecated("0.19.0", "No replacement")
+        server_version
       end
 
       private

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -232,6 +232,23 @@ describe 'Calabash Launcher' do
     expect(launcher.server_version_from_server).to be == "0.19.0"
   end
 
+  it "#server_version_from_bundle - deprecated" do
+    version = RunLoop::Version.new("2.0")
+    path = Resources.shared.app_bundle_path(:cal_smoke_app)
+    app = RunLoop::App.new(path)
+
+    hash = {
+      :app => app,
+      :bundle_id => app.bundle_identifier,
+      :is_ipa => false
+    }
+    options = {:app => path }
+    expect(RunLoop::DetectAUT).to receive(:detect_app_under_test).with(options).and_return(hash)
+    expect(app).to receive(:calabash_server_version).and_return(version)
+
+    expect(launcher.server_version_from_bundle(path)).to be == version
+  end
+
   describe "#check_server_gem_compatibility" do
 
     let(:cal_device) { Resources.shared.device_for_mocking }

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -227,6 +227,10 @@ describe 'Calabash Launcher' do
     expect(launcher.calabash_notify(nil)).to be == false
   end
 
+  it "#server_version_from_server - deprecated" do
+    expect(launcher).to receive(:server_version).and_return("0.19.0")
+    expect(launcher.server_version_from_server).to be == "0.19.0"
+  end
   describe 'checking server/gem compatibility' do
 
     before(:example) do
@@ -235,26 +239,6 @@ describe 'Calabash Launcher' do
 
     after(:example) do
       Calabash::Cucumber::Launcher.class_variable_set(:@@server_version, nil)
-    end
-
-    describe '#server_version_from_server' do
-
-      it 'returns a version by asking the running server' do
-        # We can't stand up the server, so we'll create a device and ask for
-        # its version.  It is the best we can do for now.
-        device = Resources.shared.device_for_mocking
-        launcher.instance_variable_set(:@device, device)
-        actual = launcher.server_version_from_server
-        expect(actual).not_to be == nil
-        expect(RunLoop::Version.new(actual).to_s).to be == '0.10.0'
-      end
-
-      it "returns '@@server_version' if it is not nil" do
-        Calabash::Cucumber::Launcher.class_variable_set(:@@server_version, '1.0.0')
-        actual = launcher.server_version_from_server
-        expect(actual).not_to be == nil
-        expect(RunLoop::Version.new(actual).to_s).to be == '1.0.0'
-      end
     end
 
     describe '#server_version_from_bundle' do

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -231,132 +231,49 @@ describe 'Calabash Launcher' do
     expect(launcher).to receive(:server_version).and_return("0.19.0")
     expect(launcher.server_version_from_server).to be == "0.19.0"
   end
-  describe 'checking server/gem compatibility' do
 
-    before(:example) do
-      Calabash::Cucumber::Launcher.class_variable_set(:@@server_version, nil)
+  describe "#check_server_gem_compatibility" do
+
+    let(:cal_device) { Resources.shared.device_for_mocking }
+    let(:v20) { RunLoop::Version.new("2.0") }
+    let(:v10) { RunLoop::Version.new("1.0") }
+
+    before do
+      launcher.instance_variable_set(:@server_version, nil)
+      allow(launcher).to receive(:device).and_return(cal_device)
     end
 
-    after(:example) do
-      Calabash::Cucumber::Launcher.class_variable_set(:@@server_version, nil)
+    it "server version is set" do
+      expect(launcher).to receive(:server_version).twice.and_return("2.0")
+
+      expect(launcher.check_server_gem_compatibility).to be == "2.0"
     end
 
-    describe '#server_version_from_bundle' do
+    it "compatible" do
+      stub_const("Calabash::Cucumber::MIN_SERVER_VERSION", v20.to_s)
+      expect(cal_device).to receive(:server_version).and_return(v20.to_s)
 
-      describe 'returns calabash version an app bundle when' do
-        it 'strings can find the version' do
-          abp = Resources.shared.app_bundle_path :server_gem_compatibility
-          actual = launcher.server_version_from_bundle abp
-          expect(actual).not_to be == nil
-          expect(RunLoop::Version.new(actual).to_s).to be == '11.11.11'
-        end
-
-        it 'and when there is a space is the path' do
-          abp = Resources.shared.app_bundle_path :server_gem_compatibility
-          dir = Dir.mktmpdir('path with space')
-          FileUtils.cp_r abp, dir
-          abp = File.expand_path(File.join(dir, 'server-gem-compatibility.app'))
-          actual = launcher.server_version_from_bundle abp
-          expect(actual).not_to be == nil
-          expect(RunLoop::Version.new(actual).to_s).to be == '11.11.11'
-        end
-      end
-
-      it "returns '0.0.0' when strings cannot extract a version" do
-        abp = Resources.shared.app_bundle_path :calabash_not_linked
-        actual = nil
-        capture_stderr do
-          actual = launcher.server_version_from_bundle abp
-        end
-        expect(actual).not_to be == nil
-        expect(RunLoop::Version.new(actual).to_s).to be == '0.0.0'
-      end
-
-      it "returns '@@server_version' if it is not nil" do
-        Calabash::Cucumber::Launcher.class_variable_set(:@@server_version, '1.0.0')
-        actual = launcher.server_version_from_bundle nil
-        expect(actual).not_to be == nil
-        expect(RunLoop::Version.new(actual).to_s).to be == '1.0.0'
-      end
+      expect(launcher.check_server_gem_compatibility).to be == v20
+      expect(launcher.instance_variable_get(:@server_version)).to be == v20
+      expect(launcher.send(:server_version)).to be == v20
     end
 
-    describe '#check_server_gem_compatibility' do
+    it "not compatible" do
+      stub_const("Calabash::Cucumber::MIN_SERVER_VERSION", v20.to_s)
+      expect(cal_device).to receive(:server_version).and_return(v10.to_s)
 
-      describe 'when targeting an .app' do
-        let (:app) { Resources.shared.app_bundle_path :smoke }
+      actual = nil
 
-        describe 'prints a message if server' do
-          it 'and gem are compatible' do
-            launcher.launch_args = {:app => app}
-            min_server_version = Calabash::Cucumber::MIN_SERVER_VERSION
-            expect(launcher).to receive(:server_version_from_bundle).and_return(min_server_version)
-            out = capture_stderr do
-              launcher.check_server_gem_compatibility
-            end
-            expect(out.string).to be == ''
-          end
+      out = capture_stdout do
+        actual = launcher.check_server_gem_compatibility
+      end.string
 
-          it 'and gem are not compatible' do
-            launcher.launch_args = {:app => app}
-            min_server_version = '0.0.1'
-            expect(launcher).to receive(:server_version_from_bundle).and_return(min_server_version)
-            out = capture_stdout do
-              launcher.check_server_gem_compatibility
-            end
-            expect(out.string).not_to be == nil
-            expect(out.string.length).not_to be == 0
-          end
+      expect(actual).to be == v10
+      expect(launcher.instance_variable_get(:@server_version)).to be == v10
+      expect(launcher.send(:server_version)).to be == v10
 
-          it 'version cannot be found' do
-            launcher.launch_args = {:app => app}
-            min_server_version = Calabash::Cucumber::Launcher::SERVER_VERSION_NOT_AVAILABLE
-            expect(launcher).to receive(:server_version_from_bundle).and_return(min_server_version)
-            out = capture_stdout do
-              launcher.check_server_gem_compatibility
-            end
-            expect(out.string).not_to be == nil
-            expect(out.string.length).not_to be == 0
-          end
-        end
-      end
-
-      describe 'when targeting an .ipa' do
-        let (:app) { 'foo.ipa' }
-
-        describe 'prints a message if server' do
-          it 'and gem are compatible' do
-            launcher.launch_args = {:app => app}
-            min_server_version = Calabash::Cucumber::MIN_SERVER_VERSION
-            expect(launcher).to receive(:server_version_from_server).and_return(min_server_version)
-            out = capture_stdout do
-              launcher.check_server_gem_compatibility
-            end
-            expect(out.string).to be == ''
-          end
-
-          it 'and gem are not compatible' do
-            launcher.launch_args = {:app => app}
-            min_server_version = '0.0.1'
-            expect(launcher).to receive(:server_version_from_server).and_return(min_server_version)
-            out = capture_stdout do
-              launcher.check_server_gem_compatibility
-            end
-            expect(out.string).not_to be == nil
-            expect(out.string.length).not_to be == 0
-          end
-
-          it 'version cannot be found' do
-            launcher.launch_args = {:app => app}
-            min_server_version = Calabash::Cucumber::Launcher::SERVER_VERSION_NOT_AVAILABLE
-            expect(launcher).to receive(:server_version_from_server).and_return(min_server_version)
-            out = capture_stdout do
-              launcher.check_server_gem_compatibility
-            end
-            expect(out.string).not_to be == nil
-            expect(out.string.length).not_to be == 0
-          end
-        end
-      end
+      match = out[/The server version is not compatible with gem version/, 0]
+      expect(match).to be_truthy
     end
   end
 


### PR DESCRIPTION
### Motivation

The original idea was to raise an error _before attempting to launch the AUT_ if the server and gem were not compatible.  This was never implemented.  Instead we issue a warning.  Since all we are doing is generating a warning, we can remove all the checks against the bundle and simply do a check after we have successfully launched.

+1 code reduction.