### PR TITLE
Replaced calls to touch() to use Hash argument instead of String

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/automator/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/automator/device_agent.rb
@@ -222,7 +222,7 @@ args[0] = #{args[0]}])
           if mark
             begin
               # The underlying query for coordinates always expects results.
-              value = client.touch(mark)
+              value = client.touch({marked: mark})
               return value
             rescue RuntimeError => e
               RunLoop.log_debug("Cannot find mark '#{mark}' with query; will send a newline")
@@ -237,7 +237,7 @@ args[0] = #{args[0]}])
 
         # @!visibility private
         def tap_keyboard_delete_key
-          client.touch("delete")
+          client.touch({marked: "delete"})
         end
 
         # @!visibility private
@@ -249,7 +249,7 @@ args[0] = #{args[0]}])
         #
         # Stable across different keyboard languages.
         def dismiss_ipad_keyboard
-          client.touch("Hide keyboard")
+          client.touch({marked: "Hide keyboard"})
         end
 
         # @!visibility private

--- a/calabash-cucumber/spec/lib/automator/device_agent_spec.rb
+++ b/calabash-cucumber/spec/lib/automator/device_agent_spec.rb
@@ -378,7 +378,7 @@ describe Calabash::Cucumber::Automator::DeviceAgent do
           expect(device_agent).to(
             receive(:mark_for_return_key_of_first_responder)
           ).and_return("Mark")
-          expect(device_agent.client).to receive(:touch).with("Mark").and_return({})
+          expect(device_agent.client).to receive(:touch).with({marked: "Mark"}).and_return({})
 
           expect(device_agent.tap_keyboard_action_key).to be == {}
         end
@@ -399,7 +399,7 @@ describe Calabash::Cucumber::Automator::DeviceAgent do
           ).and_return("Unmatchable identifier")
 
           expect(device_agent.client).to(
-            receive(:touch).with("Unmatchable identifier").and_raise(
+            receive(:touch).with({marked: "Unmatchable identifier"}).and_raise(
               RuntimeError, "No match found")
           )
 
@@ -412,7 +412,7 @@ describe Calabash::Cucumber::Automator::DeviceAgent do
 
       context "#tap_keyboard_delete_key" do
         it "touches the keyboard delete key" do
-          expect(device_agent.client).to receive(:touch).with('delete').and_return({})
+          expect(device_agent.client).to receive(:touch).with({marked: 'delete'}).and_return({})
 
           expect(device_agent.tap_keyboard_delete_key).to be == {}
         end
@@ -428,7 +428,7 @@ describe Calabash::Cucumber::Automator::DeviceAgent do
 
       context "#dismiss_ipad_keyboard" do
         it "touches the hide keyboard key" do
-          expect(device_agent.client).to receive(:touch).with("Hide keyboard").and_return({})
+          expect(device_agent.client).to receive(:touch).with({marked: "Hide keyboard"}).and_return({})
 
           expect(device_agent.dismiss_ipad_keyboard).to be == {}
         end


### PR DESCRIPTION
Fix for ```TypeError: no implicit conversion of String into Hash``` with calls to tap_keyboard_action_key.

Also includes the fix for tap_keyboard_delete_key and dismiss_ipad_keyboard, which had the same issue of using a String instead of Hash.