### PR TITLE
IRB: add the .irbrc file back to the gem

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -18,7 +18,7 @@ staticlib = %w(staticlib/calabash.framework.zip staticlib/libFrankCalabash.a)
 dylibs = %w(dylibs/libCalabashDyn.dylib dylibs/libCalabashDynSim.dylib)
 
 # files in script
-scripts = %w(scripts/calabash.xcconfig.erb)
+scripts = %w(scripts/.irbrc scripts/calabash.xcconfig.erb)
 
 # files in script/data
 scripts_data = Dir.glob('scripts/data/*.plist')


### PR DESCRIPTION
### Motivation

Fixes **calabash-ios console doesn't work in 0.19.0.pre2** #1064