### PR TITLE
Change Map module to class and provide class methods

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/actions/instruments_actions.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/actions/instruments_actions.rb
@@ -1,14 +1,14 @@
 require 'calabash-cucumber/uia'
 require 'calabash-cucumber/connection_helpers'
 require 'calabash-cucumber/query_helpers'
-require 'calabash-cucumber/map'
 
 # @!visibility private
 class Calabash::Cucumber::InstrumentsActions
   include Calabash::Cucumber::UIA
   include Calabash::Cucumber::ConnectionHelpers
   include Calabash::Cucumber::QueryHelpers
-  include Calabash::Cucumber::Map
+
+  require "calabash-cucumber/map"
 
   # @!visibility private
   def touch(options)
@@ -100,7 +100,7 @@ class Calabash::Cucumber::InstrumentsActions
 
   # @!visibility private
   def find_and_normalize(ui_query)
-    raw_result = raw_map(ui_query, :query)
+    raw_result = Calabash::Cucumber::Map.raw_map(ui_query, :query)
     orientation = raw_result['status_bar_orientation']
     res = raw_result['results']
 

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -17,18 +17,22 @@ module Calabash
     # A collection of methods that provide the core calabash behaviors.
     module Core
 
+      require "calabash-cucumber/map"
       include Calabash::Cucumber::EnvironmentHelpers
       include Calabash::Cucumber::ConnectionHelpers
       include Calabash::Cucumber::QueryHelpers
       include Calabash::Cucumber::FailureHelpers
-      include Calabash::Cucumber::Map
       include Calabash::Cucumber::UIA
       include Calabash::Cucumber::StatusBarHelpers
       include Calabash::Cucumber::RotationHelpers
 
       # @!visibility private
-      # @deprecated Use Cucumber's step method (avoid this: using step is not considered best practice).
+      # @deprecated Use Cucumber's step method.
+      #
+      # Using `step` is not considered a best practice.
+      #
       # Used in older cucumber versions that didn't have the `step` method.
+      #
       # Shouldn't be used anymore.
       def macro(txt)
         if self.respond_to? :step
@@ -139,7 +143,7 @@ module Calabash
       # @param [Array] args optional var-args list describing a chain of method selectors.
       #   Full details {http://developer.xamarin.com/guides/testcloud/calabash/calabash-query-syntax/ Query Syntax}.
       def query(uiquery, *args)
-        map(uiquery, :query, *args)
+        Map.map(uiquery, :query, *args)
       end
 
       # Shorthand alias for `query`.
@@ -160,7 +164,7 @@ module Calabash
       def flash(uiquery, *args)
         # todo deprecate the *args argument in the flash method
         # todo :flash operation should return views as JSON objects
-        map(uiquery, :flash, *args).compact
+        Map.map(uiquery, :flash, *args).compact
       end
 
       # Returns the version of the running calabash server.
@@ -410,9 +414,9 @@ module Calabash
           raise ArgumentError, "Expected '#{direction} to be one of #{allowed_directions}"
         end
 
-        views_touched=map(uiquery, :scroll, dir_symbol)
+        views_touched = Map.map(uiquery, :scroll, dir_symbol)
         msg = "could not find view to scroll: '#{uiquery}', args: #{dir_symbol}"
-        assert_map_results(views_touched, msg)
+        Map.assert_map_results(views_touched, msg)
         views_touched
       end
 
@@ -425,9 +429,9 @@ module Calabash
       #
       # @param {String} uiquery query describing view scroll (should be  UIScrollView or a web view).
       def scroll_to_row(uiquery, number)
-        views_touched=map(uiquery, :scrollToRow, number)
+        views_touched = Map.map(uiquery, :scrollToRow, number)
         msg = "unable to scroll: '#{uiquery}' to: #{number}"
-        assert_map_results(views_touched, msg)
+        Map.assert_map_results(views_touched, msg)
         views_touched
       end
 
@@ -468,9 +472,9 @@ module Calabash
         if options.has_key?(:animate)
           args << options[:animate]
         end
-        views_touched=map(uiquery, :scrollToRow, row.to_i, sec.to_i, *args)
+        views_touched = Map.map(uiquery, :scrollToRow, row.to_i, sec.to_i, *args)
         msg = "unable to scroll: '#{uiquery}' to '#{options}'"
-        assert_map_results(views_touched, msg)
+        Map.assert_map_results(views_touched, msg)
         views_touched
       end
 
@@ -517,9 +521,9 @@ module Calabash
           args << options[:animate]
         end
 
-        views_touched=map(uiquery, :scrollToRowWithMark, mark, *args)
+        views_touched = Map.map(uiquery, :scrollToRowWithMark, mark, *args)
         msg = options[:failed_message] || "Unable to scroll: '#{uiquery}' to: #{options}"
-        assert_map_results(views_touched, msg)
+        Map.assert_map_results(views_touched, msg)
         views_touched
       end
 
@@ -574,7 +578,9 @@ module Calabash
 
         animate = opts[:animate]
 
-        views_touched=map(uiquery, :collectionViewScroll, item.to_i, section.to_i, scroll_position, animate)
+        views_touched = Map.map(uiquery, :collectionViewScroll,
+                                item.to_i, section.to_i,
+                                scroll_position, animate)
 
         if opts[:failed_message]
           msg = opts[:failed_message]
@@ -582,7 +588,7 @@ module Calabash
           msg = "unable to scroll: '#{uiquery}' to item '#{item}' in section '#{section}'"
         end
 
-        assert_map_results(views_touched, msg)
+        Map.assert_map_results(views_touched, msg)
         views_touched
       end
 
@@ -640,9 +646,11 @@ module Calabash
         args << scroll_position
         args << opts[:animate]
 
-        views_touched=map(uiquery, :collectionViewScrollToItemWithMark, mark, *args)
+        views_touched = Map.map(uiquery, :collectionViewScrollToItemWithMark,
+                                mark, *args)
+
         msg = opts[:failed_message] || "Unable to scroll: '#{uiquery}' to cell with mark: '#{mark}' with #{opts}"
-        assert_map_results(views_touched, msg)
+        Map.assert_map_results(views_touched, msg)
         views_touched
       end
 
@@ -830,10 +838,10 @@ details => '#{result["details"]}'
         value_str = value.to_s
 
         args = [merged_options[:animate], merged_options[:notify_targets]]
-        views_touched = map(uiquery, :changeSlider, value_str, *args)
+        views_touched = Map.map(uiquery, :changeSlider, value_str, *args)
 
         msg = "Could not set value of slider to '#{value}' using query '#{uiquery}'"
-        assert_map_results(views_touched, msg)
+        Map.assert_map_results(views_touched, msg)
         views_touched
       end
 
@@ -849,7 +857,7 @@ details => '#{result["details"]}'
       #   trailing ":"
       #
       # @param [String] selector the selector to perform on the app delegate
-      # @param [Object] argument the argument to pass to the selector
+      # @param [Object] arguments the arguments to pass to the selector
       # @return [Object] the result of performing the selector with the argument
       def backdoor(selector, *arguments)
         parameters = {
@@ -1075,10 +1083,10 @@ arguments => '#{arguments}'
       #
       # @return [Array<String>] The text fields that were modified.
       def set_text(uiquery, txt)
-        text_fields_modified = map(uiquery, :setText, txt)
+        text_fields_modified = Map.map(uiquery, :setText, txt)
 
         msg = "query '#{uiquery}' returned no matching views that respond to 'setText'"
-        assert_map_results(text_fields_modified, msg)
+        Map.assert_map_results(text_fields_modified, msg)
         text_fields_modified
       end
 
@@ -1095,9 +1103,9 @@ arguments => '#{arguments}'
       #
       # @return [Array<String>] The text fields that were modified.
       def clear_text(uiquery)
-        views_modified = map(uiquery, :setText, '')
+        views_modified = Map.map(uiquery, :setText, '')
         msg = "query '#{uiquery}' returned no matching views that respond to 'setText'"
-        assert_map_results(views_modified, msg)
+        Map.assert_map_results(views_modified, msg)
         views_modified
       end
 
@@ -1222,7 +1230,7 @@ arguments => '#{arguments}'
         views_touched = launcher.actions.send(action, options)
         unless uiquery.nil?
           msg = "#{action} could not find view: '#{uiquery}', args: #{options}"
-          assert_map_results(views_touched, msg)
+          Map.assert_map_results(views_touched, msg)
         end
         views_touched
       end

--- a/calabash-cucumber/lib/calabash-cucumber/date_picker.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/date_picker.rb
@@ -281,9 +281,10 @@ module Calabash
         args = args_for_change_date_on_picker options
         query_str = query_string_for_picker picker_id
 
-        views_touched = map(query_str, :changeDatePickerDate, target_str, fmt_str, *args)
+        views_touched = Map.map(query_str, :changeDatePickerDate, target_str,
+                                fmt_str, *args)
         msg = "could not change date on picker to '#{target_dt}' using query '#{query_str}' with options '#{options}'"
-        assert_map_results(views_touched,msg)
+        Map.assert_map_results(views_touched,msg)
         views_touched
       end
     end

--- a/calabash-cucumber/lib/calabash-cucumber/status_bar_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/status_bar_helpers.rb
@@ -21,7 +21,7 @@ module Calabash
       # @return [Symbol] Returns the device orientation as one of
       #  `{:down, :up, :left, :right}`.
       def device_orientation(force_down=false)
-        res = map(nil, :orientation, :device).first
+        res = Map.map(nil, :orientation, :device).first
 
         if ['face up', 'face down'].include?(res)
           if force_down
@@ -47,7 +47,7 @@ module Calabash
       # @return [String] Returns the device orientation as one of
       #  `{'down' | 'up' | 'left' | 'right'}`.
       def status_bar_orientation
-        map(nil, :orientation, :status_bar).first
+        Map.map(nil, :orientation, :status_bar).first
       end
 
       # Is the device in the portrait orientation?

--- a/calabash-cucumber/spec/lib/core_spec.rb
+++ b/calabash-cucumber/spec/lib/core_spec.rb
@@ -3,6 +3,8 @@ describe Calabash::Cucumber::Core do
   let(:actions) do
     Class.new do
       def swipe(dir, options); :success; end
+      def to_s; "#<ActionInterface>"; end
+      def inspect; to_s; end
     end.new
   end
 
@@ -15,6 +17,8 @@ describe Calabash::Cucumber::Core do
   let(:world) do
     Class.new do
       include Calabash::Cucumber::Core
+      def to_s; "#<World>"; end
+      def inspect; to_s; end
     end.new
   end
 
@@ -70,8 +74,8 @@ describe Calabash::Cucumber::Core do
 
       describe 'valid' do
         before do
-          expect(world).to receive(:map).twice.and_return [true]
-          expect(world).to receive(:assert_map_results).twice.and_return true
+          expect(Calabash::Cucumber::Map).to receive(:map).twice.and_return [true]
+          expect(Calabash::Cucumber::Map).to receive(:assert_map_results).twice.and_return true
         end
 
         it 'up' do
@@ -403,4 +407,3 @@ describe Calabash::Cucumber::Core do
     end
   end
 end
-


### PR DESCRIPTION
### Motivation

Replaces **Map: rename map to fetch_results** #1062

Defining `map` in the Cucumber World is causing problems with third-party gems.

ATTN: @svandeven, @krukow