### PR TITLE
Comparison of Array with Array failed for `marks` and `text`

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/console_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/console_helpers.rb
@@ -38,7 +38,7 @@ module Calabash
         }
 
         counter = -1
-        res.sort.each { |elm|
+        res.sort_by.each { |elm|
           printf("%4s %-6s => %#{max_width}s => %s\n",
                  "[#{counter = counter + 1}]",
                  elm[2], elm[0], elm[1])
@@ -155,7 +155,7 @@ module Calabash
       # @param {Integer} max_width
       def print_marks(marks, max_width)
         counter = -1
-        marks.sort.each { |elm|
+        marks.sort_by.each { |elm|
           printf("%4s %#{max_width + 2}s => %s\n", "[#{counter = counter + 1}]", elm[0], elm[1])
         }
       end


### PR DESCRIPTION
When I called `marks` and `text` on my app, I got:

```irb(main):001:0> marks
ArgumentError: comparison of Array with Array failed
	from /Library/Ruby/Gems/2.0.0/gems/calabash-cucumber-0.19.1/lib/calabash-cucumber/console_helpers.rb:41:in `sort'
	from /Library/Ruby/Gems/2.0.0/gems/calabash-cucumber-0.19.1/lib/calabash-cucumber/console_helpers.rb:41:in `marks'
	from (irb):1
	from /usr/bin/irb:12:in `<main>'
```
```irb(main):002:0> text
ArgumentError: comparison of Array with Array failed
	from /Library/Ruby/Gems/2.0.0/gems/calabash-cucumber-0.19.1/lib/calabash-cucumber/console_helpers.rb:158:in `sort'
	from /Library/Ruby/Gems/2.0.0/gems/calabash-cucumber-0.19.1/lib/calabash-cucumber/console_helpers.rb:158:in `print_marks'
	from /Library/Ruby/Gems/2.0.0/gems/calabash-cucumber-0.19.1/lib/calabash-cucumber/console_helpers.rb:223:in `text_marks'
	from /Library/Ruby/Gems/2.0.0/gems/calabash-cucumber-0.19.1/lib/calabash-cucumber/console_helpers.rb:25:in `text'
	from (irb):2
	from /usr/bin/irb:12:in `<main>'
```