### PR TITLE
Map: rename map to fetch_results

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -139,7 +139,7 @@ module Calabash
       # @param [Array] args optional var-args list describing a chain of method selectors.
       #   Full details {http://developer.xamarin.com/guides/testcloud/calabash/calabash-query-syntax/ Query Syntax}.
       def query(uiquery, *args)
-        map(uiquery, :query, *args)
+        fetch_results(uiquery, :query, *args)
       end
 
       # Shorthand alias for `query`.
@@ -160,7 +160,7 @@ module Calabash
       def flash(uiquery, *args)
         # todo deprecate the *args argument in the flash method
         # todo :flash operation should return views as JSON objects
-        map(uiquery, :flash, *args).compact
+        fetch_results(uiquery, :flash, *args).compact
       end
 
       # Returns the version of the running calabash server.
@@ -410,7 +410,7 @@ module Calabash
           raise ArgumentError, "Expected '#{direction} to be one of #{allowed_directions}"
         end
 
-        views_touched=map(uiquery, :scroll, dir_symbol)
+        views_touched=fetch_results(uiquery, :scroll, dir_symbol)
         msg = "could not find view to scroll: '#{uiquery}', args: #{dir_symbol}"
         assert_map_results(views_touched, msg)
         views_touched
@@ -425,7 +425,7 @@ module Calabash
       #
       # @param {String} uiquery query describing view scroll (should be  UIScrollView or a web view).
       def scroll_to_row(uiquery, number)
-        views_touched=map(uiquery, :scrollToRow, number)
+        views_touched=fetch_results(uiquery, :scrollToRow, number)
         msg = "unable to scroll: '#{uiquery}' to: #{number}"
         assert_map_results(views_touched, msg)
         views_touched
@@ -468,7 +468,7 @@ module Calabash
         if options.has_key?(:animate)
           args << options[:animate]
         end
-        views_touched=map(uiquery, :scrollToRow, row.to_i, sec.to_i, *args)
+        views_touched=fetch_results(uiquery, :scrollToRow, row.to_i, sec.to_i, *args)
         msg = "unable to scroll: '#{uiquery}' to '#{options}'"
         assert_map_results(views_touched, msg)
         views_touched
@@ -517,7 +517,7 @@ module Calabash
           args << options[:animate]
         end
 
-        views_touched=map(uiquery, :scrollToRowWithMark, mark, *args)
+        views_touched=fetch_results(uiquery, :scrollToRowWithMark, mark, *args)
         msg = options[:failed_message] || "Unable to scroll: '#{uiquery}' to: #{options}"
         assert_map_results(views_touched, msg)
         views_touched
@@ -574,7 +574,7 @@ module Calabash
 
         animate = opts[:animate]
 
-        views_touched=map(uiquery, :collectionViewScroll, item.to_i, section.to_i, scroll_position, animate)
+        views_touched=fetch_results(uiquery, :collectionViewScroll, item.to_i, section.to_i, scroll_position, animate)
 
         if opts[:failed_message]
           msg = opts[:failed_message]
@@ -640,7 +640,7 @@ module Calabash
         args << scroll_position
         args << opts[:animate]
 
-        views_touched=map(uiquery, :collectionViewScrollToItemWithMark, mark, *args)
+        views_touched=fetch_results(uiquery, :collectionViewScrollToItemWithMark, mark, *args)
         msg = opts[:failed_message] || "Unable to scroll: '#{uiquery}' to cell with mark: '#{mark}' with #{opts}"
         assert_map_results(views_touched, msg)
         views_touched
@@ -830,7 +830,7 @@ details => '#{result["details"]}'
         value_str = value.to_s
 
         args = [merged_options[:animate], merged_options[:notify_targets]]
-        views_touched = map(uiquery, :changeSlider, value_str, *args)
+        views_touched = fetch_results(uiquery, :changeSlider, value_str, *args)
 
         msg = "Could not set value of slider to '#{value}' using query '#{uiquery}'"
         assert_map_results(views_touched, msg)
@@ -1075,7 +1075,7 @@ arguments => '#{arguments}'
       #
       # @return [Array<String>] The text fields that were modified.
       def set_text(uiquery, txt)
-        text_fields_modified = map(uiquery, :setText, txt)
+        text_fields_modified = fetch_results(uiquery, :setText, txt)
 
         msg = "query '#{uiquery}' returned no matching views that respond to 'setText'"
         assert_map_results(text_fields_modified, msg)
@@ -1095,7 +1095,7 @@ arguments => '#{arguments}'
       #
       # @return [Array<String>] The text fields that were modified.
       def clear_text(uiquery)
-        views_modified = map(uiquery, :setText, '')
+        views_modified = fetch_results(uiquery, :setText, '')
         msg = "query '#{uiquery}' returned no matching views that respond to 'setText'"
         assert_map_results(views_modified, msg)
         views_modified

--- a/calabash-cucumber/lib/calabash-cucumber/date_picker.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/date_picker.rb
@@ -281,7 +281,7 @@ module Calabash
         args = args_for_change_date_on_picker options
         query_str = query_string_for_picker picker_id
 
-        views_touched = map(query_str, :changeDatePickerDate, target_str, fmt_str, *args)
+        views_touched = fetch_results(query_str, :changeDatePickerDate, target_str, fmt_str, *args)
         msg = "could not change date on picker to '#{target_dt}' using query '#{query_str}' with options '#{options}'"
         assert_map_results(views_touched,msg)
         views_touched

--- a/calabash-cucumber/lib/calabash-cucumber/map.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/map.rb
@@ -25,31 +25,31 @@ module Calabash
       # @examples
       #
       #   # Calls 'text' on any visible UITextField, because :text is not a defined operation.
-      #   > map("textField", :text)
+      #   > fetch_results("textField", :text)
       #   => [ "old text" ]
       #
       #   # Does not call 'setText:', because :setText is a defined operation.
-      #   > map("textField", :setText, 'new text')
+      #   > fetch_results("textField", :setText, 'new text')
       #   => [ <UITextField ... > ]
       #
       #   # Calls 'setText:', because 'setText:' is not a defined operation.
-      #   > map("textField", 'setText:', 'newer text')
+      #   > fetch_results("textField", 'setText:', 'newer text')
       #   => [ "<VOID>" ]
       #
       #   # Will return [] because :unknownSelector is not defined on UITextField.
-      #   > map("textField", :unknownSelector)
+      #   > fetch_results("textField", :unknownSelector)
       #   => []
       #
       #   # Will return [] because 'setAlpha' requires 1 argument and none was provided.
       #   # An error will be logged by the server in the device logs.
-      #   > map("textField", 'setAlpha:')
+      #   > fetch_results("textField", 'setAlpha:')
       #   => []
       #
       #
       # Well behaved LPOperations should return the view as JSON objects.
       #
       # @todo Calabash LPOperations should return 'views touched' in JSON format
-      def map(query, method_name, *method_args)
+      def fetch_results(query, method_name, *method_args)
         raw_map(query, method_name, *method_args)['results']
       end
 
@@ -70,7 +70,7 @@ module Calabash
       #                  the `method_name` with arguments defined in
       #                  `method_args` on all views matched by the `query`
       #
-      # @see Calabash::Cucumber::Map#map for examples.
+      # @see Calabash::Cucumber::Map#fetch_results for examples.
       def raw_map(query, method_name, *method_args)
         operation_map = {
             :method_name => method_name,
@@ -80,13 +80,13 @@ module Calabash
                    {:query => query, :operation => operation_map})
         res = JSON.parse(res)
         if res['outcome'] != 'SUCCESS'
-          screenshot_and_raise "map #{query}, #{method_name} failed because: #{res['reason']}\n#{res['details']}"
+          screenshot_and_raise "fetch_results #{query}, #{method_name} failed because: #{res['reason']}\n#{res['details']}"
         end
 
         res
       end
 
-      # Asserts the result of a calabash `map` call and raises an error with
+      # Asserts the result of a calabash `fetch_results` call and raises an error with
       # `msg` if no valid results are found.
       #
       # Casual gem users should never need to call this method; this is a
@@ -99,7 +99,7 @@ module Calabash
       #       contains '*****' string #=> [ "*****"  ]
       #         contains a single nil #=> [ nil ]
       #
-      # When evaluating whether a `map` call is successful it is important to
+      # When evaluating whether a `fetch_results` call is successful it is important to
       # note that sometimes a <tt>[ nil ]</tt> or <tt>[nil, <val>, nil]</tt> is
       # a valid result.
       #
@@ -109,14 +109,14 @@ module Calabash
       #    label @ index 1 has text nil (the [label text] => nil)
       #    label @ index 2 has text "bar"
       #
-      #    map('label', :text) => ['foo', nil, 'bar']
-      #    map('label index:1', :text) => [nil]
+      #    fetch_results('label', :text) => ['foo', nil, 'bar']
+      #    fetch_results('label index:1', :text) => [nil]
       #
       # In other cases, <tt>[ nil ]</tt> should be treated as an invalid result
       #
       #    # invalid
       #    > mark = 'mark does not exist'
-      #    > map('tableView', :scrollToRowWithMark, mark, args) => [ nil ]
+      #    > fetch_results('tableView', :scrollToRowWithMark, mark, args) => [ nil ]
       #
       # Here a <tt>[ nil ]</tt> should be considered invalid because the
       # the operation could not be performed because there is not row that

--- a/calabash-cucumber/lib/calabash-cucumber/status_bar_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/status_bar_helpers.rb
@@ -21,7 +21,7 @@ module Calabash
       # @return [Symbol] Returns the device orientation as one of
       #  `{:down, :up, :left, :right}`.
       def device_orientation(force_down=false)
-        res = map(nil, :orientation, :device).first
+        res = fetch_results(nil, :orientation, :device).first
 
         if ['face up', 'face down'].include?(res)
           if force_down
@@ -47,7 +47,7 @@ module Calabash
       # @return [String] Returns the device orientation as one of
       #  `{'down' | 'up' | 'left' | 'right'}`.
       def status_bar_orientation
-        map(nil, :orientation, :status_bar).first
+        fetch_results(nil, :orientation, :status_bar).first
       end
 
       # Is the device in the portrait orientation?

--- a/calabash-cucumber/lib/frank-calabash.rb
+++ b/calabash-cucumber/lib/frank-calabash.rb
@@ -16,7 +16,7 @@ module Calabash
                    {:query => query, :operation => operation_map})
         res = JSON.parse(res)
         if res['outcome'] != 'SUCCESS'
-          screenshot_and_raise "map #{query}, #{method_name} failed because: #{res['reason']}\n#{res['details']}"
+          screenshot_and_raise "fetch_results #{query}, #{method_name} failed because: #{res['reason']}\n#{res['details']}"
         end
 
         res

--- a/calabash-cucumber/spec/lib/core_spec.rb
+++ b/calabash-cucumber/spec/lib/core_spec.rb
@@ -70,7 +70,7 @@ describe Calabash::Cucumber::Core do
 
       describe 'valid' do
         before do
-          expect(world).to receive(:map).twice.and_return [true]
+          expect(world).to receive(:fetch_results).twice.and_return [true]
           expect(world).to receive(:assert_map_results).twice.and_return true
         end
 


### PR DESCRIPTION
Map is conflicting with other tools - like mockserver-client.

My tests failed due to this error

```
 wrong number of arguments (0 for 2+) (ArgumentError)
      /Users/svandeven/dev/mobile/calabash-ios/calabash-cucumber/lib/calabash-cucumber/map.rb:52:in `map'
      /opt/boxen/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/logging-1.8.2/lib/logging/color_scheme.rb:173:in `[]='
      /opt/boxen/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/logging-1.8.2/lib/logging/color_scheme.rb:141:in `block in load_from_hash'
```