### PR TITLE
Remove experimental Launcher and Environment methods

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/environment.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment.rb
@@ -36,37 +36,6 @@ module Calabash
       end
 
       # @!visibility private
-      def self.device_target
-        value = RunLoop::Environment.device_target
-        if value
-          if value == "simulator"
-            identifier = RunLoop::Core.default_simulator
-          elsif value == "device"
-            identifier = RunLoop::Core.detect_connected_device
-          else
-            identifier = value
-          end
-        else
-          identifier = RunLoop::Core.default_simulator
-        end
-
-        identifier
-      end
-
-      # @!visibility private
-      def self.run_loop_device
-        return nil if self.xtc?
-
-        identifier = self.device_target
-
-        options = {
-          :sim_control => self.simctl,
-          :instruments => self.instruments
-        }
-        RunLoop::Device.device_with_identifier(identifier, options)
-      end
-
-      # @!visibility private
       def self.device_endpoint
         value = RunLoop::Environment.device_endpoint
         if value

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -505,26 +505,6 @@ true.  Please remove this method call from your hooks.
       # The version of the embedded LPServer
       # @return RunLoop::Version
       attr_reader :server_version
-
-      # @!visibility private
-      # @return [RunLoop::Device] A RunLoop::Device instance.
-      # TODO Remove
-      def ensure_device_target
-        begin
-          @run_loop_device ||= Calabash::Cucumber::Environment.run_loop_device
-        rescue ArgumentError => e
-          raise Calabash::Cucumber::DeviceNotFoundError,
-                %Q[Could not find a matching device in your environment.
-
-#{e.message}
-
-To see what devices are available on your machine, use instruments:
-
-$ xcrun instruments -s devices
-
-]
-        end
-      end
     end
   end
 end

--- a/calabash-cucumber/spec/lib/environment_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_spec.rb
@@ -59,39 +59,6 @@ describe Calabash::Cucumber::Environment do
     expect(Calabash::Cucumber::Environment.xtc?).to be_falsey
   end
 
-  describe ".device_target" do
-    describe "DEVICE_TARGET is defined" do
-      it "simulator" do
-        expect(RunLoop::Environment).to receive(:device_target).and_return("simulator")
-        expect(RunLoop::Core).to receive(:default_simulator).and_return("Default Simulator")
-
-        actual = Calabash::Cucumber::Environment.device_target
-        expect(actual).to be == "Default Simulator"
-      end
-
-      it "device" do
-        expect(RunLoop::Environment).to receive(:device_target).and_return("device")
-        expect(RunLoop::Core).to receive(:detect_connected_device).and_return("a udid")
-
-        actual = Calabash::Cucumber::Environment.device_target
-        expect(actual).to be == "a udid"
-      end
-
-      it "anything else" do
-        expect(RunLoop::Environment).to receive(:device_target).and_return("a")
-        expect(Calabash::Cucumber::Environment.device_target).to be == "a"
-      end
-    end
-
-    it "DEVICE_TARGET is not defined" do
-      expect(RunLoop::Environment).to receive(:device_target).and_return(nil)
-      expect(RunLoop::Core).to receive(:default_simulator).and_return("Default Simulator")
-
-      actual = Calabash::Cucumber::Environment.device_target
-      expect(actual).to be == "Default Simulator"
-    end
-  end
-
   describe ".device_endpoint" do
     it "DEVICE_ENDPOINT is defined" do
       expect(RunLoop::Environment).to receive(:device_endpoint).and_return("endpoint")
@@ -159,34 +126,6 @@ describe Calabash::Cucumber::Environment do
 
       stub_env({"RESET_BETWEEN_SCENARIOS" => 1})
       expect(Calabash::Cucumber::Environment.reset_between_scenarios?).to be_falsey
-    end
-  end
-
-  describe ".run_loop_device" do
-    let(:identifier) { "some device id" }
-
-    before do
-      allow(Calabash::Cucumber::Environment).to receive(:device_target).and_return(identifier)
-    end
-
-    it "returns nil on the XTC" do
-      expect(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(true)
-
-      actual = Calabash::Cucumber::Environment.run_loop_device
-      expect(actual).to be == nil
-    end
-
-    it "returns a RunLoop::Device instance" do
-      allow(Calabash::Cucumber::Environment).to receive(:xtc?).and_return(false)
-      options = {
-        :sim_control => Calabash::Cucumber::Environment.simctl,
-        :instruments => Calabash::Cucumber::Environment.instruments
-      }
-      expect(RunLoop::Device).to receive(:device_with_identifier).with(identifier, options).and_return(:device)
-
-
-      actual = Calabash::Cucumber::Environment.run_loop_device
-      expect(actual).to be == :device
     end
   end
 

--- a/calabash-cucumber/spec/lib/launcher_spec.rb
+++ b/calabash-cucumber/spec/lib/launcher_spec.rb
@@ -73,26 +73,6 @@ describe 'Calabash Launcher' do
     end
   end
 
-  describe "#ensure_device_target" do
-    it "raises an error" do
-      expect(Calabash::Cucumber::Environment).to receive(:device_target).and_return("no matching")
-
-      expect do
-        launcher.send(:ensure_device_target)
-      end.to raise_error Calabash::Cucumber::DeviceNotFoundError,
-                         /Could not find a matching device in your environment/
-    end
-
-    it "returns a RunLoop::Device" do
-      stub_env({"DEVICE_TARGET" => nil})
-
-      actual = launcher.send(:ensure_device_target)
-
-      expect(actual).to be_a_kind_of(RunLoop::Device)
-      expect(actual.simulator?).to be_truthy
-    end
-  end
-
   describe "#attach" do
     let(:run_loop) do
       {


### PR DESCRIPTION
### Motivation

Last week, I added some experimental methods to Launcher and Environment.  This methods are not necessary.