### PR TITLE
Require ::Coordinates. Use offset directly when query is not defined

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/automator/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/automator/device_agent.rb
@@ -10,6 +10,7 @@ module Calabash
 
         require "run_loop"
         require "calabash-cucumber/map"
+        require "calabash-cucumber/automator/coordinates"
 
         require "calabash-cucumber/query_helpers"
         include Calabash::Cucumber::QueryHelpers
@@ -128,7 +129,12 @@ args[0] = #{args[0]}])
           end
 
           hash = query_for_coordinates(dupped_options)
-          from_point = hash[:coordinates]
+
+          from_point = if !options[:offset].nil? && options[:query].nil?
+                         options[:offset]
+                       else
+                         hash[:coordinates]
+                       end
           element = hash[:view]
 
           # DeviceAgent does not understand the :force. Does anyone?


### PR DESCRIPTION
This PR allow user to use swipe with offset using defined offset but not calculated from query "*" in case when offset is defined and query isn't.
It also fixes problem for ::Coordinates visibility.