### PR TITLE
Core: add #ios10?

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/device.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device.rb
@@ -239,6 +239,12 @@ module Calabash
         ios_version_object.major.to_s
       end
 
+      # Is this device running iOS 10?
+      # @return [Boolean] true if the major version of the OS is 10
+      def ios10?
+        ios_version_object.major == 10
+      end
+
       # Is this device running iOS 9?
       # @return [Boolean] true if the major version of the OS is 9
       def ios9?

--- a/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/environment_helpers.rb
@@ -192,6 +192,14 @@ module Calabash
        _default_device_or_create.ios9?
       end
 
+      # Is the device under test running iOS 10?
+      #
+      # @raise [RuntimeError] if the server cannot be reached
+      # @return [Boolean] true if device under test is running iOS 9
+      def ios10?
+       _default_device_or_create.ios10?
+      end
+
       # Is the app that is being tested an iPhone app emulated on an iPad?
       #
       # @see Calabash::Cucumber::IPad

--- a/calabash-cucumber/spec/lib/device_spec.rb
+++ b/calabash-cucumber/spec/lib/device_spec.rb
@@ -130,9 +130,17 @@ describe Calabash::Cucumber::Device do
   end
 
   describe 'iOS version' do
+    let(:ten) { RunLoop::Version.new("10.0") }
     let(:nine) { RunLoop::Version.new('9.0') }
     let(:eight) { RunLoop::Version.new('8.0') }
     let(:seven) { RunLoop::Version.new('7.0') }
+
+    it "#ios10?" do
+      expect(device).to receive(:ios_version_object).and_return(ten, nine)
+
+      expect(device.ios10?).to be_truthy
+      expect(device.ios10?).to be_falsey
+    end
 
     it '#ios9?' do
       expect(device).to receive(:ios_version_object).and_return(nine, eight)

--- a/calabash-cucumber/spec/lib/environment_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/environment_helpers_spec.rb
@@ -35,6 +35,13 @@ describe Calabash::Cucumber::EnvironmentHelpers do
     expect(world.ios9?).to be_falsey
   end
 
+  it '.ios9?' do
+    expect(device).to receive(:ios10?).and_return(true, false)
+
+    expect(world.ios10?).to be_truthy
+    expect(world.ios10?).to be_falsey
+  end
+
   describe 'form factor helpers' do
     it '.iphone_35in?' do
       expect(device).to receive(:iphone_35in?).and_return(true, false)


### PR DESCRIPTION
### Motivation

```
# iOS 10 iPads support UIViewController orientation changes by default.  This behavior is new in iOS 10.
if ipad? && ios10?
  expect(landscape?).to be_truthy
else
  expect(home_direction).to be == :down
end
```