### PR TITLE
Fix rotate gesture

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -145,7 +145,7 @@ module Calabash
 
       # @! visibility private
       def rotate_with_uia(direction, current_orientation)
-        key = uia_orientation_key(direction, current_orientation)
+        key = orientation_key(direction, current_orientation)
         value = UIA_DEVICE_ORIENTATION[key]
         cmd = "UIATarget.localTarget().setDeviceOrientation(#{value})"
         uia(cmd)
@@ -162,7 +162,7 @@ module Calabash
       # :right => home button on the right => landscape_left
       #
       # Notice how :left and :right are mapped.
-      def uia_orientation_key(direction, current_orientation)
+      def orientation_key(direction, current_orientation)
         key = nil
         case direction
           when :left then

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -152,29 +152,38 @@ module Calabash
       end
 
       # @! visibility private
+      #
+      # It is important to remember that the current orientation is the
+      # position of the home button:
+      #
+      # :up => home button on the top => upside_down
+      # :bottom => home button on the bottom => portrait
+      # :left => home button on the left => landscape_right
+      # :right => home button on the right => landscape_left
+      #
+      # Notice how :left and :right are mapped.
       def uia_orientation_key(direction, current_orientation)
-
         key = nil
         case direction
           when :left then
             if current_orientation == :down
-              key = :landscape_right
-            elsif current_orientation == :right
-              key = :portrait
-            elsif current_orientation == :left
-              key = :upside_down
-            elsif current_orientation == :up
               key = :landscape_left
+            elsif current_orientation == :right
+              key = :upside_down
+            elsif current_orientation == :left
+              key = :portrait
+            elsif current_orientation == :up
+              key = :landscape_right
             end
           when :right then
             if current_orientation == :down
-              key = :landscape_left
-            elsif current_orientation == :right
-              key = :upside_down
-            elsif current_orientation == :left
-              key = :portrait
-            elsif current_orientation == :up
               key = :landscape_right
+            elsif current_orientation == :right
+              key = :portrait
+            elsif current_orientation == :left
+              key = :upside_down
+            elsif current_orientation == :up
+              key = :landscape_left
             end
           else
             raise ArgumentError,

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -91,7 +91,7 @@ module Calabash
 
         ap result if RunLoop::Environment.debug?
 
-        status_bar_orientation
+        status_bar_orientation.to_sym
       end
 
       private

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -123,8 +123,8 @@ module Calabash
       UIA_DEVICE_ORIENTATION = {
             :portrait => 1,
             :upside_down => 2,
-            :landscape_left => 3,
-            :landscape_right => 4
+            :landscape_left => 3, # Home button on the right
+            :landscape_right => 4 # Home button on the left
       }.freeze
 
       # @! visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -120,7 +120,7 @@ module Calabash
       end
 
       # @! visibility private
-      UIA_DEVICE_ORIENTATION = {
+      DEVICE_ORIENTATION = {
             :portrait => 1,
             :upside_down => 2,
             :landscape_left => 3, # Home button on the right
@@ -138,7 +138,7 @@ module Calabash
             raise ArgumentError,
                   "Expected '#{orientation}' to be :left, :right, :up, or :down"
         end
-        value = UIA_DEVICE_ORIENTATION[key]
+        value = DEVICE_ORIENTATION[key]
         cmd = "UIATarget.localTarget().setDeviceOrientation(#{value})"
         uia(cmd)
       end
@@ -146,7 +146,7 @@ module Calabash
       # @! visibility private
       def rotate_with_uia(direction, current_orientation)
         key = orientation_key(direction, current_orientation)
-        value = UIA_DEVICE_ORIENTATION[key]
+        value = DEVICE_ORIENTATION[key]
         cmd = "UIATarget.localTarget().setDeviceOrientation(#{value})"
         uia(cmd)
       end

--- a/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/rotation_helpers.rb
@@ -47,7 +47,7 @@ module Calabash
       def rotate_home_button_to(direction)
 
         begin
-          as_symbol = ensure_valid_rotate_home_to_arg(direction)
+          as_symbol = expect_valid_rotate_home_to_arg(direction)
         rescue ArgumentError => e
           raise ArgumentError, e.message
         end
@@ -102,7 +102,7 @@ module Calabash
       end
 
       # @! visibility private
-      def ensure_valid_rotate_home_to_arg(arg)
+      def expect_valid_rotate_home_to_arg(arg)
         coerced = arg.to_sym
 
         if coerced == :top

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -75,7 +75,7 @@ describe Calabash::Cucumber::RotationHelpers do
   end
 
   it '#rotate_with_uia' do
-    expect(helper).to receive(:uia_orientation_key).and_return :key
+    expect(helper).to receive(:orientation_key).and_return :key
     stub_const('Calabash::Cucumber::RotationHelpers::UIA_DEVICE_ORIENTATION', {:key => 'value' })
     expected = 'UIATarget.localTarget().setDeviceOrientation(value)'
     expect(helper).to receive(:uia).with(expected).and_return :result
@@ -86,37 +86,37 @@ describe Calabash::Cucumber::RotationHelpers do
   describe '#uia_orientation_key' do
     describe 'rotate :left' do
       it 'returns :landscape_left when home button is :down' do
-        expect(helper.send(:uia_orientation_key, :left, :down)).to be == :landscape_left
+        expect(helper.send(:orientation_key, :left, :down)).to be == :landscape_left
       end
 
       it 'returns :upside_down when home button is :right' do
-        expect(helper.send(:uia_orientation_key, :left, :right)).to be == :upside_down
+        expect(helper.send(:orientation_key, :left, :right)).to be == :upside_down
       end
 
       it 'returns :portrait with home button is :left' do
-        expect(helper.send(:uia_orientation_key, :left, :left)).to be == :portrait
+        expect(helper.send(:orientation_key, :left, :left)).to be == :portrait
       end
 
       it 'returns :landscape_right when the home button is :up' do
-        expect(helper.send(:uia_orientation_key, :left, :up)).to be == :landscape_right
+        expect(helper.send(:orientation_key, :left, :up)).to be == :landscape_right
       end
     end
 
     describe 'rotate :right' do
       it 'returns :landscape_right when home button is :down' do
-        expect(helper.send(:uia_orientation_key, :right, :down)).to be == :landscape_right
+        expect(helper.send(:orientation_key, :right, :down)).to be == :landscape_right
       end
 
       it 'returns :portrait when home button is :right' do
-        expect(helper.send(:uia_orientation_key, :right, :right)).to be == :portrait
+        expect(helper.send(:orientation_key, :right, :right)).to be == :portrait
       end
 
       it 'returns :upside_down when home button is :left' do
-        expect(helper.send(:uia_orientation_key, :right, :left)).to be == :upside_down
+        expect(helper.send(:orientation_key, :right, :left)).to be == :upside_down
       end
 
       it 'returns :landscape_left when home button is :up' do
-        expect(helper.send(:uia_orientation_key, :right, :up)).to be == :landscape_left
+        expect(helper.send(:orientation_key, :right, :up)).to be == :landscape_left
       end
     end
   end

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -19,7 +19,7 @@ describe Calabash::Cucumber::RotationHelpers do
   describe '#rotate_home_button_to' do
     it 're-raises ArgumentError' do
       error = ArgumentError.new('Expect ArgumentError')
-      expect(helper).to receive(:ensure_valid_rotate_home_to_arg).and_raise error
+      expect(helper).to receive(:expect_valid_rotate_home_to_arg).and_raise error
 
       expect do
         helper.rotate_home_button_to(:invalid)
@@ -27,7 +27,7 @@ describe Calabash::Cucumber::RotationHelpers do
     end
 
     it 'does nothing if device is already in the target orientation' do
-      expect(helper).to receive(:ensure_valid_rotate_home_to_arg).and_return :down
+      expect(helper).to receive(:expect_valid_rotate_home_to_arg).and_return :down
       expect(helper).to receive(:status_bar_orientation).and_return 'down'
 
       expect(helper.rotate_home_button_to('down')).to be == :down
@@ -168,25 +168,25 @@ describe Calabash::Cucumber::RotationHelpers do
   describe '#ensure_valid_rotate_home_to_arg' do
     it 'raises error when arg is invalid' do
       expect do
-        helper.send(:ensure_valid_rotate_home_to_arg, :invalid)
+        helper.send(:expect_valid_rotate_home_to_arg, :invalid)
       end.to raise_error ArgumentError, /Expected/
     end
 
     describe 'valid arguments' do
       it 'top' do
-        expect(helper.send(:ensure_valid_rotate_home_to_arg, 'top')).to be == :up
+        expect(helper.send(:expect_valid_rotate_home_to_arg, 'top')).to be == :up
       end
 
       it ':top' do
-        expect(helper.send(:ensure_valid_rotate_home_to_arg, :top)).to be == :up
+        expect(helper.send(:expect_valid_rotate_home_to_arg, :top)).to be == :up
       end
 
       it 'bottom' do
-        expect(helper.send(:ensure_valid_rotate_home_to_arg, 'bottom')).to be == :down
+        expect(helper.send(:expect_valid_rotate_home_to_arg, 'bottom')).to be == :down
       end
 
       it ':bottom' do
-        expect(helper.send(:ensure_valid_rotate_home_to_arg, :bottom)).to be == :down
+        expect(helper.send(:expect_valid_rotate_home_to_arg, :bottom)).to be == :down
       end
     end
   end

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -76,7 +76,7 @@ describe Calabash::Cucumber::RotationHelpers do
 
   it '#rotate_with_uia' do
     expect(helper).to receive(:orientation_key).and_return :key
-    stub_const('Calabash::Cucumber::RotationHelpers::UIA_DEVICE_ORIENTATION', {:key => 'value' })
+    stub_const('Calabash::Cucumber::RotationHelpers::DEVICE_ORIENTATION', {:key => 'value' })
     expected = 'UIATarget.localTarget().setDeviceOrientation(value)'
     expect(helper).to receive(:uia).with(expected).and_return :result
 

--- a/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/rotation_helpers_spec.rb
@@ -84,18 +84,40 @@ describe Calabash::Cucumber::RotationHelpers do
   end
 
   describe '#uia_orientation_key' do
-    describe ':left' do
-      it ':down' do helper.send(:uia_orientation_key, :left, :down) == :landscape_right end
-      it ':right' do helper.send(:uia_orientation_key, :left, :right) == :portrait end
-      it ':left' do helper.send(:uia_orientation_key, :left, :left) == :upside_down end
-      it ':up' do helper.send(:uia_orientation_key, :left, :up) == :landscape_left end
+    describe 'rotate :left' do
+      it 'returns :landscape_left when home button is :down' do
+        expect(helper.send(:uia_orientation_key, :left, :down)).to be == :landscape_left
+      end
+
+      it 'returns :upside_down when home button is :right' do
+        expect(helper.send(:uia_orientation_key, :left, :right)).to be == :upside_down
+      end
+
+      it 'returns :portrait with home button is :left' do
+        expect(helper.send(:uia_orientation_key, :left, :left)).to be == :portrait
+      end
+
+      it 'returns :landscape_right when the home button is :up' do
+        expect(helper.send(:uia_orientation_key, :left, :up)).to be == :landscape_right
+      end
     end
 
-    describe ':right' do
-      it ':down' do helper.send(:uia_orientation_key, :right, :down) == :landscape_left end
-      it ':right' do helper.send(:uia_orientation_key, :right, :right) == :upside_down end
-      it ':left' do helper.send(:uia_orientation_key, :right, :left) == :portrait end
-      it ':up' do helper.send(:uia_orientation_key, :right, :up) == :landscape_right end
+    describe 'rotate :right' do
+      it 'returns :landscape_right when home button is :down' do
+        expect(helper.send(:uia_orientation_key, :right, :down)).to be == :landscape_right
+      end
+
+      it 'returns :portrait when home button is :right' do
+        expect(helper.send(:uia_orientation_key, :right, :right)).to be == :portrait
+      end
+
+      it 'returns :upside_down when home button is :left' do
+        expect(helper.send(:uia_orientation_key, :right, :left)).to be == :upside_down
+      end
+
+      it 'returns :landscape_left when home button is :up' do
+        expect(helper.send(:uia_orientation_key, :right, :up)).to be == :landscape_left
+      end
     end
   end
 

--- a/calabash-cucumber/test/cucumber/features/orientation.feature
+++ b/calabash-cucumber/test/cucumber/features/orientation.feature
@@ -1,0 +1,31 @@
+@orientation
+Feature: Changing Orientation
+
+Background: App has launched
+Given the app has launched
+
+Scenario: Rotating around the home button
+Then I rotate the device so the home button is on the top
+Then I rotate the device so the home button is on the left
+Then I rotate the device so the home button is on the right
+Then I rotate the device so the home button is on the bottom
+
+Scenario: Rotating left and right
+Then I rotate the device so the home button is on the bottom
+When I rotate the device to the left
+Then the home button is on the right
+Then I rotate the device so the home button is on the bottom
+When I rotate the device to the right
+Then the home button is on the left
+Then I rotate the device so the home button is on the right
+When I rotate the device to the right
+Then the home button is on the bottom
+Then I rotate the device so the home button is on the right
+When I rotate the device to the left
+Then the home button is on the top
+Then I rotate the device so the home button is on the left
+When I rotate the device to the left
+Then the home button is on the bottom
+Then I rotate the device so the home button is on the left
+When I rotate the device to the right
+Then the home button is on the top

--- a/calabash-cucumber/test/cucumber/features/steps/orientation.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/orientation.rb
@@ -1,0 +1,71 @@
+
+module UnitTestApp
+  module Orientation
+
+    def upside_down_supported?
+      ipad?
+    end
+
+    def rotate_home_to_and_expect(position)
+      symbol = position.to_sym
+      orientation = rotate_home_button_to(symbol)
+
+      if [:top, :up].include?(symbol) && !upside_down_supported?
+        message = "Up-side-down orientation is not supported on iPhone"
+        colored = RunLoop::Color.blue(message)
+        $stdout.puts("    #{colored}")
+      else
+        expected = expected_position(position)
+        expect(orientation).to be == expected
+      end
+    end
+
+    def expected_position(position)
+      symbol = position.to_sym
+      case symbol
+      when :top, :up
+        :up
+      when :bottom, :down
+        :down
+      when :right
+        :right
+      when :left
+        :left
+      else
+        raise ArgumentError, %Q[
+Expected '#{position}' to be [:top, :up, :bottom, :down, :left, :right]
+]
+      end
+    end
+
+    def rotate_direction(direction)
+      rotate(direction.to_sym)
+    end
+  end
+end
+
+World(UnitTestApp::Orientation)
+
+Then(/^I rotate the device so the home button is on the (top|bottom|left|right)$/) do |position|
+  rotate_home_to_and_expect(position)
+end
+
+When(/^I rotate the device to the (left|right)$/) do |direction|
+  rotate(direction.to_sym)
+end
+
+Then(/^the home button is on the (left|right|top|bottom)$/) do |position|
+  expected = expected_position(position)
+  actual = status_bar_orientation.to_sym
+
+  if actual != expected
+    if expected == :up && !upside_down_supported?
+      message = "Up-side-down orientation is not supported iPhone"
+      colored = RunLoop::Color.blue(message)
+      $stdout.puts("    #{colored}")
+    else
+      fail %Q[Expected orientation to be #{expected}, but found #{actual}]
+    end
+  end
+end
+


### PR DESCRIPTION
### Motivation

While testing rotation with DeviceAgent, I discovered that `rotate` was not implemented correctly for some orientations.  Further, the rspec examples were not actually expecting anything.

`rotate` was also returning a String and not a Symbol as the documentation states and like `rotate_home_button_to` does.

This is breaking change and requires a 0.20.0 version because it breaks the current implementation.

### Test

This test is run against simulators on Jenkins.

```
$ git fetch
$ git checkout -t origin/feature/fix-rotate-gesture
$ cd calabash-cucumber/test/cucumber
$ bundle update
$ bundle exec cucumber -t @orientation
```

I added integration tests for `rotate` in calabash-cucumber/test/cucumber but it is a little difficult to visually verify the rotations are correct on the simulator.  The current test target is "iPhoneOnly.app" and it does not support testing on iPads so testing the up-side-down orientation is not possible.  This app will be replaced in a subsequent changeset with the DeviceAgent.iOS/UnitTestApp which does support iPads.

Ping me for ways to quickly test on physical devices.