### PR TITLE
Public query and gesture API for DeviceAgent.

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber.rb
+++ b/calabash-cucumber/lib/calabash-cucumber.rb
@@ -14,6 +14,7 @@ require "calabash-cucumber/automator/device_agent"
 require 'calabash-cucumber/keyboard_helpers'
 require 'calabash-cucumber/keychain_helpers'
 require 'calabash-cucumber/wait_helpers'
+require "calabash-cucumber/device_agent"
 require 'calabash-cucumber/operations'
 require 'calabash-cucumber/core'
 require 'calabash-cucumber/tests_helpers'

--- a/calabash-cucumber/lib/calabash-cucumber/automator/automator.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/automator/automator.rb
@@ -25,6 +25,16 @@ module Calabash
         end
 
         # @!visibility private
+        def running?
+          abstract_method!
+        end
+
+        # @!visibility private
+        def client
+          abstract_method!
+        end
+
+        # @!visibility private
         def touch(options)
           abstract_method!
         end

--- a/calabash-cucumber/lib/calabash-cucumber/automator/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/automator/device_agent.rb
@@ -76,6 +76,11 @@ args[0] = #{args[0]}])
         end
 
         # @!visibility private
+        def running?
+          client.send(:running?)
+        end
+
+        # @!visibility private
         def session_delete
           client.send(:session_delete)
         end
@@ -238,7 +243,7 @@ args[0] = #{args[0]}])
               # The underlying query for coordinates always expects results.
               value = client.touch({marked: mark})
               return value
-            rescue RuntimeError => e
+            rescue RuntimeError => _
               RunLoop.log_debug("Cannot find mark '#{mark}' with query; will send a newline")
             end
           else

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -1580,6 +1580,66 @@ arguments => '#{arguments}'
         launcher.attach({:uia_strategy => uia_strategy})
       end
 
+      def device_agent
+        launcher = Calabash::Cucumber::Launcher.launcher_if_used
+        if !launcher
+          raise RuntimeError, %Q[
+There is no launcher.
+
+If you are in the Calabash console, you can try to attach to an already running
+Calabash test using:
+
+> console_attach
+
+If you are running from Cucumber or rspec, call Launcher#relaunch before calling
+this method.
+
+]
+        end
+
+        if !launcher.automator
+          raise RuntimeError, %Q[
+The launcher is not attached to an automator.
+
+If you are in the Calabash console, you can try to attach to an already running
+Calabash test using:
+
+> console_attach
+
+If you are running from Cucumber or rspec, call Launcher#relaunch before calling
+this method.
+
+]
+        end
+
+        if launcher.automator.name != :device_agent
+          raise RuntimeError, %Q[
+The launcher automator is not DeviceAgent:
+
+#{launcher.automator}
+
+#device_agent is only available for Xcode 8.
+
+In your tests, use this pattern to branch on the availability of DeviceAgent.
+
+if uia_available?
+   # Make a UIA call
+else
+   # Make a DeviceAgent call
+end
+
+]
+        end
+        automator = launcher.automator
+
+        if !automator.running?
+          raise RuntimeError, %Q[The DeviceAgent is not running.]
+        else
+          require "calabash-cucumber/device_agent"
+          Calabash::Cucumber::DeviceAgent.new(automator.client, self)
+        end
+      end
+
       # @!visibility private
       # TODO should be private
       def launcher

--- a/calabash-cucumber/lib/calabash-cucumber/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device_agent.rb
@@ -1,0 +1,346 @@
+module Calabash
+  module Cucumber
+
+    # An interface to the DeviceAgent Query and Gesture API.
+    #
+    # Unlike Calabash or UIA gestures, all DeviceAgent gestures wait for the
+    # uiquery to match a view.  This behavior match the Calabash 2.0 and
+    # Calabash 0.x Android behavior.
+    #
+    # This API is work in progress.  There are several methods that are
+    # experimental and several methods that will probably removed soon.
+    #
+    # Wherever possible use Core#query and the gestures defined in Core.
+    #
+    # TODO Screenshots
+    class DeviceAgent < BasicObject
+
+      # @!visibility private
+      #
+      # @param [RunLoop::DeviceAgent::Client] client The DeviceAgent client.
+      # @param [Cucumber::World] world The Cucumber World.
+      def initialize(client, world)
+        @client = client
+        @world = world
+      end
+
+      # @!visibility private
+      #
+      # @example
+      #  query({id: "login", :type "Button"})
+      #
+      #  query({marked: "login"})
+      #
+      #  query({marked: "login", type: "TextField"})
+      #
+      #  query({type: "Button", index: 2})
+      #
+      #  query({text: "Log in"})
+      #
+      #  query({id: "hidden button", :all => true})
+      #
+      #  # Escaping single quote is not necessary, but supported.
+      #  query({text: "Karl's problem"})
+      #  query({text: "Karl\'s problem"})
+      #
+      #  # Escaping double quote is not necessary, but supported.
+      #  query({text: "\"To know is not enough.\""})
+      #  query({text: %Q["To know is not enough."]})
+      #
+      # Querying for text with newlines is not supported yet.
+      #
+      # The query language supports the following keys:
+      # * :marked - accessibilityIdentifier, accessibilityLabel, text, and value
+      # * :id - accessibilityIdentifier
+      # * :type - an XCUIElementType shorthand, e.g. XCUIElementTypeButton =>
+      #   Button. See the link below for available types.  Note, however that
+      #   some XCUIElementTypes are not available on iOS.
+      # * :index - Applied after all other specifiers.
+      # * :all - Filter the result by visibility. Defaults to false. See the
+      #   discussion below about visibility.
+      #
+      # ### Visibility
+      #
+      # The rules for visibility are:
+      #
+      # 1. If any part of the view is visible, the visible.
+      # 2. If the view has alpha 0, it is not visible.
+      # 3. If the view has a size (0,0) it is not visible.
+      # 4. If the view is not within the bounds of the screen, it is not visible.
+      #
+      # Visibility is determined using the "hitable" XCUIElement property.
+      # XCUITest, particularly under Xcode 7, is not consistent about setting
+      # the "hitable" property correctly.  Views that are not "hitable" will
+      # still respond to gestures. For this reason, gestures use the
+      # element["rect"] for computing the touch point.
+      #
+      # Regarding rule #1 - this is different from the Calabash iOS and Android
+      # definition of visibility which requires the mid-point of the view to be
+      # visible.
+      #
+      # Please report visibility problems.
+      #
+      # ### Results
+      #
+      # Results are returned as an Array of Hashes.  The key/value pairs are
+      # similar to those returned by the Calabash iOS Server, but not exactly
+      # the same.
+      #
+      # ```
+      # [
+      #  {
+      #    "enabled": true,
+      #    "id": "mostly hidden button",
+      #    "hitable": true,
+      #    "rect": {
+      #      "y": 459,
+      #      "x": 24,
+      #      "height": 25,
+      #      "width": 100
+      #    },
+      #    "label": "Mostly Hidden",
+      #    "type": "Button",
+      #    "hit_point": {
+      #      "x": 25,
+      #      "y": 460
+      #    },
+      #  }
+      # ]
+      # ```
+      #
+      # @see http://masilotti.com/xctest-documentation/Constants/XCUIElementType.html
+      # @param [Hash] uiquery A hash describing the query.
+      # @return [Array<Hash>] An array of elements matching the `uiquery`.
+      def query(uiquery)
+        client.query(uiquery)
+      end
+
+      # Query for the center of a view.
+      #
+      # @see #query
+      #
+      # This method waits for the query to match at least one element.
+      #
+      # @param uiquery See #query
+      # @return [Hash] The center of first view matched by query.
+      #
+      # @raise [RuntimeError] if no view matches the uiquery after waiting.
+      def query_for_coordinate(uiquery)
+        fail_with_screenshot { client.query_for_coordinate(uiquery) }
+      end
+
+      # Perform a touch on the center of the first view matched the uiquery.
+      #
+      # This method waits for the query to match at least one element.
+      #
+      # @see #query
+      #
+      # @param [Hash] uiquery See #query for examples.
+      # @return [Array<Hash>] The view that was touched.
+      #
+      # @raise [RuntimeError] if no view matches the uiquery after waiting.
+      def touch(uiquery)
+        fail_with_screenshot { client.touch(uiquery) }
+      end
+
+      # Perform a touch at a coordinate.
+      #
+      # This method does not wait; the touch is performed immediately.
+      #
+      # @param [Hash] coordinate The coordinate to touch.
+      def touch_coordinate(coordinate)
+        client.touch_coordinate(coordinate)
+      end
+
+      # Perform a touch at a point.
+      #
+      # This method does not wait; the touch is performed immediately.
+      #
+      # @param [Hash] x the x coordinate
+      # @param [Hash] y the y coordinate
+      def touch_point(x, y)
+        client.touch_point(x, y)
+      end
+
+      # Perform a double tap on the center of the first view matched the uiquery.
+      #
+      # @see #query
+      #
+      # This method waits for the query to match at least one element.
+      #
+      # @param uiquery See #query
+      # @return [Array<Hash>] The view that was touched.
+      #
+      # @raise [RuntimeError] if no view matches the uiquery after waiting.
+      def double_tap(uiquery)
+        fail_with_screenshot { client.double_tap(uiquery) }
+      end
+
+      # Perform a two finger tap on the center of the first view matched the uiquery.
+      #
+      # @see #query
+      #
+      # This method waits for the query to match at least one element.
+      #
+      # @param uiquery See #query
+      # @return [Array<Hash>] The view that was touched.
+      #
+      # @raise [RuntimeError] if no view matches the uiquery after waiting.
+      def two_finger_tap(uiquery)
+        fail_with_screenshot { client.two_finger_tap(uiquery) }
+      end
+
+      # Perform a long press on the center of the first view matched the uiquery.
+      #
+      # @see #query
+      #
+      # This method waits for the query to match at least one element.
+      #
+      # @param uiquery See #query
+      # @param [Numeric] duration How long to press.
+      # @return [Array<Hash>] The view that was touched.
+      #
+      # @raise [RuntimeError] if no view matches the uiquery after waiting.
+      def long_press(uiquery, duration)
+        fail_with_screenshot { client.long_press(uiquery, {:duration => duration}) }
+      end
+
+      # Returns true if there is a keyboard visible.
+      #
+      # Scheduled for removal in 0.21.0.  Use Core#keyboard_visible?. If you
+      # find an example where Core#keyboard_visible? does not find visible
+      # keyboard, please report it.
+      #
+      # @deprecated 0.21.0 Use Core#keyboard_visible?
+      def keyboard_visible?
+        client.keyboard_visible?
+      end
+
+      # Enter text into the UITextInput view that is the first responder.
+      #
+      # The first responder is the view that is attached to the keyboard.
+      #
+      # Scheduled for removal in 0.21.0. Use Core#enter_text. If you find an
+      # example where Core#enter_text does not work, please report it.
+      #
+      # @param [String] text the text to enter
+      #
+      # @raise [RuntimeError] if there is no visible keyboard.
+      # @deprecated 0.21.0 Use Core#enter_text
+      def enter_text(text)
+        fail_with_screenshot { client.enter_text(text) }
+      end
+
+      # Enter text into the first view matched by uiquery.
+      #
+      # This method waits for the query to match at least one element and for
+      # the keyboard to appear.
+      #
+      # Scheduled for removal in 0.21.0. Use Core#enter_text_in. If you find an
+      # example where Core#enter_text_in does not work, please report it.
+      #
+      # @raise [RuntimeError] if no view matches the uiquery after waiting.
+      # @raise [RuntimeError] if the touch does not cause a keyboard to appear.
+      #
+      # @deprecated 0.21.0 Use Core#enter_text
+      def enter_text_in(uiquery, text)
+        fail_with_screenshot do
+          client.touch(uiquery)
+          client.wait_for_keyboard
+          client.enter_text(text)
+        end
+      end
+
+      # EXPERIMENTAL: This API may change.
+      #
+      # Is an alert generated by your Application visible?
+      #
+      # This does not detect SpringBoard alerts.
+      #
+      # @see #springboard_alert
+      #
+      # @see #springboard_alert
+      def app_alert_visible?
+        client.alert_visible?
+      end
+
+      # EXPERIMENTAL: This API may change.
+      #
+      # Queries for an alert generate by your Application.
+      #
+      # This does not detect SpringBoard alerts.
+      #
+      # @see #spring_board_alert
+      #
+      # @return [Array<Hash>] The view that was touched.
+      def app_alert
+        client.alert
+      end
+
+      # EXPERIMENTAL: This API may change.
+      #
+      # Is an alert generated by SpringBoard visible?
+      #
+      # This does not detect alerts generated by your Application.
+      #
+      # Examples of SpringBoard alerts are:
+      # * Privacy Alerts generated by requests for access to protected iOS
+      #   services like Contacts and Location,
+      # * "No SIM card"
+      # * iOS Update available
+      #
+      # @see #alert
+      def springboard_alert_visible?
+        client.springboard_alert_visible?
+      end
+
+      # EXPERIMENTAL: This API may change.
+      #
+      # Queries for an alert generated by SpringBoard.
+      #
+      # This does not detect alerts generated by your Application.
+      #
+      # Examples of SpringBoard alerts are:
+      # * Privacy Alerts generated by requests for access to protected iOS
+      #   services like Contacts and Location,
+      # * "No SIM card"
+      # * iOS Update available
+      #
+      # @see #alert
+      def springboard_alert
+        client.springboard_alert
+      end
+
+=begin
+PROTECTED
+=end
+      protected
+
+      # @!visibility private
+      def method_missing(name, *args, &block)
+        if world.respond_to?(name)
+          world.send(name, *args, &block)
+        else
+          super
+        end
+      end
+
+=begin
+PRIVATE
+=end
+      private
+
+      # @!visibility private
+      attr_reader :client, :world
+
+      # @!visibility private
+      def fail_with_screenshot(&block)
+        begin
+          block.call
+        rescue => e
+          world.send(:fail, e.class, e.message)
+        end
+      end
+    end
+  end
+end

--- a/calabash-cucumber/test/cucumber/features/automator.feature
+++ b/calabash-cucumber/test/cucumber/features/automator.feature
@@ -1,0 +1,21 @@
+@automator
+Feature: Automator
+In order to transition from UIAutomation to DeviceAgent
+As a UI tester
+I want a DeviceAgent API that can replace Calabash UIA methods
+
+Background: Application is launched
+Given the app has launched
+
+Scenario: Querying UIA and DeviceAgent
+And I am looking at the Touch tab
+Then I query for the Silly Alpha button by mark using id
+Then I query for the Silly Zero button by mark using the title
+Then UIA and DeviceAgent can find views that are hidden
+Then UIA and DeviceAgent results can be filtered by visibility
+Then I can query by text
+And I am looking at the Misc tab
+Then I query for Same as views by mark using id
+Then I query for Same as views by mark using id and filter by TextField
+Then I query for Same as views by mark using id and filter by TextView
+Then I query for Same as views by mark using id and use an index to find the Button

--- a/calabash-cucumber/test/cucumber/features/steps/automator.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/automator.rb
@@ -1,0 +1,142 @@
+module TestApp
+  module Automator
+
+    def normalize_element(element)
+      normal = element.dup
+      if uia_available?
+        normal["id"] = element["name"]
+        hp = element["hit-point"]
+        if hp.empty?
+          normal["hitable"] = false
+          normal["hit_point"] = {"x": -1, "y": -1}
+        else
+          normal["hitable"] = true
+          normal["hit_point"] = hp
+        end
+      else
+        normal.delete("test_id")
+      end
+      normal
+    end
+
+    def normalize_elements(elements)
+      elements.map { |element| normalize_element(element) }
+    end
+
+    def with_correct_automator(uia, device_agent)
+      if uia_available?
+        normalize_elements(uia.call)
+      else
+        normalize_elements(device_agent.call)
+      end
+    end
+  end
+end
+
+World(TestApp::Automator)
+
+Then(/^I query for the Silly Alpha button by mark using id$/) do
+  uia = -> { uia_query(:view, {marked: "alpha button"}) }
+  da = -> { device_agent.query({marked: "alpha button"}) }
+
+  elements = with_correct_automator(uia, da)
+
+  expect(elements.count).to be == 1
+  expect(elements[0]["id"]).to be == "alpha button"
+end
+
+Then(/^I query for the Silly Zero button by mark using the title$/) do
+  uia = -> { uia_query(:view, {marked: "alpha button"}) }
+  da = -> { device_agent.query({marked: "alpha button"}) }
+
+  elements = with_correct_automator(uia, da)
+
+  expect(elements.count).to be == 1
+  expect(elements[0]["id"]).to be == "alpha button"
+end
+
+Then(/^UIA and DeviceAgent can find views that are hidden$/) do
+  # Note: :all is not required for uia_query
+  uia = -> { uia_query(:view, {marked: "hidden button"}) }
+  da = -> { device_agent.query({marked: "hidden button", all: true}) }
+
+  elements = with_correct_automator(uia, da)
+
+  expect(elements.count).to be == 1
+  expect(elements[0]["id"]).to be == "hidden button"
+end
+
+Then(/^UIA and DeviceAgent results can be filtered by visibility$/) do
+  # Note: uia_query returns the element with "hit-point" => {}
+  uia = -> { uia_query(:view, {marked: "hidden button"}) }
+  da = -> { device_agent.query({marked: "hidden button", all: false}) }
+
+  elements = with_correct_automator(uia, da)
+
+  if uia_available?
+    expect(elements.count).to be == 1
+    expect(elements[0]["hit-point"]).to be == {}
+  else
+    expect(elements.count).to be == 0
+  end
+end
+
+Then(/^I can query by text$/) do
+  uia = -> { uia_query(:view, {label: "Silly Buttons"}) }
+  # Note: :marked could also be used with device_agent.query
+  da = -> { device_agent.query({text: "Silly Buttons"}) }
+
+  elements = with_correct_automator(uia, da)
+
+  expect(elements.count).to be == 1
+  expect(elements[0]["label"]).to be == "Silly Buttons"
+end
+
+Then(/^I query for Same as views by mark using id$/) do
+  uia = -> { uia_query(:view, {marked: "same as"}) }
+  da = -> { device_agent.query({marked: "same as"}) }
+
+  elements = with_correct_automator(uia, da)
+
+  expect(elements.count).to be == 7
+end
+
+Then(/^I query for Same as views by mark using id and filter by TextField$/) do
+  uia = -> { uia_query(:textField, {marked: "same as"}) }
+  da = -> { device_agent.query({type: "TextField", marked: "same as"}) }
+
+  elements = with_correct_automator(uia, da)
+
+  expect(elements.count).to be == 2
+end
+
+Then(/^I query for Same as views by mark using id and filter by TextView$/) do
+  uia = -> { uia_query(:textView, {marked: "same as"}) }
+  da = -> { device_agent.query({type: "TextView", marked: "same as"}) }
+
+  elements = with_correct_automator(uia, da)
+
+  expect(elements.count).to be == 2
+end
+
+Then(/^I query for Same as views by mark using id and use an index to find the Button$/) do
+  uia = -> { uia_query(:button, {marked: "same as"}) }
+  da = -> { device_agent.query({type: "Button", marked: "same as"}) }
+  elements = with_correct_automator(uia, da)
+  expect(elements.count).to be == 1
+  button_result = elements[0]
+
+  uia = -> { uia_query(:view, {marked: "same as"}) }
+  da = -> { device_agent.query({marked: "same as", index: 5}) }
+  elements = with_correct_automator(uia, da)
+
+  if uia_available?
+    expect(elements.count).to be == 7
+    index_result = elements[5]
+  else
+    expect(elements.count).to be == 1
+    index_result = elements[0]
+  end
+
+  expect(button_result).to be == index_result
+end

--- a/calabash-cucumber/test/cucumber/features/steps/keyboard.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/keyboard.rb
@@ -315,7 +315,7 @@ When(/^UIA is not available, checking for keyboards with UIA raises an error$/) 
   if !uia_available?
     expect do
       uia_wait_for_keyboard
-    end.to raise_error RuntimeError, /This method requires UIAutomation/
+    end.to raise_error RuntimeError, /UIAutomation is not available in Xcode >= 8.0/
   end
 end
 

--- a/calabash-cucumber/test/cucumber/features/support/01_launch.rb
+++ b/calabash-cucumber/test/cucumber/features/support/01_launch.rb
@@ -147,7 +147,15 @@ After("@stop_after") do |_|
 end
 
 After do |scenario|
-  if scenario.failed?
-    exit!(1)
+
+  case :shutdown
+  when :shutdown
+    if scenario.failed?
+      calabash_exit
+    end
+  when :exit
+    if scenario.failed?
+      exit!(1)
+    end
   end
 end


### PR DESCRIPTION
### Motivation

This is a first pass at public API for DeviceAgent to replace the UIA interactions.

There are known issues:

* DeviceAgent query cannot find views on Today/Notification and Control Panel views #1149  @JoeSSS
* The alert and springboard alert API is EXPERIMENTAL and may change at any time.

The following methods will probably be removed because they are unnecessary - they perform the same operation as the`Core` methods.  They are included because it is not clear if the Core methods will work for every view that is presented outside your app's view hierarchy.

* keyboard_visible?
* enter_text
* enter_text_in

See the `test/cucumber/features/steps/automator.rb` for a side-by-side comparison of `uia` syntax and `device_agent` syntax.
