### PR TITLE
Gem: pin listen to 3.0.6

### DIFF
--- a/calabash-cucumber/Gemfile
+++ b/calabash-cucumber/Gemfile
@@ -1,4 +1,3 @@
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in calabash-ios-cucumber.gemspec
 gemspec

--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -79,6 +79,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-nav'
   s.add_development_dependency 'guard-rspec'
   s.add_development_dependency 'guard-bundler'
+  # Pin to 3.0.6; >= 3.1.0 requires ruby 2.2. This is guard dependency.
+  s.add_development_dependency("listen", "3.0.6")
   s.add_development_dependency 'growl'
   s.add_development_dependency 'stub_env'
   # Sometimes JSON.parse is failing to parse JSON dumped to a file.


### PR DESCRIPTION
### Motivation

`listen` is a dependency of `guard` which is part of our development stack.

`listen` 3.1.0 dropped ruby support for ruby < 2.2.