### PR TITLE
CI: try to fix APP variable on Jenkins (has spaces)

### DIFF
--- a/calabash-cucumber/test/cucumber/config/cucumber.yml
+++ b/calabash-cucumber/test/cucumber/config/cucumber.yml
@@ -7,8 +7,8 @@ require "run_loop"
 #SIM_APP = File.join(DEVICE_AGENT_PRODUCTS, "app", "TestApp", "TestApp.app")
 #DEVICE_APP = File.join(DEVICE_AGENT_PRODUCTS, "ipa", "TestApp", "TestApp.app")
 
-SIM_APP = File.expand_path(File.join(".", "aut", "sim", "TestApp.app"))
-DEVICE_APP = File.expand_path(File.join(".", "aut", "device", "TestApp.app"))
+SIM_APP = File.join("aut", "sim", "TestApp.app")
+DEVICE_APP = File.join("aut", "device", "TestApp.app")
 
 # Path to DeviceAgent.iOS repo to support launching CBX-Runner with xcodebuild.
 #


### PR DESCRIPTION
### Motivation

Cucumbers are failing in CI because the APP variable is not being set correctly.

```
16:25:35 No such file or directory - iOS/workspace/calabash-cucumber/test/cucumber/aut/sim/TestApp.app. You can use `cucumber --init` to get started.
```

The problem is on Jenkins, there are spaces in the path.