### PR TITLE
Replace XCUITest references with DeviceAgent::Client

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -60,7 +60,7 @@ Gem::Specification.new do |s|
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
   s.add_dependency("clipboard", "~> 1.0")
-  s.add_dependency("run_loop", ">= 2.1.4", "< 3.0")
+  s.add_dependency("run_loop", ">= 2.1.8", "< 3.0")
 
   # Shared with run-loop.
   s.add_dependency('json')

--- a/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/gestures/device_agent.rb
@@ -46,9 +46,9 @@ args = #{args}
 ])
           end
 
-          if !args[0].is_a?(RunLoop::XCUITest)
-            raise(ArgumentError,
-                  %Q[Expected first element of args to be a RunLoop::XCUITest instance, found:
+          if !args[0].is_a?(RunLoop::DeviceAgent::Client)
+            raise(ArgumentError, %Q[
+Expected first element of args to be a RunLoop::DeviceAgent::Client instance, found:
 
 args[0] = #{args[0]}
 

--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -355,7 +355,7 @@ Resetting physical devices is not supported.
         @run_loop = new_run_loop(options)
         if run_loop.is_a?(Hash)
           @gesture_performer = Calabash::Cucumber::Gestures::Instruments.new(@run_loop)
-        elsif @run_loop.is_a?(RunLoop::XCUITest)
+        elsif @run_loop.is_a?(RunLoop::DeviceAgent::Client)
           @gesture_performer = Calabash::Cucumber::Gestures::DeviceAgent.new(@run_loop)
         else
           raise ArgumentError, %Q[

--- a/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
+++ b/calabash-cucumber/spec/lib/gestures/device_agent_spec.rb
@@ -2,9 +2,9 @@
 describe Calabash::Cucumber::Gestures::DeviceAgent do
 
   let(:xcuitest) do
-    Class.new(RunLoop::XCUITest) do
+    Class.new(RunLoop::DeviceAgent::Client) do
       def initialize; ; end
-      def to_s; "#<XCUITest subclass>"; end
+      def to_s; "#<DeviceAgent::Client subclass>"; end
       def inspect; to_s; end
       def rotate_home_button_to(_); ; end
       def perform_coordinate_gesture(_, _, _, _={}); ; end
@@ -35,11 +35,11 @@ describe Calabash::Cucumber::Gestures::DeviceAgent do
       end.to raise_error ArgumentError, /Expected args to be an Array with one element/
     end
 
-    it "raises error if arg[0] is not a RunLoop::XCUITest instance" do
+    it "raises error if arg[0] is not a RunLoop::DeviceAgent::Client instance" do
       expect do
         Calabash::Cucumber::Gestures::DeviceAgent.expect_valid_args(["a"])
       end.to raise_error ArgumentError,
-                         /Expected first element of args to be a RunLoop::XCUITest instance/
+                         /Expected first element of args to be a RunLoop::DeviceAgent::Client instance/
     end
 
     it "returns true if args are valid" do

--- a/calabash-cucumber/test/cucumber/config/cucumber.yml
+++ b/calabash-cucumber/test/cucumber/config/cucumber.yml
@@ -2,24 +2,8 @@
 
 require "run_loop"
 
-#DEVICE_AGENT_REPO = File.expand_path(File.join("..", "..", "..", "..", "DeviceAgent.iOS"))
-#DEVICE_AGENT_PRODUCTS = File.join(DEVICE_AGENT_REPO, "Products")
-#SIM_APP = File.join(DEVICE_AGENT_PRODUCTS, "app", "TestApp", "TestApp.app")
-#DEVICE_APP = File.join(DEVICE_AGENT_PRODUCTS, "ipa", "TestApp", "TestApp.app")
-
 SIM_APP = File.join("aut", "sim", "TestApp.app")
 DEVICE_APP = File.join("aut", "device", "TestApp.app")
-
-# Path to DeviceAgent.iOS repo to support launching CBX-Runner with xcodebuild.
-#
-# This will allow you to run cucumbers against non-released versions of DeviceAgent.
-#
-# CBX_LAUNCHER=xcodebuild be cucumber
-CBXWS = begin
-  repo = File.join("..", "..", "..", "..", "DeviceAgent.iOS")
-  workspace = File.join(repo, "CBXDriver.xcworkspace")
-  "#{File.expand_path(workspace)}"
-end
 
 calabash_dir = File.expand_path(File.join(ENV["HOME"], ".calabash"))
 
@@ -43,13 +27,12 @@ FileUtils.mkdir_p("./reports")
 
 verbose: DEBUG=1
 formatter: -f pretty
-cbxws: CBXWS=<%= CBXWS %>
 
 # Launch on default simulator.
 simulator_vars: APP=<%= SIM_APP %>
 simulator_tags: --tags ~@device_only --tags ~@device
 
-default:  -p simulator_vars -p simulator_tags -p cbxws
+default:  -p simulator_vars -p simulator_tags
 
 # Launch on device.
 # DeviceAgent requires CODE_SIGN_IDENTITY; could not make this work as a profile

--- a/calabash-cucumber/test/cucumber/features/support/01_launch.rb
+++ b/calabash-cucumber/test/cucumber/features/support/01_launch.rb
@@ -95,24 +95,17 @@ module Calabash
 
     def options
       @options ||= begin
-        env = ENV["CBX_LAUNCHER"]
-        if env
-          cbx_launcher = env.to_sym
-          cbx = {
-            :gesture_performer => :device_agent,
-            :cbx_launcher => cbx_launcher
+        if xcode.version_gte_8?
+          performer = {
+            :gesture_performer => :device_agent
           }
         else
-          cbx = {
+          performer = {
             :gesture_performer => :instruments
           }
         end
 
-        if cbx[:cbx_launcher] == :xcodebuild
-          cbx[:shutdown_device_agent_before_launch] = true
-        end
-
-        cbx.merge(environment)
+        performer.merge(environment)
       end
     end
 
@@ -131,6 +124,9 @@ Before do |scenario|
 
   options = {
     # Add launch options here.
+    # Maintainers can use:
+    #   cbx_launcher => :xcodebuild
+    # when debugging the DeviceAgent
   }
 
   merged_options = options.merge(Calabash::Launchctl.instance.options)


### PR DESCRIPTION
### Motivation

There were breaking name changes in the last couple of weeks that caused Calabash iOS to be out of step with the current release of run-loop.

See the run-loop release notes for details: https://github.com/calabash/run_loop/pull/518

