### PR TITLE
calabash_exit does not raise an error if the server is not running

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -1292,12 +1292,15 @@ arguments => '#{arguments}'
           []
         end
 
-        if launcher.gesture_performer.class.name == :device_agent
-          delay = merged_opts[:post_resign_active_delay] +
-            merged_opts[:post_will_terminate_delay] + 0.4
-          sleep(delay)
-          launcher.gesture_performer.send(:session_delete)
+        if launcher.gesture_performer
+          if launcher.gesture_performer.class.name == :device_agent
+            delay = merged_opts[:post_resign_active_delay] +
+              merged_opts[:post_will_terminate_delay] + 0.4
+            sleep(delay)
+            launcher.gesture_performer.send(:session_delete)
+          end
         end
+        true
       end
 
       # Get the Calabash server log level.

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -1288,7 +1288,7 @@ arguments => '#{arguments}'
                }
           )
 
-        rescue Errno::ECONNREFUSED, HTTPClient::KeepAliveDisconnected
+        rescue Errno::ECONNREFUSED, HTTPClient::KeepAliveDisconnected, SocketError
           []
         end
 

--- a/calabash-cucumber/spec/integration/core/calabash_exit_spec.rb
+++ b/calabash-cucumber/spec/integration/core/calabash_exit_spec.rb
@@ -1,23 +1,31 @@
-class CoreIncluded
-  include Calabash::Cucumber::Core
-end
 
 describe Calabash::Cucumber::Core do
 
   let(:launcher) { Calabash::Cucumber::Launcher.new }
-  let(:core_instance) { CoreIncluded.new }
+  let(:world) do
+    Class.new do
+      include Calabash::Cucumber::Core
+      def to_s; "#<World>"; end
+      def inspect; "#<World>"; end
+    end.new
+  end
 
-  describe '#calabash_exit' do
-    it 'targeting simulators' do
+  context "#calabash_exit" do
+
+    it "does not raise an error when the LPServer is not running" do
+      expect { world.calabash_exit }.not_to raise_error
+    end
+
+    it "does not raise an error when LPServer is running" do
       options =
-            {
-                  :app => Resources.shared.app_bundle_path(:cal_smoke_app),
-                  :device_target =>  'simulator',
-                  :launch_retries => Luffa::Retry.instance.launch_retries
-            }
+        {
+          :app => Resources.shared.app_bundle_path(:cal_smoke_app),
+          :device_target =>  "simulator",
+          :launch_retries => Luffa::Retry.instance.launch_retries
+        }
       launcher.relaunch(options)
       expect(launcher.run_loop).not_to be == nil
-      expect { core_instance.calabash_exit }.not_to raise_error
+      expect { world.calabash_exit }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
### Motivation

We need to support this use case:

```
Before("@reset_device") do
  calabash_exit
  ...
end
```