### PR TITLE
Improve the pan documentation and add pan_coordinates

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -451,21 +451,57 @@ Expected: options[:offset] = {:x => NUMERIC, :y => NUMERIC}
         launcher.gesture_performer.swipe(dir.to_sym, merged_options)
       end
 
-
-      # Performs the "pan" or "drag-n-drop" gesture on from the `from` parameter
-      # to the `to` parameter (both are queries).
+      # Performs the "pan" or "drag-n-drop" gesture between two views.
+      #
+      # Swipes, scrolls, drag-and-drop, and flicks are all pan gestures.
+      #
       # @example
-      #   q1="* marked:'Cell 3' parent tableViewCell descendant tableViewCellReorderControl"
-      #   q2="* marked:'Cell 6' parent tableViewCell descendant tableViewCellReorderControl"
+      #   # Reorder table view rows.
+      #   q1="* marked:'Reorder Apple'"
+      #   q2="* marked:'Reorder Google'"
       #   pan q1, q2, duration:4
-      # @param {String} from query describing view to start the gesture
-      # @param {String} to query describing view to end the gesture
-      # @option options {Hash} :offset (nil) optional offset to touch point. Offset supports an `:x` and `:y` key
-      #   and causes the touch to be offset with `(x,y)` relative to the center (`center + (offset[:x], offset[:y])`).
-      # @option options {Numeric} :duration (1) duration of the 'pan'.
-      # @return {Array<Hash>} array containing the serialized version of the touched view.
-      def pan(from, to, options={})
-        launcher.gesture_performer.pan(from, to, options)
+      #
+      # @param {String} from_query query describing view to start the gesture
+      # @param {String} to_query query describing view to end the gesture
+      # @option options {Hash} :offset (nil) optional offset to touch point.
+      #  Offset supports an `:x` and `:y` key and causes the pan to be offset
+      #  with `(x,y)` relative to the center.
+      # @option options {Numeric} :duration (1.0) duration of the 'pan'.  The
+      #  minimum value of pan in UIAutomation is 0.5.  For DeviceAgent, the
+      #  duration must be > 0.
+      # @return {Array<Hash>} array containing the serialized version of the
+      #  touched views.  The first element is the first view matched by
+      #  the from_query and the second element is the first view matched by
+      #  the to_query.
+      #
+      # @raise [ArgumentError] If duration is < 0.5 for UIAutomation and <= 0
+      #  for DeviceAgent.
+      def pan(from_query, to_query, options={})
+        merged_options = {
+          # Minimum value for UIAutomation is 0.5.
+          # DeviceAgent duration must be > 0.
+          :duration => 1.0
+        }.merge(options)
+
+        duration = merged_options[:duration]
+
+        if uia_available? && duration < 0.5
+          raise ArgumentError, %Q[
+Invalid duration: #{duration}
+
+The minimum duration is 0.5
+
+]
+        elsif duration <= 0.0
+          raise ArgumentError, %Q[
+Invalid duration: #{duration}
+
+The minimum duration is 0.0.
+
+]
+        end
+
+        launcher.gesture_performer.pan(from_query, to_query, merged_options)
       end
 
       # Performs a "pinch" gesture.

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -451,7 +451,7 @@ Expected: options[:offset] = {:x => NUMERIC, :y => NUMERIC}
         launcher.gesture_performer.swipe(dir.to_sym, merged_options)
       end
 
-      # Performs the "pan" or "drag-n-drop" gesture between two views.
+      # Performs the pan gesture between two coordinates.
       #
       # Swipes, scrolls, drag-and-drop, and flicks are all pan gestures.
       #
@@ -502,6 +502,64 @@ The minimum duration is 0.0.
         end
 
         launcher.gesture_performer.pan(from_query, to_query, merged_options)
+      end
+
+      # Performs the pan gesture between two coordinates.
+      #
+      # Swipes, scrolls, drag-and-drop, and flicks are all pan gestures.
+      #
+      # @example
+      #   # Pan to go back in UINavigationController
+      #   element = query("*").first
+      #   y = element["rect"]["center_y"]
+      #   pan_coordinates({10, y}, {160, y})
+      #
+      #   # Pan to reveal Today and Notifications
+      #   element = query("*").first
+      #   x = element["rect"]["center_x"]
+      #   pan_coordinates({x, 0}, {x, 240})
+      #
+      #   # Pan to reveal Control Panel
+      #   element = query("*").first
+      #   x = element["rect"]["center_x"]
+      #   y = element["rect"]["height"]
+      #   pan_coordinates({x, height}, {x, 240})
+      #
+      # @param {String} from_point where to start the pan.
+      # @param {String} to_query where to end the pan.
+      # @option options {Numeric} :duration (1.0) duration of the 'pan'.  The
+      #  minimum value of pan in UIAutomation is 0.5.  For DeviceAgent, the
+      #  duration must be > 0.
+      #
+      # @raise [ArgumentError] If duration is < 0.5 for UIAutomation and <= 0
+      #  for DeviceAgent.
+      def pan_coordinates(from_point, to_point, options={})
+        merged_options = {
+          # Minimum value for UIAutomation is 0.5.
+          # DeviceAgent duration must be > 0.
+          :duration => 1.0
+        }.merge(options)
+
+        duration = merged_options[:duration]
+
+        if uia_available? && duration < 0.5
+          raise ArgumentError, %Q[
+Invalid duration: #{duration}
+
+The minimum duration is 0.5
+
+]
+        elsif duration <= 0.0
+          raise ArgumentError, %Q[
+Invalid duration: #{duration}
+
+The minimum duration is 0.0.
+
+]
+        end
+
+        launcher.gesture_performer.pan_coordinates(from_point, to_point,
+                                                   merged_options)
       end
 
       # Performs a "pinch" gesture.

--- a/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
@@ -137,6 +137,17 @@ args[0] = #{args[0]}
           [from_hash[:view], to_hash[:view]]
         end
 
+        def pan_coordinates(from_point, to_point, options)
+
+          gesture_options = {
+            :duration => options[:duration]
+          }
+
+          device_agent.pan_between_coordinates(from_point, to_point,
+                                               gesture_options)
+          [first_element_for_query("*")]
+        end
+
         # @!visibility private
         def enter_text_with_keyboard(string, options={})
           device_agent.enter_text(string)

--- a/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
@@ -127,9 +127,12 @@ args[0] = #{args[0]}
           to_hash = query_for_coordinates(dupped_options)
           to_point = to_hash[:coordinates]
 
-          dupped_options.delete(:query)
+          gesture_options = {
+            :duration => dupped_options[:duration]
+          }
+
           device_agent.pan_between_coordinates(from_point, to_point,
-                                               dupped_options)
+                                               gesture_options)
 
           [from_hash[:view], to_hash[:view]]
         end

--- a/calabash-cucumber/lib/calabash-cucumber/gestures/instruments.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/instruments.rb
@@ -178,6 +178,12 @@ Expected '#{strategy}' to be one of these supported strategies:
         end
 
         # @!visibility private
+        def pan_coordinates(from, to, options={})
+          uia_pan_offset(from, to, options)
+          [find_and_normalize("*")]
+        end
+
+        # @!visibility private
         def pinch(in_out, options)
           query_action(options) do |offset|
             options[:duration] = options[:duration] || 0.5

--- a/calabash-cucumber/lib/calabash-cucumber/gestures/performer.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/performer.rb
@@ -50,6 +50,8 @@ module Calabash
         end
 
         # @!visibility private
+        #
+        # Callers must validate the options.
         def pan(from_query, to_query, options={})
           abstract_method!
         end

--- a/calabash-cucumber/lib/calabash-cucumber/gestures/performer.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/performer.rb
@@ -57,6 +57,13 @@ module Calabash
         end
 
         # @!visibility private
+        #
+        # Callers must validate the options.
+        def pan_coordinates(from_point, to_point, options={})
+          abstract_method!
+        end
+
+        # @!visibility private
         def pinch(in_or_out, options)
           abstract_method!
         end

--- a/calabash-cucumber/spec/lib/core_spec.rb
+++ b/calabash-cucumber/spec/lib/core_spec.rb
@@ -209,6 +209,40 @@ describe Calabash::Cucumber::Core do
     end
   end
 
+  context "#pan" do
+    context "raises an ArgumentError if called with an invalid duration" do
+      let(:options) { {} }
+
+      it "raises if duration < 0.5 with UIAutomation" do
+        expect(world).to receive(:uia_available?).and_return(true)
+        options[:duration] = 0.4
+
+        expect do
+          world.pan("from", "to", options)
+        end.to raise_error ArgumentError, /Invalid duration/
+      end
+
+      it "raises if duration <= 0.0 with DeviceAgent" do
+        expect(world).to receive(:uia_available?).and_return(false)
+        options[:duration] = 0.0
+
+        expect do
+          world.pan("from", "to", options)
+        end.to raise_error ArgumentError, /Invalid duration/
+      end
+    end
+
+    it "calls the gesture performer #pan method" do
+      expect(world).to receive(:launcher).and_return(launcher)
+      expect(launcher).to receive(:gesture_performer).and_return(gesture_performer)
+      expect(gesture_performer).to(
+        receive(:pan).with("from", "to", {:duration => 1.0}).and_return(true)
+      )
+
+      expect(world.pan("from", "to")).to be_truthy
+    end
+  end
+
   context "#rotate_home_button_to" do
     let(:position) { :left }
 

--- a/calabash-cucumber/spec/lib/core_spec.rb
+++ b/calabash-cucumber/spec/lib/core_spec.rb
@@ -243,6 +243,40 @@ describe Calabash::Cucumber::Core do
     end
   end
 
+  context "#pan_coordinates" do
+    context "raises an ArgumentError if called with an invalid duration" do
+      let(:options) { {} }
+
+      it "raises if duration < 0.5 with UIAutomation" do
+        expect(world).to receive(:uia_available?).and_return(true)
+        options[:duration] = 0.4
+
+        expect do
+          world.pan_coordinates("from", "to", options)
+        end.to raise_error ArgumentError, /Invalid duration/
+      end
+
+      it "raises if duration <= 0.0 with DeviceAgent" do
+        expect(world).to receive(:uia_available?).and_return(false)
+        options[:duration] = 0.0
+
+        expect do
+          world.pan_coordinates("from", "to", options)
+        end.to raise_error ArgumentError, /Invalid duration/
+      end
+    end
+
+    it "calls the gesture performer #pan method" do
+      expect(world).to receive(:launcher).and_return(launcher)
+      expect(launcher).to receive(:gesture_performer).and_return(gesture_performer)
+      expect(gesture_performer).to(
+        receive(:pan_coordinates).with("from", "to", {:duration => 1.0}).and_return(true)
+      )
+
+      expect(world.pan_coordinates("from", "to")).to be_truthy
+    end
+  end
+
   context "#rotate_home_button_to" do
     let(:position) { :left }
 

--- a/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
+++ b/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
@@ -8,6 +8,7 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
       def inspect; to_s; end
       def rotate_home_button_to(_); ; end
       def perform_coordinate_gesture(_, _, _, _={}); ; end
+      def pan_between_coordinates(_, _, _={}); ; end
     end.new
   end
 
@@ -255,6 +256,42 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
         expected = [hash[:view]]
 
         expect(device_agent.touch_hold(options)).to be == expected
+      end
+    end
+
+    context "#pan" do
+      it "pans between the center of the queries and returns both views" do
+        from_query = "from"
+        to_query = "to"
+        options = {:duration => 1.0}
+
+        from_options = options.merge({:query => from_query})
+        to_options = options.merge({:query => to_query})
+
+        from_hash = {:coordinates => :from_point,
+                     :view => :from_view}
+
+        to_hash = {:coordinates => :to_point,
+                     :view => :to_view}
+
+
+        expect(device_agent).to(
+          receive(:query_for_coordinates).with(from_options).and_return(from_hash)
+        )
+
+        expect(device_agent).to(
+          receive(:query_for_coordinates).with(to_options).and_return(to_hash)
+        )
+
+        expect(device_agent.device_agent).to(
+          receive(:pan_between_coordinates).with(:from_point, :to_point,
+                                                 {:duration => 1.0}).and_return(true)
+        )
+
+        actual = device_agent.pan(from_query, to_query, options)
+        expect(actual[0]).to be == :from_view
+        expect(actual[1]).to be == :to_view
+        expect(actual.count).to be == 2
       end
     end
 

--- a/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
+++ b/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
@@ -295,6 +295,24 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
       end
     end
 
+    context "#pan_coordinates" do
+      it "pans between two coordinates" do
+        options = {:duration => 1.0}
+
+        expect(device_agent.device_agent).to(
+          receive(:pan_between_coordinates).with(:from_point, :to_point,
+                                                 {:duration => 1.0}).and_return(true)
+        )
+
+        expect(device_agent).to(
+          receive(:first_element_for_query).with("*").and_return(:view)
+        )
+
+        actual = device_agent.pan_coordinates(:from_point, :to_point, options)
+        expect(actual).to be == [:view]
+      end
+    end
+
     context "Text Entry" do
       context "#enter_text_with_keyboard" do
         it "types a string by calling out to enter_text" do

--- a/calabash-cucumber/test/cucumber/features/drag_and_drop.feature
+++ b/calabash-cucumber/test/cucumber/features/drag_and_drop.feature
@@ -1,4 +1,5 @@
 @drag_and_drop
+@pan
 Feature: Drag and Drop
 In order to test the Calabash pan API
 As a Calabash developer

--- a/calabash-cucumber/test/cucumber/features/pan.feature
+++ b/calabash-cucumber/test/cucumber/features/pan.feature
@@ -1,0 +1,18 @@
+@pan
+Feature: Pan
+In order to perform flicks, swipes, scrolls, and drag-and-drop
+As an iOS UI tester
+I want a pan API
+
+Background: Navigate to Pan page
+Given the app has launched
+And I am looking at the Pan tab
+
+# Restart after because this Scenario might leave a blocking iOS OS view
+@restart_after
+Scenario: Full Screen Pan
+And I am looking at the Pan Palette page
+Then I can pan to go back to the Pan menu
+Then I can pull down to see the Today and Notifications page
+Then I can pan to go back to the Pan menu
+Then I can pull up to see the Control Panel page

--- a/calabash-cucumber/test/cucumber/features/steps/pan.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/pan.rb
@@ -1,0 +1,135 @@
+
+module TestApp
+  module Pan
+
+    def wait_for_external_animations
+      wait_for_animations
+      delay = RunLoop::Environment.ci? ? 1.0 : 0.5
+      sleep(delay)
+    end
+  end
+end
+
+World(TestApp::Pan)
+
+And(/^I am looking at the Pan Palette page$/) do
+  wait_for_view("* marked:'pan page'")
+  wait_for_view("* marked:'pan palette row'")
+  touch("* marked:'pan palette row'")
+  wait_for_view("* marked:'pan palette page'")
+  wait_for_animations
+end
+
+Given(/^I am looking at the Everything's On the Table page$/) do
+  wait_for_view("* marked:'table row'")
+  touch("* marked:'table row'")
+  wait_for_view("* marked:'table page'")
+  wait_for_animations
+end
+
+Given(/^I am looking at the Scrollplications page$/) do
+  wait_for_view("* marked:'scrollplications row'")
+  touch("* marked:'scrollplications row'")
+  wait_for_view("* marked:'scroll'")
+  wait_for_animations
+end
+
+Then(/^I can pan to go back to the Pan menu$/) do
+  element = wait_for_view("*")
+  y = element["rect"]["center_y"]
+  final_x = element["rect"]["center_x"] + (element["rect"]["width"]/2)
+  pan_coordinates({:x => 0, :y => y},
+                  {:x => final_x, :y => y},
+                  {duration: 0.5})
+  wait_for_animations
+  wait_for_view("* marked:'pan page'")
+end
+
+Then(/^I can pull down to see the Today and Notifications page$/) do
+  if ipad?
+    puts "Test is not stable on iPad; skipping"
+  end
+
+  element = wait_for_view("*")
+  x = element["rect"]["center_x"]
+  final_y = element["rect"]["center_y"] + (element["rect"]["height"]/2)
+  pan_coordinates({:x => x, :y => 0},
+                  {:x => x, :y => final_y},
+                  {duration: 0.5})
+
+  # Waiting for animations is not good enough - the animation is outside of
+  # the AUT's view hierarchy
+  wait_for_external_animations
+
+  # Screenshots will not show the iOS Today and Notifications page.
+  if uia_available?
+    if uia_call_windows([:button, {marked: 'Today'}], :isVisible) != 1
+      fail("Expected to see the iOS Today and Notifications page.")
+    end
+  else
+    # Today and Notifications view is invisible to the LPServer and the
+    # DeviceAgent queries.  Try to touch a row that is hidden by the page and
+    # expect no transition.
+    touch("* marked:'pan palette row'")
+    wait_for_animations
+    if !query("* marked:'pan palette page'").empty?
+      fail("Expected to see the iOS Today and Notifications page.")
+    end
+  end
+
+  y = element["rect"]["height"] - 20
+  touch(nil, {offset: {x: x, y: y}})
+  wait_for_external_animations
+
+  wait_for_view("* marked:'table row'")
+  touch("* marked:'table row'")
+  wait_for_view("* marked:'table page'")
+  wait_for_animations
+end
+
+Then(/^I can pull up to see the Control Panel page$/) do
+  if ipad?
+    puts "Test is not stable on iPad; skipping"
+  end
+
+  element = wait_for_view("*")
+  x = element["rect"]["center_x"]
+  start_y = element["rect"]["height"]
+  final_y = element["rect"]["center_x"] + (element["rect"]["height"]/2)
+  pan_coordinates({:x => x, :y => start_y},
+                  {:x => x, :y => final_y},
+                  {duration: 0.5})
+
+  # Waiting for animations is not good enough - the animation is outside of
+  # the AUT's view hierarchy
+  wait_for_external_animations
+
+  # Screenshots will not show the Control Panel page.
+  if uia_available?
+    if uia_call_windows([:button, {marked: 'Camera'}], :isVisible) != 1
+       fail("Expected to see the iOS Control page.")
+    end
+
+    # This will dismiss the control panel by touching the navigation bar.
+    touch("* marked:'Pan'")
+  else
+    # Control Panel view is invisible to the LPServer and the DeviceAgent queries.
+    # Try to touch a row that is hidden by the page and expect no transition.
+
+    # This will dismiss the control panel.
+    touch("* marked:'pan palette row'")
+
+    if !query("* marked:'pan palette page'").empty?
+      fail("Expected to see the iOS Control panel page.")
+    end
+  end
+
+  wait_for_external_animations
+
+  wait_for_view("* marked:'table row'")
+  touch("* marked:'table row'")
+  wait_for_view("* marked:'table page'")
+  wait_for_animations
+end
+
+

--- a/calabash-cucumber/test/cucumber/features/steps/shared.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/shared.rb
@@ -29,6 +29,8 @@ Given(/^the app has launched$/) do
     !query("*").empty?
   end
 
+  rotate_home_button_to(:bottom)
+
   if keyboard_visible?
     ['textField', 'textView'].each do |ui_class|
       query = "#{ui_class} isFirstResponder:1"


### PR DESCRIPTION
### Motivation

The documentation for `Core#pan` was out of step with the implementation and needed changes for DeviceAgent.

I added `Core#pan_coordinates` as a convenience method so I will not have to change the existing `swipe` and `flick` API and still provide a reasonably good experience for DeviceAgent users.

```
# pan_coordinates
Scenario: Full Screen Pan
And I am looking at the Pan Palette page
Then I can pan to go back to the Pan menu
Then I can pull down to see the Today and Notifications page
Then I can pan to go back to the Pan menu
Then I can pull up to see the Control Panel page
```

Thanks to the [Gitter](https://gitter.im/calabash/calabash0x?utm_source=share-link&utm_medium=link&utm_campaign=share-link) crew for their help this afternoon.

@ark-konopacki @TeresaP @@mmorrisseymm @JoeSSS Sorry if I missed someone!
