### PR TITLE
Support SSL with OpenSSL::SSL::VERIFY_NONE and path prefixes

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/http/http.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/http/http.rb
@@ -15,12 +15,15 @@ module Calabash
       def self.ping_app
         endpoint = Calabash::Cucumber::Environment.device_endpoint
         url = URI.parse(endpoint)
-
+        path = url.path
         http = Net::HTTP.new(url.host, url.port)
-        response = http.start do |sess|
-          sess.request(Net::HTTP::Get.new("version"))
+        if url.scheme == "https"
+          http.use_ssl = true
+          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
-
+        response = http.start do |sess|
+          sess.request(Net::HTTP::Get.new("#{path}version"))
+        end
         body = nil
         success = response.is_a?(Net::HTTPSuccess)
         if success
@@ -112,4 +115,3 @@ If your app is crashing at launch, find a crash report to determine the cause.
     end
   end
 end
-


### PR DESCRIPTION
In Xamarin Test Cloud, we use SSL to connect to devicehosts. Further the paths for the `Calabash::Cucumber::Environment.device_endpoint` will take a form of:

`https://devicehost.dev:6767/sessions/token-19b0dfcc-eb10-4e1d-bfda-4e8b1ea8c796/ios-proxy-socket/`

which means we need to take into account `url.path` when pinging app