### PR TITLE
Release/0.19.0.pre3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This release remove almost all deprecated methods.  Further, Calabash
 will no longer respond to legacy environment variables.
 
+* Improve console experience #1073
+* Remove 'sim location' CLI tool #1071
+* Added tree feature for console #1070 @ark-konopacki
+* Added briar's marks extension for irbc #1068 @ark-konopacki
+* Complete switch to run loop 2.1.0 interface #1069
+* Change Map module to class and provide class methods #1065 @svandeven
 * Use tap_keyboard_action_key instead of done #1057 @lucatorella
 * Launcher#check_server_gem_compatibility should be a post-launch check
   #1051

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -3,7 +3,7 @@ module Calabash
 
     # @!visibility public
     # The Calabash iOS gem version.
-    VERSION = "0.19.0.pre2"
+    VERSION = "0.19.0.pre3"
 
     # @!visibility public
     # The minimum required version of the Calabash embedded server.

--- a/changelog/0.19.0.md
+++ b/changelog/0.19.0.md
@@ -2,113 +2,26 @@
 
 These notes are not complete yet.
 
+### TODO
 
-### Removed
+- [ ] update API docs
 
-* Calabash::Cucumber::SimulatorHelper
-* Calabash::Cucumber::SimulatorLauncher
+This is a significant release. We have dropped many legacy APIs and behaviors
+to make space for our new DeviceAgent tool which is our replacement for
+UIAutomation.  This release of Calabash does not contain an interface to
+DeviceAgent, but if you look at commit history of run_loop, you will see that
+have already started integrating DeviceAgent with run_loop.
 
-### Logging
+Requirements:
 
-* no_deprecation_warnings?
-
-### EnvironmentHelpers
-
-* full\_console\_logging?
-
-### Launcher
-
-* Launcher#detect_connected_device?
-* discover_device_target
-* sdk_version
-* sdk_version_for_simulator_target
-* use_instruments_env?
-* use_sim_launcher_env?
-* calabash_no_launch? <== NO OP
-
-### Environment Variables
-
-* CALABASH_NO_DEPRECATION
-* DETECT_CONNECTED_DEVICE
-* CALABASH_FULL_CONSOLE_LOGGING
-* SDK_VERSION
-* OS
-
-### KeyboardHelpers
-
-* await_keyboard
-* done
-
-* This release requires a server update to 0.18.2.
-* This releases requires at least run-loop 2.0.9.
-* Calabash iOS now requires ruby >= 2.0.
+* Calabash iOS server == 0.19.0
+* run_loop >= 2.1.1
+* Ruby >= 2.0
 
 These two wiki pages have instructions for updating the most recent versions.
 
 * [Updating your Calabash iOS version.](https://github.com/calabash/calabash-ios/wiki/B1-Updating-your-Calabash-iOS-version)
 * [Updating your run-loop version.](https://github.com/calabash/calabash-ios/wiki/Updating-your-run-loop-version)
-
-### IMPORTANT
-
-The TCC.db interface for iOS Simulators has been removed from Calabash
-iOS.  It has been broken for CoreSimulator environments since Xcode 6.
-
-The `done` method is now deprecated.  It will be removed in Calabash iOS
-0.19.0.  It was replaced with `tap_keyboard_action_key` in Calabash
-0.10.0.
-
-A number of methods have been removed from Calabash::Cucumber::Launcher.
-See the Deprecated section below.
-
-### Fixes
-
-* Improved screenshots for OpenGL views, custom keyboards, alerts, and
-  sheets.
-* App bundle detection has been reimplement in RunLoop.  Thank you to
-  @ark-konopacki, @arulami, and @topgenorth for letting me borrow their
-  machines to debug this problem.
-
-### Automatic App Detection
-
-If Calabash cannot detect your application, you will see new errors.
-The error messages will tell you where Calabash searched for you
-application and give you suggestions about how to help Calabash find
-your application.
-
-#### MultipleXcodeProjectError
-
-Calabash depends on information in your .xcodeproj to find your application.
-If there are multiple .xcodeproj in or below the directory where you run
-`cucumber`, Calabash might not be able to determine which .xcodeproj to use.
-If you get this error,  set the `XCODEPROJ` environment variable.
-
-```
-$ XCODEPROJ=My.xcodeproj bundle exec cucumber
-```
-
-#### NoSimulatorAppFoundError
-
-If no application for the iOS Simulator can be found in your DerivedData
-directories or by searching recursively down from the directory where
-you run `cucumber`, this error will be raised.  You probably need to
-build your application for the iOS Simulator.
-
-#### Dylib injection
-
-If you are using dylib injection, automatic detection _will not work_
-for you.  The search algorithm only finds .app bundles that have been
-linked with Calabash.  You must continue to use the `APP` environment
-variable.
-
-### 0.19.0
-
-Calabash iOS 0.19.0 will deprecate many parts Calabash.  In particular,
-the playback API will be removed and the SimulatorLauncher module will
-be removed.  We need to prepare for running with XCUITest.
-
-We wll try hard to be backwards compatible, but there will be some bumps in
-the road.  We have a lot of legacy code from iOS 3, 4, 5, and 6 that needs to
-go because it is slowing down the development of new features.
 
 ### Sudo
 
@@ -121,6 +34,81 @@ For advanced users, we recommend a [managed ruby](https://github.com/calabash/ca
 
 If you are not already using bundler and Gemfile, we strongly recommend
 that you start.
+
+### IMPORTANT
+
+The WebView marked API [1] has been removed; see this issue [2] for more details. 
+
+`done` has been removed [3] from the public API because it conflicts with Cucumber 2.1 `done`.  
+
+`tap` has been removed from the public API.  It has been deprecated since 0.10.0.  Use `touch`.  Thank you for everyone who reported problems and for your patience.
+
+`map` has been replaced with `Calabash::Cucumber::Map.map`. [4]
+
+`Calabash::Cucumber::Launcher` has been rewritten. You will find many methods have been deprecated or removed.  You might need to update your launch hooks.
+
+Calabash no longer responds to these environment variables:
+
+* CALABASH\_NO\_DEPRECATION
+* DETECT\_CONNECTED\_DEVICE
+* CALABASH\_FULL\_CONSOLE\_LOGGING
+
+These variables are being replaced:
+
+* NO\_STOP is in the process of being deprecated; use QUIT\_APP\_AFTER\_SCENARIO
+* BUNDLE\_ID and APP\_BUNDLE\_PATH are in the process of being replaced with APP.
+
+The public documentation [5] describes what variables Calabash iOS responds to.
+
+* [1] [WebView marked API](https://github.com/calabash/calabash-ios/wiki/06-WebView-Support#deprecated-apis) 
+* [2] Cannot query UIWebView by accessibilityIdentifier or accessibilityLabel
+[#735](https://github.com/calabash/calabash-ios/issues/735) @scottgoldwater
+* [3] KeyboardHelpers#done clobbers the Cucumber 2.1 method #done [#976](https://github.com/calabash/calabash-ios/issues/976) @TeresaP, @lucatorella
+* [4] Change Map module to class and provide class methods [#1065](https://github.com/calabash/calabash-ios/issues/1065) @svandeven
+* [5] http://calabashapi.xamarin.com/ios/file.ENVIRONMENT_VARIABLES.html
+
+### Improvements
+
+The `calabash-ios console` was updated with methods to improve discoverability and your workflow.
+
+Thanks to @ark-konopacki for porting console methods from briar and
+Calabash 2.0
+
+```
+$ bundle exec calabash-ios console
+
+#########################  Useful Methods  ##########################
+     ids => List all the visible accessibility ids.
+  labels => List all the visible accessibility labels.
+    text => List all the visible texts.
+   marks => List all the visible marks.
+    tree => The app's visible view hierarchy.
+   flash => flash(<query>); Disco effect for views matching <query>
+ verbose => Turn debug logging on.
+   quiet => Turn debug logging off.
+    copy => Copy console commands to clipboard.
+   clear => Clear the console.
+
+Calabash says, "Don't touch that button!"
+calabash-ios 0.19.0.pre2>
+```
+
+The `DEVICE_TARGET` method can take a device name as an argument as long as it appears as the name that appears in the output of `xcrun instruments -s devices`.
+
+```
+$ xcrun instruments -s devices
+Known Devices:
+stern [4AFA58C7-<snip>-04301E70E235]
+denis (9.3.1) [19368<snip>d8dd0d]
+
+$ DEVICE_TARGET=denis DEVICE_ENDPOINT=http://denis.local:37265 bundle exec cucumber
+```
+
+We are experimenting with the automatic detection of the DEVICE_ENDPOINT.  Pull requests are welcome. [1][2]
+
+- [1] https://github.com/calabash/run_loop/pull/385
+- [2] https://github.com/calabash/run_loop/blob/develop/lib/run_loop/xcuitest.rb#L189
+
 
 ### Docs and Examples
 
@@ -176,17 +164,9 @@ http://developer.xamarin.com/testcloud/
 
 See https://github.com/calabash/calabash-ios/wiki/Deprecated
 
-* RunLoop::XCTools has been deprecated (replaced) in run-loop 1.5.0.
-* RunLoop::Bridge::Simctl has been deprecated (replaced) in run-loop 2.0
 * RunLoop::SimControl is in the process of being deprecated; planned for run-loop 3.0
-* Calabash::Cucumber::Launcher - these methods have been removed and not
-  replaced:
-  * `detect_device_from_args`
-  * `detect_app_bundle_from_args`
-  * `info_plist_from_bundle_path`
-  * `info_plist_as_hash`
-  * `detect_bundle_id`
-  * `device_env`
+* NO_STOP is in the process of being deprecated; use QUIT_APP_AFTER_SCENARIO
+* BUNDLE_ID, APP_BUNDLE_PATH are in the process of being replaced with APP.
 
 ### Hot Topics
 


### PR DESCRIPTION
### 0.19.0

This release remove almost all deprecated methods.  Further, Calabash
will no longer respond to legacy environment variables.

* Improve console experience #1073
* Remove 'sim location' CLI tool #1071
* Added tree feature for console #1070 @ark-konopacki
* Added briar's marks extension for irbc #1068 @ark-konopacki
* Complete switch to run loop 2.1.0 interface #1069
* Change Map module to class and provide class methods #1065 @svandeven
* Use tap_keyboard_action_key instead of done #1057 @lucatorella
* Launcher#check_server_gem_compatibility should be a post-launch check
  #1051
* Launcher: use RunLoop 2.1.0 APIs where possible #1050
* Core: remove references to @calabash_launcher Cucumber World variable
  #1049
* Deprecate Launcher#calabash_notify #1048
* Deprecate old Launcher behaviors and use new RunLoop APIs in #relaunch
  #1047
* Launcher: deprecated #default_uia_strategy #1046
* Move http methods out of launcher #1044
* Rotation: remove playback API - since 0.16.2 #1040
* Replace NO_STOP with QUIT_APP_AFTER_SCENARIO #1038
* Unify logging between RunLoop and Calabash #1035
* Gem: remove deprecated.rb #1034
* Remove more deprecated Device behaviors #1033
* Remove CALABASH_VERSION_PATH #1028
* Remove unnecessary methods from Launcher #1027
* Remove deprecated methods for 0.19.0 #1026
* Remove the Playback API #1025
* Remove deprecated XcodeTools, PlistBuddy, and SimulatorAccessibility
  #1024
* Remove deprecated methods from KeyboardHelpers #1023
* Remove deprecated ENV variables and constants #1022
* Core: undeprecate #set_text #1021
* CLI: remove 'update' command #1020
* Remove sim_launcher gem dependency and SimulatorLauncher class #1016
* Remove KeyboardHelpers.done #1004
* Screen coordinates are incorrect when running in Zoomed mode #998
* Remove the sim_launcher dependency #921
* Cannot query UIWebView by accessibilityIdentifier or
  accessibilityLabel #735
