### PR TITLE
Map: dismiss SpringBoard alerts when DeviceAgent is available

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/map.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/map.rb
@@ -55,6 +55,12 @@ module Calabash
       #
       # @todo Calabash LPOperations should return 'views touched' in JSON format
       def self.map(query, method_name, *method_args)
+        require "calabash-cucumber/launcher"
+        launcher = Calabash::Cucumber::Launcher.launcher_if_used
+        if launcher && launcher.automator && launcher.automator.name == :device_agent
+          launcher.automator.client.send(:_dismiss_springboard_alerts)
+        end
+
         self.raw_map(query, method_name, *method_args)['results']
       end
 


### PR DESCRIPTION
### Motivation

* DeviceAgent needs to handle localized privacy alerts [JIRA](https://jira.xamarin.com/browse/TCFW-377)