### PR TITLE
Implement touch point with DeviceAgent

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -276,8 +276,18 @@ module Calabash
       # @raise [ArgumentError] If query is nil and there is no :offset in the
       #  the options.  The offset must contain both an :x and :y value.
       def touch(uiquery, options={})
-        if uiquery.nil? && options[:offset].nil?
-          raise "called touch(nil) without specifying an offset in options (#{options})"
+        if uiquery.nil?
+          offset = options[:offset]
+
+          if !(offset && offset[:x] && offset[:y])
+            raise ArgumentError, %Q[
+If query is nil, there must be a valid offset in the options.
+
+Expected: options[:offset] = {:x => NUMERIC, :y => NUMERIC}
+  Actual: options[:offset] = #{offset ? offset : "nil"}
+
+            ]
+          end
         end
         query_action_with_options(:touch, uiquery, options)
       end

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -252,19 +252,29 @@ module Calabash
       end
 
       # Performs the `tap` gesture on the (first) view that matches
-      # query `uiquery`. Note that `touch` assumes the view is visible and not animating.
-      # If the view is not visible `touch` will fail. If the view is animating
-      # `touch` will *silently* fail.
+      # query `uiquery`. Note that `touch` assumes the view is visible and not
+      # animating. If the view is not visible `touch` will fail. If the view is
+      # animating `touch` will *silently* fail.
+      #
       # By default, taps the center of the view.
       # @see Calabash::Cucumber::WaitHelpers#wait_tap
       # @see Calabash::Cucumber::Operations#tap_mark
       # @see #tap_point
-      # @param {String} uiquery query describing view to tap. Note `nil` is allowed and is interpreted as
-      #   `tap_point(options[:offset][:x],options[:offset][:y])`
+      #
+      # @param {String} uiquery query describing view to tap. If this value is
+      #  `nil` then an :offset must be passed as an option.  This can be used
+      #  to tap a specific coordinate.
       # @param {Hash} options option for modifying the details of the touch
-      # @option options {Hash} :offset (nil) optional offset to touch point. Offset supports an `:x` and `:y` key
-      #   and causes the touch to be offset with `(x,y)` relative to the center (`center + (offset[:x], offset[:y])`).
-      # @return {Array<Hash>} array containing the serialized version of the tapped view.
+      # @option options {Hash} :offset (nil) optional offset to touch point.
+      #  Offset supports an `:x` and `:y` key and causes the touch to be offset
+      #  with `(x,y)` relative to the center.
+      #
+      # @return {Array<Hash>} array containing the serialized version of the
+      # tapped view.
+      #
+      # @raise [RuntimeError] If query is non nil and matches no views.
+      # @raise [ArgumentError] If query is nil and there is no :offset in the
+      #  the options.  The offset must contain both an :x and :y value.
       def touch(uiquery, options={})
         if uiquery.nil? && options[:offset].nil?
           raise "called touch(nil) without specifying an offset in options (#{options})"

--- a/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
@@ -207,32 +207,57 @@ args[0] = #{args[0]}
         #
         # Calls #point_from which applies any :offset supplied in the options.
         def query_for_coordinates(options)
-          ui_query = options[:query]
+          uiquery = options[:query]
 
-          first_element = first_element_for_query(ui_query)
+          if uiquery.nil?
+            offset = options[:offset]
 
-          if first_element.nil?
-            msg = %Q[
+            if offset && offset[:x] && offset[:y]
+              {
+                :coordinates => offset,
+                :view => offset
+              }
+            else
+              raise ArgumentError, %Q[
+If query is nil, there must be a valid offset in the options.
+
+Expected: options[:offset] = {:x => NUMERIC, :y => NUMERIC}
+  Actual: options[:offset] = #{offset ? offset : "nil"}
+
+              ]
+            end
+          else
+
+            first_element = first_element_for_query(uiquery)
+
+            if first_element.nil?
+              msg = %Q[
 Could not find any views with query:
 
-#{ui_query}
+  #{uiquery}
 
-Try adjusting your query to return at least one view.
+Make sure your query returns at least one view.
 
 ]
-            Calabash::Cucumber::Map.new.screenshot_and_raise(msg)
-          else
-            {
-              :coordinates => point_from(first_element),
-              :view => first_element
-            }
+              Calabash::Cucumber::Map.new.screenshot_and_raise(msg)
+            else
+              {
+                :coordinates => point_from(first_element),
+                :view => first_element
+              }
+            end
           end
         end
 
         # @!visibility private
-        def first_element_for_query(ui_query)
+        def first_element_for_query(uiquery)
+
+          if uiquery.nil?
+            raise ArgumentError, "Query cannot be nil"
+          end
+
           # Will raise if response "outcome" is not SUCCESS
-          results = Calabash::Cucumber::Map.raw_map(ui_query, :query)["results"]
+          results = Calabash::Cucumber::Map.raw_map(uiquery, :query)["results"]
 
           if results.empty?
             nil

--- a/calabash-cucumber/spec/lib/core_spec.rb
+++ b/calabash-cucumber/spec/lib/core_spec.rb
@@ -69,6 +69,37 @@ describe Calabash::Cucumber::Core do
     end
   end
 
+  context "#touch" do
+    it "calls the gesture performer :touch method" do
+      expect(world).to(
+        receive(:query_action_with_options).with(:touch, "query", {})
+      ).and_return([:view])
+
+      expect(world.touch("query", {})).to be == [:view]
+    end
+
+    context "uiquery is nil" do
+      it "raises an ArgumentError if there is not an :offset" do
+        expect do
+          world.touch(nil, {})
+        end.to raise_error ArgumentError,
+                           /If query is nil, there must be a valid offset/
+      end
+
+      it "raises an ArgumentError if there is not a valid :offset" do
+        expect do
+          world.touch(nil, {offset: { x: 10 }})
+        end.to raise_error ArgumentError,
+                           /If query is nil, there must be a valid offset/
+
+        expect do
+          world.touch(nil, {offset: { y: 10 }})
+        end.to raise_error ArgumentError,
+                           /If query is nil, there must be a valid offset/
+      end
+    end
+  end
+
   describe '#scroll' do
     describe 'handling direction argument' do
       describe 'raises error if invalid' do

--- a/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
+++ b/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
@@ -102,6 +102,35 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
         expect(actual[:coordinates]).to be == :coordinates
         expect(actual[:view]).to be == "a"
       end
+
+      context ":query is nil" do
+        it "raises an ArgumentError if there is not an :offset" do
+          expect do
+            device_agent.send(:query_for_coordinates, {})
+          end.to raise_error ArgumentError,
+                             /If query is nil, there must be a valid offset/
+        end
+
+        it "raises an ArgumentError if there is not a valid :offset" do
+          expect do
+            device_agent.send(:query_for_coordinates, {offset: { x: 10 }})
+          end.to raise_error ArgumentError,
+                             /If query is nil, there must be a valid offset/
+
+          expect do
+            device_agent.send(:query_for_coordinates, {offset: { y: 10 }})
+          end.to raise_error ArgumentError,
+                             /If query is nil, there must be a valid offset/
+        end
+
+        it "returns a hash with the :coordinate and :view values the same" do
+          options = {offset: {x: 10, y: 20}}
+
+          actual = device_agent.send(:query_for_coordinates, options)
+          expect(actual[:coordinates]).to be == options[:offset]
+          expect(actual[:view]).to be == options[:offset]
+        end
+      end
     end
 
     context "#first_element_for_query" do
@@ -119,6 +148,12 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
         expect(Calabash::Cucumber::Map).to receive(:raw_map).and_return(response)
 
         expect(device_agent.send(:first_element_for_query, "query")).to be == "a"
+      end
+
+      it "raises an ArgumentError if uiquery is nil" do
+        expect do
+          device_agent.send(:first_element_for_query, nil)
+        end.to raise_error ArgumentError, /Query cannot be nil/
       end
     end
 

--- a/calabash-cucumber/test/cucumber/features/steps/touch.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/touch.rb
@@ -40,6 +40,17 @@ And(/^I clear the touch action label$/) do
   clear_small_button_action_label
 end
 
+Then(/^I can touch by coordinate$/) do
+  query = "* marked:'touch'"
+  element = wait_for_view(query).first
+  offset = {
+    x: element["rect"]["center_x"],
+            y: element["rect"]["center_y"]
+  }
+  touch(nil, {offset: offset})
+  wait_for_gesture_text("touch", "small button action")
+end
+
 When(/^the home button is on the (top|right|left|bottom), I can (double tap|touch)$/) do |position, gesture|
   rotate_home_to_and_expect(position)
   if gesture == "double tap"

--- a/calabash-cucumber/test/cucumber/features/touch.feature
+++ b/calabash-cucumber/test/cucumber/features/touch.feature
@@ -39,3 +39,7 @@ When the home button is on the left, I can two-finger tap
 When the home button is on the top, I can two-finger tap
 When the home button is on the right, I can two-finger tap
 When the home button is on the bottom, I can two-finger tap
+
+Scenario: Touch by point
+And I rotate the device so the home button is on the bottom
+Then I can touch by coordinate


### PR DESCRIPTION
### Motivation

I was reviewing `Core#touch` while implementing `flick` and `swipe`.

I realized that the `DeviceAgent#touch` did not handle `nil` queries correctly.

```
# Touch a point
touch(nil, {offset: {x: 10, y: 10}}) <==> tap_point(10, 10)
```

[JIRA](https://xamarin.atlassian.net/browse/TCFW-403)