### PR TITLE
Improve console experience

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -59,6 +59,7 @@ Gem::Specification.new do |s|
   s.add_dependency('httpclient', '>= 2.3.2', '< 3.0')
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
+  s.add_dependency("clipboard", "~> 1.0")
   s.add_dependency("run_loop", ">= 2.1.1", "< 3.0")
 
   # Shared with run-loop.

--- a/calabash-cucumber/lib/calabash-cucumber/console_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/console_helpers.rb
@@ -73,6 +73,30 @@ module Calabash
         puts RunLoop::Color.green("Calabash says, '#{messages.shuffle.first}'")
       end
 
+      # Turn on debug logging.
+      def verbose
+        if RunLoop::Environment.debug?
+          puts RunLoop::Color.cyan("Debug logging is already turned on.")
+        else
+          ENV["DEBUG"] = "1"
+          puts RunLoop::Color.cyan("Turned on debug logging.")
+        end
+
+        true
+      end
+
+      # Turn off debug logging.
+      def quiet
+        if RunLoop::Environment.debug?
+          ENV["DEBUG"] = "0"
+          puts RunLoop::Color.cyan("Turned off debug logging.")
+        else
+          puts RunLoop::Color.cyan("Debug logging is already turned off.")
+        end
+
+        true
+      end
+
       private
 
       # List the visible element with given mark(s).

--- a/calabash-cucumber/lib/calabash-cucumber/console_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/console_helpers.rb
@@ -46,6 +46,33 @@ module Calabash
         true
       end
 
+      # Print a message to the console.
+      def puts_message_of_the_day
+        messages = [
+          "Let's get this done!",
+          "Ready to rumble.",
+          "Enjoy.",
+          "Remember to breathe.",
+          "Take a deep breath.",
+          "Isn't it time for a break?",
+          "Can I get you a coffee?",
+          "What is a calabash anyway?",
+          "Smile! You are on camera!",
+          "Let op! Wild Rooster!",
+          "Don't touch that button!",
+          "I'm gonna take this to 11.",
+          "Console. Engaged.",
+          "Your wish is my command.",
+          "This console session was created just for you.",
+          "Den som jager to harer, får ingen.",
+          "Uti, non abuti.",
+          "Non Satis Scire",
+          "Nullius in verba",
+          "Det ka æn jå væer ei jált"
+        ]
+        puts RunLoop::Color.green("Calabash says, '#{messages.shuffle.first}'")
+      end
+
       private
 
       # List the visible element with given mark(s).

--- a/calabash-cucumber/lib/calabash-cucumber/console_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/console_helpers.rb
@@ -131,6 +131,23 @@ module Calabash
         true
       end
 
+      # @!visibility private
+      def puts_console_details
+        puts ""
+        puts RunLoop::Color.magenta("#########################  Useful Methods  ##########################")
+        puts RunLoop::Color.cyan("     ids => List all the visible accessibility ids.")
+        puts RunLoop::Color.cyan("  labels => List all the visible accessibility labels.")
+        puts RunLoop::Color.cyan("    text => List all the visible texts.")
+        puts RunLoop::Color.cyan("   marks => List all the visible marks.")
+        puts RunLoop::Color.cyan("    tree => The app's visible view hierarchy.")
+        puts RunLoop::Color.cyan("   flash => flash(<query>); Disco effect for views matching <query>")
+        puts RunLoop::Color.cyan(" verbose => Turn debug logging on.")
+        puts RunLoop::Color.cyan("   quiet => Turn debug logging off.")
+        puts RunLoop::Color.cyan("    copy => Copy console commands to clipboard.")
+        puts RunLoop::Color.cyan("   clear => Clear the console.")
+        puts ""
+      end
+
       private
 
       # List the visible element with given mark(s).

--- a/calabash-cucumber/scripts/.irbrc
+++ b/calabash-cucumber/scripts/.irbrc
@@ -42,6 +42,8 @@ end
 
 require "calabash-cucumber"
 
+Calabash::Cucumber::ConsoleHelpers.start_readline_history!
+
 def preferences
   Calabash::Cucumber::Preferences.new
 end

--- a/calabash-cucumber/scripts/.irbrc
+++ b/calabash-cucumber/scripts/.irbrc
@@ -57,3 +57,5 @@ def enable_usage_tracking(level="system_info")
   puts "Calabash will collect statistics using the '#{level}' rule."
   level
 end
+
+puts_message_of_the_day

--- a/calabash-cucumber/scripts/.irbrc
+++ b/calabash-cucumber/scripts/.irbrc
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'irb/completion'
 require 'irb/ext/save-history'
 

--- a/calabash-cucumber/scripts/.irbrc
+++ b/calabash-cucumber/scripts/.irbrc
@@ -1,5 +1,6 @@
 require "irb/completion"
 require "irb/ext/save-history"
+require "benchmark"
 
 begin
   require "awesome_print"

--- a/calabash-cucumber/scripts/.irbrc
+++ b/calabash-cucumber/scripts/.irbrc
@@ -60,4 +60,5 @@ def enable_usage_tracking(level="system_info")
   level
 end
 
+puts_console_details
 puts_message_of_the_day

--- a/calabash-cucumber/scripts/.irbrc
+++ b/calabash-cucumber/scripts/.irbrc
@@ -27,14 +27,17 @@ ARGV.concat [ '--readline',
               '--prompt-mode',
               'simple']
 
-IRB.conf[:SAVE_HISTORY] = 50
+IRB.conf[:SAVE_HISTORY] = 100
 IRB.conf[:HISTORY_FILE] = '.irb-history'
 
-require 'calabash-cucumber/operations'
-extend Calabash::Cucumber::Operations
+begin
+  require "pry"
+  Pry.config.history.should_save = false
+  Pry.config.history.should_load = false
+  require "pry-nav"
+rescue LoadError => _
 
-require 'calabash-cucumber/console_helpers'
-include Calabash::Cucumber::ConsoleHelpers
+end
 
 def embed(x,y=nil,z=nil)
   puts "Screenshot at #{x}"
@@ -42,6 +45,24 @@ end
 
 require "calabash-cucumber"
 
+IRB.conf[:AUTO_INDENT] = true
+
+IRB.conf[:PROMPT][:CALABASH_IOS] = {
+  :PROMPT_I => "calabash-ios #{Calabash::Cucumber::VERSION}> ",
+  :PROMPT_N => "calabash-ios #{Calabash::Cucumber::VERSION}> ",
+  :PROMPT_S => nil,
+  :PROMPT_C => "> ",
+  :AUTO_INDENT => false,
+  :RETURN => "%s\n"
+}
+
+IRB.conf[:PROMPT_MODE] = :CALABASH_IOS
+
+require 'calabash-cucumber/operations'
+extend Calabash::Cucumber::Operations
+
+require 'calabash-cucumber/console_helpers'
+include Calabash::Cucumber::ConsoleHelpers
 Calabash::Cucumber::ConsoleHelpers.start_readline_history!
 
 def preferences

--- a/calabash-cucumber/scripts/.irbrc
+++ b/calabash-cucumber/scripts/.irbrc
@@ -1,33 +1,35 @@
-require 'irb/completion'
-require 'irb/ext/save-history'
+require "irb/completion"
+require "irb/ext/save-history"
 
 begin
-  require 'awesome_print'
+  require "awesome_print"
 rescue LoadError => e
-  msg = ["Caught a LoadError: could not load 'awesome_print'",
-         "#{e}",
-         '',
-         'Use bundler (recommended) or uninstall awesome_print.',
-         '',
-         '# Use bundler (recommended)',
-         '$ bundle update',
-         '$ bundle exec calabash-ios console',
-         '',
-         '# Uninstall',
-         '$ gem update --system',
-         '$ gem uninstall -Vax --force --no-abort-on-dependent awesome_print']
-  puts msg
+  puts %Q[
+Caught a LoadError: could not load 'awesome_print'",
+
+#{e}
+
+Use bundler (recommended) or uninstall awesome_print.
+
+# Use bundler (recommended)
+$ bundle update
+$ bundle exec calabash-ios console
+
+# Uninstall awesome_print and reinstall calabash-cucumber
+$ gem update --system
+$ gem uninstall -Vax --force --no-abort-on-dependent awesome_print
+$ gem install calabash-cucumber
+
+]
   exit(1)
 end
 
 AwesomePrint.irb!
 
-ARGV.concat [ '--readline',
-              '--prompt-mode',
-              'simple']
+ARGV.concat ["--readline", "--prompt-mode", "simple"]
 
 IRB.conf[:SAVE_HISTORY] = 100
-IRB.conf[:HISTORY_FILE] = '.irb-history'
+IRB.conf[:HISTORY_FILE] = ".irb-history"
 
 begin
   require "pry"
@@ -57,10 +59,10 @@ IRB.conf[:PROMPT][:CALABASH_IOS] = {
 
 IRB.conf[:PROMPT_MODE] = :CALABASH_IOS
 
-require 'calabash-cucumber/operations'
+require "calabash-cucumber/operations"
 extend Calabash::Cucumber::Operations
 
-require 'calabash-cucumber/console_helpers'
+require "calabash-cucumber/console_helpers"
 include Calabash::Cucumber::ConsoleHelpers
 Calabash::Cucumber::ConsoleHelpers.start_readline_history!
 

--- a/calabash-cucumber/spec/bin/calabash_ios_cli_spec.rb
+++ b/calabash-cucumber/spec/bin/calabash_ios_cli_spec.rb
@@ -45,7 +45,7 @@ describe 'Command Line Interface' do
     copied_irbrc = File.join(target_dir, '.irbrc')
     FileUtils.cp(original_irbrc, copied_irbrc)
     contents = File.read(copied_irbrc)
-    substituted = contents.gsub(/require 'awesome_print'/, "require 'unknown_gem'")
+    substituted = contents.gsub(/require "awesome_print"/, "require 'unknown_gem'")
     File.open(copied_irbrc, 'w') do |file|
       file.puts substituted
     end
@@ -58,7 +58,7 @@ describe 'Command Line Interface' do
       err = stderr.read.strip
 
       expect(err).to be == ''
-      expect(out[/Caught a LoadError: could not load 'awesome_print'/,0]).to_not be nil
+      expect(out[/Caught a LoadError: could not load 'awesome_print'/,0]).to be_truthy
       expect(process_status.value.exitstatus).to be == 1
     end
   end

--- a/calabash-cucumber/spec/integration/console_helpers_spec.rb
+++ b/calabash-cucumber/spec/integration/console_helpers_spec.rb
@@ -22,16 +22,22 @@ describe "Calabash::Cucumber::ConsoleHelpers" do
     path
   end
 
-  it "ids, labels, text, marks, and tree" do
+  it "calabash-ios console" do
     env = {"CALABASH_IRBRC" => dot_irbrc}
     out, err = nil
     Open3.popen3(env, "bundle", "exec", "calabash-ios", "console") do |stdin, stdout, stderr, _|
       stdin.puts "start_test_server_in_background(#{launch_options})"
       stdin.puts "ids"
       stdin.puts "labels"
+      stdin.puts %Q[query("view marked:'switch'")]
       stdin.puts "text"
       stdin.puts "marks"
       stdin.puts "tree"
+      stdin.puts %Q[touch("view marked:'switch'")]
+      stdin.puts "copy"
+      stdin.puts "clear_clipboard"
+      # Don't call because it messes with debugging output
+      # stdin.puts "clear"
       stdin.close
       out = stdout.read.strip
       err = stderr.read.strip
@@ -40,12 +46,17 @@ describe "Calabash::Cucumber::ConsoleHelpers" do
     puts out
     puts err
     expect(out[/Error/,0]).to be == nil
+    expect(err).to be == ""
 
     out_no_color = out.gsub(/\e\[(\d+)m/, "")
 
     # message of the day
     expect(out_no_color[/Calabash says,/, 0]).to be_truthy
 
-    expect(err).to be == ""
+    # clip board does not seem to be available in subshell
+    # copy-n-paste
+    # expected = "query(\"view marked:'switch'\")\ntouch(\"view marked:'switch'\")"
+    # expect(out_no_color[/#{expected}/,0]).to be_truthy
+
   end
 end

--- a/calabash-cucumber/spec/integration/console_helpers_spec.rb
+++ b/calabash-cucumber/spec/integration/console_helpers_spec.rb
@@ -40,6 +40,12 @@ describe "Calabash::Cucumber::ConsoleHelpers" do
     puts out
     puts err
     expect(out[/Error/,0]).to be == nil
-    expect(err).to be == ''
+
+    out_no_color = out.gsub(/\e\[(\d+)m/, "")
+
+    # message of the day
+    expect(out_no_color[/Calabash says,/, 0]).to be_truthy
+
+    expect(err).to be == ""
   end
 end

--- a/calabash-cucumber/spec/lib/console_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/console_helpers_spec.rb
@@ -131,16 +131,51 @@ describe "Calabash::Cucumber::ConsoleHelpers" do
     expect(out[/\[24\] id     =>                   UITextField => text/, 0]).to be_truthy
   end
 
-  it "#print_marks" do
-    console.send(:print_marks, ids, 29)
-  end
-
   it "#puts_message_of_the_day" do
     out = capture_stdout do
       console.puts_message_of_the_day
     end.string.gsub(/\e\[(\d+)m/, "")
 
     expect(out[/Calabash says,/, 0]).to be_truthy
+  end
+
+  describe "verbose and quiet" do
+    let(:original_debug) { ENV["DEBUG"] }
+
+    describe "#verbose" do
+      it "already on" do
+        expect(RunLoop::Environment).to receive(:debug?).and_return(true)
+        console.verbose
+      end
+
+      it "turns it on" do
+        expect(RunLoop::Environment).to receive(:debug?).and_return(false)
+        console.verbose
+        expect(ENV["DEBUG"]).to be == "1"
+      end
+    end
+
+    describe "#quiet" do
+      it "already off" do
+        expect(RunLoop::Environment).to receive(:debug?).and_return(false)
+        console.quiet
+      end
+
+      it "turns it off" do
+        expect(RunLoop::Environment).to receive(:debug?).and_return(true)
+        console.quiet
+        expect(ENV["DEBUG"]).to be == "0"
+      end
+    end
+
+    after do
+      ENV["DEBUG"] = original_debug
+    end
+  end
+
+
+  it "#print_marks" do
+    console.send(:print_marks, ids, 29)
   end
 
   describe "accessibility_marks" do

--- a/calabash-cucumber/spec/lib/console_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/console_helpers_spec.rb
@@ -135,6 +135,14 @@ describe "Calabash::Cucumber::ConsoleHelpers" do
     console.send(:print_marks, ids, 29)
   end
 
+  it "#puts_message_of_the_day" do
+    out = capture_stdout do
+      console.puts_message_of_the_day
+    end.string.gsub(/\e\[(\d+)m/, "")
+
+    expect(out[/Calabash says,/, 0]).to be_truthy
+  end
+
   describe "accessibility_marks" do
     let(:options) { {:print => false, :return => true} }
 

--- a/calabash-cucumber/spec/resources/console/history-with-non-utf8.log
+++ b/calabash-cucumber/spec/resources/console/history-with-non-utf8.log
@@ -1,0 +1,4 @@
+  PID COMMAND
+  324 /usr/libexec/UserEventAgent (Aqua)
+  403 /Applications/ÊM^\M^IÈM^AM^SËØM^MÂM^E∏.app/Contents/MacOS/ÊM^\M^IÈM^AM^SËØM^MÂM^E∏
+ 1497 irb


### PR DESCRIPTION
### Motivation

* Improves view discoverability with `tree`, `ids`, `labels`, `text`, and `marks` commands.
* Improves workflow with `copy` and `clear` commands.
* Prints useful console methods
* Loads `pry` and `pry-nav` if they are available
* Console prompt includes current Calabash iOS version
* Improved indenting for multiline commands
* Adds levity by printing a message of the day.

Thanks @ark-konopacki for porting `briar` console commands and Calabash 2.0 `copy`.


```
$ DEBUG=1 APP=spec/resources/CalSmoke-cal.app IRBRC=scripts/.irbrc be irb
#########################  Useful Methods  ##########################
     ids => List all the visible accessibility ids.
  labels => List all the visible accessibility labels.
    text => List all the visible texts.
   marks => List all the visible marks.
    tree => The app's visible view hierarchy.
   flash => flash(<query>); Disco effect for views matching <query>
 verbose => Turn debug logging on.
   quiet => Turn debug logging off.
    copy => Copy console commands to clipboard.
   clear => Clear the console.

Calabash says, "Don't touch that button!"
calabash-ios 0.19.0.pre2>
```