### PR TITLE
Release/0.19.0.pre2

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |s|
   s.add_dependency('httpclient', '>= 2.3.2', '< 3.0')
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
-  s.add_dependency("run_loop", "2.1.1.pre3")
+  s.add_dependency("run_loop", "2.1.1.pre4")
 
   # Shared with run-loop.
   s.add_dependency('json')

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -3,7 +3,7 @@ module Calabash
 
     # @!visibility public
     # The Calabash iOS gem version.
-    VERSION = "0.19.0.pre1"
+    VERSION = "0.19.0.pre2"
 
     # @!visibility public
     # The minimum required version of the Calabash embedded server.


### PR DESCRIPTION
### 0.19.0

This release remove almost all deprecated methods.  Further, Calabash
will no longer respond to legacy environment variables.

* Use tap_keyboard_action_key instead of done #1057 @lucatorella
* Launcher#check_server_gem_compatibility should be a post-launch check
  #1051
* Launcher: use RunLoop 2.1.0 APIs where possible #1050
* Core: remove references to @calabash_launcher Cucumber World variable
  #1049
* Deprecate Launcher#calabash_notify #1048
* Deprecate old Launcher behaviors and use new RunLoop APIs in #relaunch
  #1047
* Launcher: deprecated #default_uia_strategy #1046
* Move http methods out of launcher #1044
* Rotation: remove playback API - since 0.16.2 #1040
* Replace NO_STOP with QUIT_APP_AFTER_SCENARIO #1038
* Unify logging between RunLoop and Calabash #1035
* Gem: remove deprecated.rb #1034
* Remove more deprecated Device behaviors #1033
* Remove CALABASH_VERSION_PATH #1028
* Remove unnecessary methods from Launcher #1027
* Remove deprecated methods for 0.19.0 #1026
* Remove the Playback API #1025
* Remove deprecated XcodeTools, PlistBuddy, and SimulatorAccessibility
  #1024
* Remove deprecated methods from KeyboardHelpers #1023
* Remove deprecated ENV variables and constants #1022
* Core: undeprecate #set_text #1021
* CLI: remove 'update' command #1020
* Remove sim_launcher gem dependency and SimulatorLauncher class #1016
* Remove KeyboardHelpers.done #1004
* Screen coordinates are incorrect when running in Zoomed mode #998
* Remove the sim_launcher dependency #921
* Cannot query UIWebView by accessibilityIdentifier or
  accessibilityLabel #735