### PR TITLE
Core: calabash-exit calls out to #session_delete

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -983,8 +983,16 @@ arguments => '#{arguments}'
                      :exit_code => merged_opts[:exit_code]
                }
           )
+
         rescue Errno::ECONNREFUSED, HTTPClient::KeepAliveDisconnected
           []
+        end
+
+        if launcher.gesture_performer.class.name == :device_agent
+          delay = merged_opts[:post_resign_active_delay] +
+            merged_opts[:post_will_terminate_delay] + 0.4
+          sleep(delay)
+          launcher.gesture_performer.send(:session_delete)
         end
       end
 

--- a/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
@@ -68,6 +68,10 @@ args[0] = #{args[0]}
           @device_agent = args[0]
         end
 
+        def session_delete
+          device_agent.send(:session_delete)
+        end
+
         # @!visibility private
         def touch(options)
           hash = query_for_coordinates(options)

--- a/calabash-cucumber/test/cucumber/features/support/01_launch.rb
+++ b/calabash-cucumber/test/cucumber/features/support/01_launch.rb
@@ -61,7 +61,8 @@ module Calabash::Launcher
   def self.prepare_physical_device
     return if self.target_is_simulator?
 
-    self.ensure_app_installed
+    # Not yet.
+    #self.ensure_app_installed
     #self.uninstall_cbx_runner
   end
 
@@ -123,5 +124,5 @@ Before do |scenario|
 end
 
 After do |scenario|
-
+  calabash_exit
 end


### PR DESCRIPTION
### Motivation

`calabash_exit` will terminate the AUT, but when testing with DeviceAgent, we need to send `session_delete`.