### PR TITLE
Remove 'sim location' CLI tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - script/ci/travis/bundle-install.rb
   - script/ci/travis/install-gem-ci.rb
   - script/ci/travis/rspec.sh
+  - script/ci/cli.sh
 
 rvm:
   - 2.1.7

--- a/calabash-cucumber/bin/calabash-ios
+++ b/calabash-cucumber/bin/calabash-ios
@@ -55,8 +55,6 @@ elsif cmd == 'sim'
     calabash_sim_reset
   elsif subcmd == 'acc'
     calabash_sim_accessibility
-  elsif subcmd == 'location'
-      calabash_sim_location(ARGV)
   elsif subcmd == 'locale'
     calabash_sim_locale(ARGV)
   else

--- a/calabash-cucumber/bin/calabash-ios-helpers.rb
+++ b/calabash-cucumber/bin/calabash-ios-helpers.rb
@@ -1,14 +1,11 @@
 require 'tempfile'
 require 'json'
 
-UPDATE_TARGETS = ['hooks']
-
 def msg(title, &block)
   puts "\n" + "-"*10 + title + "-"*10
   block.call
   puts "-"*10 + "-------" + "-"*10 + "\n"
 end
-
 
 def print_usage
   puts <<EOF
@@ -20,20 +17,18 @@ def print_usage
       generate a features folder structure.
     console
       starts an interactive console to interact with your app via Calabash
-    setup [<path>]
-      setup your XCode project for calabash-ios (EXPERIMENTAL)
     download
       install latest compatible version of calabash.framework
-    check [{<path to .ipa>|<path to .app>}]
-      check whether an app or ipa is linked with calabash.framework (EXPERIMENTAL)
-    sim locale <lang> [<region>]
-      change locale and regional settings in all iOS Simulators
-    sim location {on|off} <bundleid>
-      set allow location on/off for current project or bundleid
+    sim locale [language code] [locale code]
+      change locale and regional settings for an iOS Simulator
     sim reset
       reset content and settings in all iOS Simulators
     sim acc
       enable accessibility in all iOS Simulators
+    check [{<path to .ipa>|<path to .app>}]
+      check whether an app or ipa is linked with calabash.framework (EXPERIMENTAL)
+    setup [<path>]
+      setup your Xcode project for calabash-ios (EXPERIMENTAL)
 EOF
 end
 

--- a/calabash-cucumber/bin/calabash-ios-helpers.rb
+++ b/calabash-cucumber/bin/calabash-ios-helpers.rb
@@ -34,7 +34,7 @@ end
 
 def print_help
   file = File.join(File.dirname(__FILE__), '..', 'doc', 'calabash-ios-help.txt')
-  system("less #{file}")
+  puts File.read(file)
 end
 
 def ensure_correct_path(args)

--- a/calabash-cucumber/bin/calabash-ios-sim.rb
+++ b/calabash-cucumber/bin/calabash-ios-sim.rb
@@ -12,49 +12,6 @@ def calabash_sim_accessibility
   RunLoop::SimControl.new.enable_accessibility_on_sims
 end
 
-def calabash_sim_location(args)
-
-  if args.length == 0
-    print_usage
-    exit 0
-  end
-  on_off = args.shift
-  if args.length == 0
-    print_usage
-    exit 0
-  end
-  bundle_id = args.shift
-
-
-  dirs = Dir.glob(File.join(File.expand_path("~/Library"), "Application Support", "iPhone Simulator", "*.*", "Library", "Caches", "locationd"))
-  dirs.each do |sim_dir|
-    existing_path = "#{sim_dir}/clients.plist"
-    if File.exist?(existing_path)
-      plist_path = existing_path
-    else
-      plist_path = File.expand_path("#{@script_dir}/data/clients.plist")
-    end
-
-    plist = CFPropertyList::List.new(:file => plist_path)
-    hash = CFPropertyList.native_types(plist.value)
-
-    app_hash = hash[bundle_id]
-    if not app_hash
-      app_hash = hash[bundle_id] = {}
-    end
-    app_hash["BundleId"] = bundle_id
-    app_hash["Authorized"] = on_off == "on" ? true : false
-    app_hash["LocationTimeStarted"] = 0
-
-    ##Plist edit the template
-    res_plist = CFPropertyList::List.new
-    res_plist.value = CFPropertyList.guess(hash)
-    res_plist.save(existing_path, CFPropertyList::List::FORMAT_BINARY)
-
-  end
-end
-
-
 def calabash_sim_locale(args)
 
   if args.length != 2

--- a/calabash-cucumber/doc/calabash-ios-help.txt
+++ b/calabash-cucumber/doc/calabash-ios-help.txt
@@ -1,72 +1,35 @@
 Usage: calabash-ios <command-name> [parameters]
-  <command-name> can be one of
-    help
-    gen
-    download [opt path]?
-    sim locale [language code] [locale code]
-    sim reset
-    sim acc
-    setup (EXPERIMENTAL) [opt path]?
-    check (EXPERIMENTAL) [opt path to .ipa/.app]?
 
   Commands:
-  gen creates a skeleton features dir. This is usually used once when
+
+  version
+      Print the version of the Calabash iOS gem.
+
+  gen
+      Creates a skeleton features dir. This is usually used once when
       setting up calabash to ensure that the features folder contains
       the right step definitions and environment to run with cucumber.
+
   console
-      starts an interactive console to interact with your app via Calabash.
-      Supports setting environment var CALABASH_IRBRC for custom .irbrc file.
+      Starts an interactive console to interact with your app via Calabash.
+      If there is a .irbrc in your local directory, the IRB will load that file.
+      To share an .irbrc across projects, use the CALABASH_IRBRC environment
+      variable.
 
-  setup [path]? (EXPERIMENTAL) Automates setting up your iOS Xcode project
-        with calabash-ios-server. It is your responsibility to ensure
-        that your production build does not link with calabash.framework.
-        setup will try to ensure this, but you should check manually.
+  download
+      Copies current compatible version of calabash.framework to your project.
+      It should be run from a directory containing an Xcode project,
 
-        setup will download calabash.framework and modify you Xcode project
-        file. The parameter [path] is optional (default is the current dir).
-        If specified [path] should be the path to your iOS Xcode project
-        (i.e., the folder which contains projectname.xcodeproj).
+  check { path/to/My.app | path/to/My.ipa }
+      Check whether an app or ipa is linked with calabash.framework
 
-        The following modifications are made
-          - duplicate an existing target of your choice
-          - add the calabash.framework to your Frameworks folder
-          - add $(SRCROOT) to framework search path
-          - link with calabash.framework in duped target
-          - link with Apple's CFNetwork.framework in duped target
-          - setup special linker options to ensure calabash is loaded
+  sim locale [lang code] [locale code]
+      Changes the regional settings.  For usage information, run:
+      $ calabash-ios sim locale
 
-        Your Xcode project file will be backed up as project.pbxproj.bak.
-        The backup is placed in the .xcodeproj folder for your project.
-        If something goes wrong. Close Xcode and copy project.pbxproj.bak
-        to project.pbxproj inside your .xcodeproj folder.
+  sim reset
+      Reset the Content & Settings of all iOS Simulators
 
-  download [opt_path]?
-        copies current compatible version of calabash.framework to your project.
-        It should be run from a directory containing an Xcode project,
-        or optionally opt_path should be supplied and pointing to a
-        directory containing an Xcode project.
-        Will copy in the latest version that matches the
-        currently installed calabash-cucumber gem.
-        To update Calabash for your project run
-
-        gem install calabash-cucumber
-        calabash-ios download
-
-        Then clean and rebuild to your project.
-        Check the current server version on http://localhost:37265/version
-
-  check (EXPERIMENTAL) [.app or .ipa]?
-        check whether an app or ipa is linked with calabash.framework
-        if called without parameter [.app or .ipa] then pwd should be
-        a directory containing an xcodeproj. In this case we'll check
-        the default Xcode simulator build path for a Debug and Calabash
-        build configurations. We check that Debug doesn't link with
-        calabash.framework but Calabash does.
-
-  sim locale  [lang] [regional]? Changes the regional settings
-      for the iOS Simulators. You must ensure the correct format
-      for the optional regional parameter, for example,
-      da_DK, en_US.
-
-  sim reset Reset the Content & Settings of all iOS Simulators
+  setup [path]? (EXPERIMENTAL)
+      https://github.com/calabash/calabash-ios/wiki/calabash-ios-setup
 

--- a/calabash-cucumber/doc/calabash-ios-help.txt
+++ b/calabash-cucumber/doc/calabash-ios-help.txt
@@ -2,13 +2,12 @@ Usage: calabash-ios <command-name> [parameters]
   <command-name> can be one of
     help
     gen
-    setup (EXPERIMENTAL) [opt path]?
     download [opt path]?
-    check (EXPERIMENTAL) [opt path to .ipa/.app]?
-    sim locale [lang] [regional]?
+    sim locale [language code] [locale code]
     sim reset
     sim acc
-    sim location {on|off} <bundleid>
+    setup (EXPERIMENTAL) [opt path]?
+    check (EXPERIMENTAL) [opt path to .ipa/.app]?
 
   Commands:
   gen creates a skeleton features dir. This is usually used once when
@@ -69,9 +68,5 @@ Usage: calabash-ios <command-name> [parameters]
       for the optional regional parameter, for example,
       da_DK, en_US.
 
-  sim location {on|off} <bundleid>
-      set allow location on/off for current project or bundleid
-
-  sim reset (EXPERIMENTAL) Will select "Reset Content and Settings"
-      in the iOS Simulators using AppleScript.
+  sim reset Reset the Content & Settings of all iOS Simulators
 

--- a/script/ci/cli.sh
+++ b/script/ci/cli.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+cd calabash-cucumber
+
+function info {
+  echo "$(tput setaf 2)INFO: $1$(tput sgr0)"
+}
+
+set -e
+
+export DEBUG=1
+
+info "Testing 'calabash-ios'"
+bundle exec calabash-ios
+
+info "Testing 'calabash-ios help'"
+bundle exec calabash-ios help
+
+info "Testing 'calabash-ios version'"
+bundle exec calabash-ios version
+
+info "Testing 'calabash-ios check .app'"
+bundle exec calabash-ios check spec/resources/CalSmoke-cal.app
+
+info "Testing 'calabash-ios check .ipa'"
+bundle exec calabash-ios check spec/resources/LPSimpleExample-cal.ipa
+
+info "Testing 'calabash-ios check .app' without calabash"
+set +e
+bundle exec calabash-ios check spec/resources/CalSmoke.app
+if [ "$?" != "1" ]; then
+  exit 1
+fi
+set -e
+
+info "Testing 'calabash-ios sim locale' usage info"
+bundle exec calabash-ios sim locale
+
+info "Testing 'calabash-ios sim reset'"
+bundle exec calabash-ios sim reset
+
+info "Testing 'calabash-ios sim acc'"
+bundle exec calabash-ios sim acc
+

--- a/script/ci/jenkins/run.sh
+++ b/script/ci/jenkins/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+script/ci/jenkins/rspec.sh
+script/ci/cli.sh
+


### PR DESCRIPTION
### Motivation

This feature has been broken since Xcode 6. 

