### PR TITLE
Implement complex touches with DeviceAgent

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -304,8 +304,8 @@ module Calabash
       #
       # @note This assumes the view is visible and not animating.
       #
-      # If the view is not visible it will fail with an error. If the view is animating
-      # it will *silently* fail.
+      # If the view is not visible it will fail with an error. If the view is
+      # animating it will *silently* fail.
       #
       # By default, taps the center of the view.
       #
@@ -313,9 +313,11 @@ module Calabash
       #   two_finger_tap "view marked:'Third'", offset:{x:100}
       # @param {String} uiquery query describing view to touch.
       # @param {Hash} options option for modifying the details of the touch.
-      # @option options {Hash} :offset (nil) optional offset to touch point. Offset supports an `:x` and `:y` key
-      #   and causes the touch to be offset with `(x,y)` relative to the center (`center + (offset[:x], offset[:y])`).
-      # @return {Array<Hash>} array containing the serialized version of the tapped view.
+      # @option options {Hash} :offset (nil) optional offset to touch point.
+      #  Offset supports an `:x` and `:y` key and causes the touch to be offset
+      #  with `(x,y)` relative to the center (`center + (offset[:x], offset[:y])`).
+      # @return {Array<Hash>} array containing the serialized version of the
+      #  tapped view.
       def two_finger_tap(uiquery,options={})
         query_action_with_options(:two_finger_tap, uiquery, options)
       end

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -360,13 +360,13 @@ module Calabash
         views_touched
       end
 
-      # Performs the "long press" or "touch and hold" gesture on the (first) view that matches
-      # query `uiquery`.
+      # Performs the "long press" or "touch and hold" gesture on the (first)
+      # view that matches query `uiquery`.
       #
       # @note This assumes the view is visible and not animating.
       #
-      # If the view is not visible it will fail with an error. If the view is animating
-      # it will *silently* fail.
+      # If the view is not visible it will fail with an error. If the view is
+      # animating it will *silently* fail.
       #
       # By default, the gesture starts at the center of the view.
       #
@@ -374,10 +374,12 @@ module Calabash
       #   touch_hold "webView css:'input'", duration:10, offset:{x: -40}
       # @param {String} uiquery query describing view to touch.
       # @param {Hash} options option for modifying the details of the touch.
-      # @option options {Hash} :offset (nil) optional offset to touch point. Offset supports an `:x` and `:y` key
-      #   and causes the touch to be offset with `(x,y)` relative to the center (`center + (offset[:x], offset[:y])`).
+      # @option options {Hash} :offset (nil) optional offset to touch point.
+      #   Offset supports an `:x` and `:y` key and causes the touch to be offset
+      #   with `(x,y)` relative to the center (`center + (offset[:x], offset[:y])`).
       # @option options {Numeric} :duration (3) duration of the 'hold'.
-      # @return {Array<Hash>} array containing the serialized version of the touched view.
+      # @return {Array<Hash>} array containing the serialized version of the
+      #  touched view.
       def touch_hold(uiquery, options={})
         query_action_with_options(:touch_hold, uiquery, options)
       end

--- a/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
@@ -83,6 +83,15 @@ args[0] = #{args[0]}
         end
 
         # @!visibility private
+        def double_tap(options)
+          hash = query_for_coordinates(options)
+          device_agent.perform_coordinate_gesture("double_tap",
+                                                  hash[:coordinates][:x],
+                                                  hash[:coordinates][:y])
+          [hash[:view]]
+        end
+
+        # @!visibility private
         def rotate(direction)
           # Caller is responsible for normalizing and verifying direction.
           current_orientation = status_bar_orientation.to_sym

--- a/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
@@ -92,6 +92,15 @@ args[0] = #{args[0]}
         end
 
         # @!visibility private
+        def two_finger_tap(options)
+          hash = query_for_coordinates(options)
+          device_agent.perform_coordinate_gesture("two_finger_tap",
+                                                  hash[:coordinates][:x],
+                                                  hash[:coordinates][:y])
+          [hash[:view]]
+        end
+
+        # @!visibility private
         def touch_hold(options)
           hash = query_for_coordinates(options)
 

--- a/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
@@ -92,6 +92,18 @@ args[0] = #{args[0]}
         end
 
         # @!visibility private
+        def touch_hold(options)
+          hash = query_for_coordinates(options)
+
+          duration = options[:duration] || 3
+          device_agent.perform_coordinate_gesture("touch",
+                                                  hash[:coordinates][:x],
+                                                  hash[:coordinates][:y],
+                                                  {:duration => duration})
+          [hash[:view]]
+        end
+
+        # @!visibility private
         def rotate(direction)
           # Caller is responsible for normalizing and verifying direction.
           current_orientation = status_bar_orientation.to_sym
@@ -110,6 +122,8 @@ args[0] = #{args[0]}
         private
 
         # @!visibility private
+        #
+        # Calls #point_from which applies any :offset supplied in the options.
         def query_for_coordinates(options)
           ui_query = options[:query]
 

--- a/calabash-cucumber/lib/calabash-cucumber/gestures/performer.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/performer.rb
@@ -35,12 +35,12 @@ module Calabash
         end
 
         # @!visibility private
-        def flick(options)
+        def touch_hold(options)
           abstract_method!
         end
 
         # @!visibility private
-        def touch_hold(options)
+        def flick(options)
           abstract_method!
         end
 

--- a/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
+++ b/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
@@ -164,6 +164,27 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
       end
     end
 
+    context "#two_finger_tap" do
+      it "performs a two-finger tap and returns an array with one element" do
+        hash = {
+          :view => "the view acted on",
+          :coordinates => {
+            :x => 10,
+            :y => 20
+          }
+        }
+
+        options = {}
+
+        expect(device_agent).to receive(:query_for_coordinates).with(options).and_return(hash)
+        expect(device_agent.device_agent).to(
+          receive(:perform_coordinate_gesture).with("two_finger_tap", 10, 20)).and_return(true)
+        expected = [hash[:view]]
+
+        expect(device_agent.two_finger_tap(options)).to be == expected
+      end
+    end
+
     context "#touch_hold" do
       let(:hash) do
         {

--- a/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
+++ b/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
@@ -7,6 +7,7 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
       def to_s; "#<XCUITest subclass>"; end
       def inspect; to_s; end
       def rotate_home_button_to(_); ; end
+      def perform_coordinate_gesture(_, _, _); ; end
     end.new
   end
 
@@ -118,6 +119,26 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
         expect(Calabash::Cucumber::Map).to receive(:raw_map).and_return(response)
 
         expect(device_agent.send(:first_element_for_query, "query")).to be == "a"
+      end
+    end
+
+    context "#touch" do
+      it "performs a touch and returns an array with one element: view that was touched" do
+        hash = {
+          :view => "the view acted on",
+          :coordinates => {
+            :x => 10,
+            :y => 20
+          }
+        }
+
+        options = {}
+
+        expect(device_agent).to receive(:query_for_coordinates).with(options).and_return(hash)
+        expect(device_agent.device_agent).to receive(:perform_coordinate_gesture).with("touch", 10, 20).and_return(true)
+        expected = [hash[:view]]
+
+        expect(device_agent.touch(options)).to be == expected
       end
     end
   end

--- a/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
+++ b/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
@@ -7,7 +7,7 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
       def to_s; "#<XCUITest subclass>"; end
       def inspect; to_s; end
       def rotate_home_button_to(_); ; end
-      def perform_coordinate_gesture(_, _, _); ; end
+      def perform_coordinate_gesture(_, _, _, _={}); ; end
     end.new
   end
 
@@ -123,7 +123,7 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
     end
 
     context "#touch" do
-      it "performs a touch and returns an array with one element: view that was touched" do
+      it "performs a touch and returns an array with one element" do
         hash = {
           :view => "the view acted on",
           :coordinates => {
@@ -144,7 +144,7 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
     end
 
     context "#double_tap" do
-      it "performs a double tap and returns an array with one element: view that was touched" do
+      it "performs a double tap and returns an array with one element" do
         hash = {
           :view => "the view acted on",
           :coordinates => {
@@ -161,6 +161,44 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
         expected = [hash[:view]]
 
         expect(device_agent.double_tap(options)).to be == expected
+      end
+    end
+
+    context "#touch_hold" do
+      let(:hash) do
+        {
+          :view => "the view acted on",
+          :coordinates => {
+            :x => 10,
+            :y => 20
+          },
+        }
+      end
+
+      let(:options) { {} }
+
+      it "performs a long press for 3 seconds and returns an array with one element" do
+        expect(device_agent).to receive(:query_for_coordinates).with(options).and_return(hash)
+        expect(device_agent.device_agent).to(
+          receive(:perform_coordinate_gesture).with("touch",
+                                                    10, 20,
+                                                    {:duration => 3 })).and_return(true)
+        expected = [hash[:view]]
+
+        expect(device_agent.touch_hold(options)).to be == expected
+      end
+
+      it "performs a long press for N seconds and returns an array with one element" do
+        options[:duration] = 1
+
+        expect(device_agent).to receive(:query_for_coordinates).with(options).and_return(hash)
+        expect(device_agent.device_agent).to(
+          receive(:perform_coordinate_gesture).with("touch",
+                                                    10, 20,
+                                                    {:duration => 1 })).and_return(true)
+        expected = [hash[:view]]
+
+        expect(device_agent.touch_hold(options)).to be == expected
       end
     end
   end

--- a/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
+++ b/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
@@ -135,10 +135,32 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
         options = {}
 
         expect(device_agent).to receive(:query_for_coordinates).with(options).and_return(hash)
-        expect(device_agent.device_agent).to receive(:perform_coordinate_gesture).with("touch", 10, 20).and_return(true)
+        expect(device_agent.device_agent).to(
+          receive(:perform_coordinate_gesture).with("touch", 10, 20)).and_return(true)
         expected = [hash[:view]]
 
         expect(device_agent.touch(options)).to be == expected
+      end
+    end
+
+    context "#double_tap" do
+      it "performs a double tap and returns an array with one element: view that was touched" do
+        hash = {
+          :view => "the view acted on",
+          :coordinates => {
+            :x => 10,
+            :y => 20
+          }
+        }
+
+        options = {}
+
+        expect(device_agent).to receive(:query_for_coordinates).with(options).and_return(hash)
+        expect(device_agent.device_agent).to(
+          receive(:perform_coordinate_gesture).with("double_tap", 10, 20)).and_return(true)
+        expected = [hash[:view]]
+
+        expect(device_agent.double_tap(options)).to be == expected
       end
     end
   end

--- a/calabash-cucumber/test/cucumber/features/steps/touch.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/touch.rb
@@ -55,3 +55,33 @@ When(/^the home button is on the (top|right|left|bottom), I can (double tap|touc
   end
   clear_small_button_action_label
 end
+
+Then(/^I long press a little button for (a short|a long|enough) time$/) do |time|
+  clear_small_button_action_label
+  expected_text = "long press"
+
+  if time == "a short"
+    duration = 0.5
+    expected_text = "CLEARED"
+  elsif time == "a long"
+    duration = 2.0
+  elsif time == "enough"
+    duration = 1.1
+  end
+
+  query = "* marked:'long press'"
+  wait_for_view(query)
+
+  touch_hold(query, {:duration => duration})
+  wait_for_gesture_text(expected_text, "small button action")
+end
+
+When(/^the home button is on the (top|right|left|bottom), I can long press$/) do |position|
+  clear_small_button_action_label
+  rotate_home_to_and_expect(position)
+  query = "* marked:'long press'"
+  wait_for_view(query)
+  touch_hold(query, {:duration => 1.1})
+  wait_for_gesture_text("long press", "small button action")
+  clear_small_button_action_label
+end

--- a/calabash-cucumber/test/cucumber/features/steps/touch.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/touch.rb
@@ -43,7 +43,10 @@ end
 When(/^the home button is on the (top|right|left|bottom), I can (double tap|touch)$/) do |position, gesture|
   rotate_home_to_and_expect(position)
   if gesture == "double tap"
-    raise "Not implemented yet"
+    query = "* marked:'double tap'"
+    wait_for_view(query)
+    double_tap(query)
+    wait_for_gesture_text("double tap", "small button action")
   else
     query = "* marked:'touch'"
     wait_for_view(query)

--- a/calabash-cucumber/test/cucumber/features/steps/touch.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/touch.rb
@@ -85,3 +85,13 @@ When(/^the home button is on the (top|right|left|bottom), I can long press$/) do
   wait_for_gesture_text("long press", "small button action")
   clear_small_button_action_label
 end
+
+When(/^the home button is on the (top|right|left|bottom), I can two-finger tap$/) do |position|
+  rotate_home_to_and_expect(position)
+  query = "* marked:'two finger tap'"
+  wait_for_view(query)
+  two_finger_tap(query)
+  wait_for_gesture_text("two-finger tap", "complex touches")
+  clear_complex_button_action_label
+end
+

--- a/calabash-cucumber/test/cucumber/features/touch.feature
+++ b/calabash-cucumber/test/cucumber/features/touch.feature
@@ -12,3 +12,10 @@ When the home button is on the bottom, I can touch
 When the home button is on the right, I can touch
 When the home button is on the left, I can touch
 When the home button is on the top, I can touch
+
+Scenario: Double tap in any orientation
+Given I am looking at the Tao tab
+When the home button is on the bottom, I can double tap
+When the home button is on the right, I can double tap
+When the home button is on the left, I can double tap
+When the home button is on the top, I can double tap

--- a/calabash-cucumber/test/cucumber/features/touch.feature
+++ b/calabash-cucumber/test/cucumber/features/touch.feature
@@ -19,3 +19,16 @@ When the home button is on the bottom, I can double tap
 When the home button is on the right, I can double tap
 When the home button is on the left, I can double tap
 When the home button is on the top, I can double tap
+
+Scenario: Long press durations
+Given I am looking at the Tao tab
+Then I long press a little button for a short time
+Then I long press a little button for enough time
+Then I long press a little button for a long time
+
+Scenario: Long press in any orientation
+Given I am looking at the Tao tab
+When the home button is on the top, I can long press
+When the home button is on the right, I can long press
+When the home button is on the left, I can long press
+When the home button is on the bottom, I can long press

--- a/calabash-cucumber/test/cucumber/features/touch.feature
+++ b/calabash-cucumber/test/cucumber/features/touch.feature
@@ -32,3 +32,10 @@ When the home button is on the top, I can long press
 When the home button is on the right, I can long press
 When the home button is on the left, I can long press
 When the home button is on the bottom, I can long press
+
+Scenario: Two finger tap in any orientation
+Given I am looking at the Tao tab
+When the home button is on the left, I can two-finger tap
+When the home button is on the top, I can two-finger tap
+When the home button is on the right, I can two-finger tap
+When the home button is on the bottom, I can two-finger tap


### PR DESCRIPTION
### Motivation

Implements:

* double_tap
* touch_hold (AKA long_press)
* two_finger_tap

with DeviceAgent.

Completes:

* Implement basic touches with DeviceAgent [JIRA](https://xamarin.atlassian.net/browse/TCFW-239)

Related to:

* Expose complex touch API that is supported by DeviceAgent [JIRA](https://xamarin.atlassian.net/browse/TCFW-338)