### PR TITLE
Duration is not a valid option for #swipe

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/automator/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/automator/device_agent.rb
@@ -131,12 +131,25 @@ args[0] = #{args[0]}])
           from_point = hash[:coordinates]
           element = hash[:view]
 
+          # DeviceAgent does not understand the :force. Does anyone?
+          force = dupped_options[:force]
+          case force
+            when :strong
+              duration = 0.2
+            when :normal
+              duration = 0.4
+            when :light
+              duration = 0.7
+            else
+              # Caller is responsible for validating the :force option.
+              duration = 0.5
+          end
+
           gesture_options = {
-            :duration => dupped_options[:duration]
+            :duration => duration
           }
 
           direction = dupped_options[:direction]
-          force = dupped_options[:force]
           to_point = Coordinates.end_point_for_swipe(direction, element, force)
           client.pan_between_coordinates(from_point, to_point, gesture_options)
           [hash[:view]]

--- a/calabash-cucumber/test/cucumber/features/steps/swipe.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/swipe.rb
@@ -4,7 +4,6 @@ Then(/^I can swipe to go back to the Pan menu$/) do
   # to open menu this behavior could probably also be changed in the test app.
   swipe(:right, {
     :query => "*",
-    :duration => 0.7,
     :offset => {:x => x_offset, :y => 0},
     :force => :strong,
 
@@ -20,7 +19,9 @@ And(/^I swipe to delete the '(.*?)' table cell$/) do |cell_title|
   cell_query = "UILabel marked:'#{cell_title}'"
   wait_for_view(cell_query)
   x_offset = query(cell_query)[0]["rect"]["width"] / 2.5
-  swipe(:left, {:query => cell_query, :duration => 0.5, :force => :strong, :offset => {:x => x_offset, :y => 0}})
+  swipe(:left, {:query => cell_query,
+                :force => :strong,
+                :offset => {:x => x_offset, :y => 0}})
   wait_for_animations
   touch("UIButton marked:'Delete'")
 end

--- a/calabash-cucumber/test/cucumber/features/support/01_launch.rb
+++ b/calabash-cucumber/test/cucumber/features/support/01_launch.rb
@@ -147,5 +147,7 @@ After("@stop_after") do |_|
 end
 
 After do |scenario|
-
+  if scenario.failed?
+    exit!(1)
+  end
 end

--- a/calabash-cucumber/test/cucumber/features/support/env.rb
+++ b/calabash-cucumber/test/cucumber/features/support/env.rb
@@ -8,4 +8,9 @@ if !RunLoop::Environment.xtc?
   require "pry"
   Pry.config.history.file = ".pry-history"
   require "pry-nav"
+
+  require 'pry/config'
+  class Pry
+      trap('INT') { exit!(1) }
+  end
 end


### PR DESCRIPTION
### Motivation

`Automator::DeviceAgent#swipe` expected a `:duration` argument in the options, but `:duration` is not a valid `Core#swipe` option.    The `:duration` needs to be derived from the `:force` option.

Thanks to @JoeSSS for reporting.