### PR TITLE
DeviceAgent gestures apply :offset correctly

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
@@ -242,7 +242,7 @@ Make sure your query returns at least one view.
               Calabash::Cucumber::Map.new.screenshot_and_raise(msg)
             else
               {
-                :coordinates => point_from(first_element),
+                :coordinates => point_from(first_element, options),
                 :view => first_element
               }
             end

--- a/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
+++ b/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
@@ -96,7 +96,7 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
 
       it "returns a hash with :coordinates and :view" do
         expect(device_agent).to receive(:first_element_for_query).with(query).and_return("a")
-        expect(device_agent).to receive(:point_from).with("a").and_return(:coordinates)
+        expect(device_agent).to receive(:point_from).with("a", options).and_return(:coordinates)
 
         actual = device_agent.send(:query_for_coordinates, options)
         expect(actual[:coordinates]).to be == :coordinates

--- a/calabash-cucumber/test/cucumber/features/steps/keyboard.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/keyboard.rb
@@ -32,7 +32,7 @@ module TestApp
 
     def text_from_text_field
       query = "* marked:'text field'"
-      wait_for_view(query).first["text"]
+      wait_for_view(query)["text"]
     end
 
     def wait_for_text_field_reset

--- a/calabash-cucumber/test/cucumber/features/steps/shared.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/shared.rb
@@ -3,7 +3,7 @@ module TestApp
 
     def wait_for_text_in_view(text, mark)
       query = "* marked:'#{mark}'"
-      actual = wait_for_view(query).first["text"]
+      actual = wait_for_view(query)["text"]
       if actual != text
         fail %Q[
 Expected query:

--- a/calabash-cucumber/test/cucumber/features/steps/touch.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/touch.rb
@@ -51,6 +51,22 @@ Then(/^I can touch by coordinate$/) do
   wait_for_gesture_text("touch", "small button action")
 end
 
+Then(/^I can apply an offset to a touch$/) do
+  query = "* marked:'gesture performed'"
+  wait_for_view(query).first
+  offset = {
+    x: -120,
+    y: -28
+  }
+
+  touch(query, {offset: offset})
+
+  wait_for_view("* marked:'Mostly Hidden Button'")
+  wait_for_animations
+
+  touch("* marked:'OK'")
+end
+
 When(/^the home button is on the (top|right|left|bottom), I can (double tap|touch)$/) do |position, gesture|
   rotate_home_to_and_expect(position)
   if gesture == "double tap"

--- a/calabash-cucumber/test/cucumber/features/steps/touch.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/touch.rb
@@ -2,7 +2,7 @@ module TestApp
   module TouchGestures
     def wait_for_gesture_text(text, mark="gesture performed")
       query = "* marked:'#{mark}'"
-      actual = wait_for_view(query).first["text"]
+      actual = wait_for_view(query)["text"]
       if actual != text
         fail %Q[
 Expected query:
@@ -42,7 +42,7 @@ end
 
 Then(/^I can touch by coordinate$/) do
   query = "* marked:'touch'"
-  element = wait_for_view(query).first
+  element = wait_for_view(query)
   offset = {
     x: element["rect"]["center_x"],
             y: element["rect"]["center_y"]
@@ -53,7 +53,7 @@ end
 
 Then(/^I can apply an offset to a touch$/) do
   query = "* marked:'gesture performed'"
-  wait_for_view(query).first
+  wait_for_view(query)
   offset = {
     x: -120,
     y: -28
@@ -63,8 +63,8 @@ Then(/^I can apply an offset to a touch$/) do
 
   wait_for_view("* marked:'Mostly Hidden Button'")
   wait_for_animations
-
   touch("* marked:'OK'")
+  wait_for_no_view("* marked:'Mostly Hidden Button'")
 end
 
 When(/^the home button is on the (top|right|left|bottom), I can (double tap|touch)$/) do |position, gesture|

--- a/calabash-cucumber/test/cucumber/features/support/2x-bridge.rb
+++ b/calabash-cucumber/test/cucumber/features/support/2x-bridge.rb
@@ -2,7 +2,7 @@ module Calabash
   module Calabash2xBridge
 
     @@default_options = {
-      timeout: 8.0,
+      timeout: RunLoop::Environment.ci? ? 16 : 8,
       retry_frequency: 0.1,
       exception_class: Timeout::Error
     }
@@ -12,36 +12,38 @@ module Calabash
       merged_options = default_options.merge(options)
 
       unless merged_options[:message]
-        message = %Q{
-"Waited #{merged_options[:timeout]} seconds for query:
-  #{query}
-to match a view"
-        }
+        message = %Q[
+Waited #{merged_options[:timeout]} seconds for
+
+ query("#{query}")
+
+to match a view.
+
+]
         merged_options[:timeout_message] = message
       end
 
       wait_for_element_exists(query, merged_options)
-      query(query)
+      query(query).first
     end
 
-    def wait_for_any(queries, options={})
+    def wait_for_no_view(query, options={})
       default_options = @@default_options.dup
       merged_options = default_options.merge(options)
 
       unless merged_options[:message]
         message = %Q[
-"Waited #{merged_options[:timeout]} seconds for any query:
-#{queries.join("\n")}
-to match a view"
+Waited #{merged_options[:timeout]} seconds for
+
+ query("#{query}")
+
+to match no views.
+
 ]
         merged_options[:timeout_message] = message
       end
 
-      bridge_wait_for(merged_options[:timeout_message], merged_options) do
-        queries.any? do |query|
-          query(query)
-        end
-      end
+      wait_for_element_does_not_exist(query, merged_options)
     end
 
     def wait_for_animations

--- a/calabash-cucumber/test/cucumber/features/touch.feature
+++ b/calabash-cucumber/test/cucumber/features/touch.feature
@@ -43,3 +43,5 @@ When the home button is on the bottom, I can two-finger tap
 Scenario: Touch by point
 And I rotate the device so the home button is on the bottom
 Then I can touch by coordinate
+And I am looking at the Touch tab
+Then I can apply an offset to a touch


### PR DESCRIPTION
### Motivation

In the initial implementation I was ignoring the `:offset` option.

Add a cucumber to demonstrate that this is working.
