### PR TITLE
Refactor DeviceAgent public API screenshot and fail

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device_agent.rb
@@ -312,20 +312,6 @@ module Calabash
       end
 
 =begin
-PROTECTED
-=end
-      protected
-
-      # @!visibility private
-      def method_missing(name, *args, &block)
-        if world.respond_to?(name)
-          world.send(name, *args, &block)
-        else
-          super
-        end
-      end
-
-=begin
 PRIVATE
 =end
       private

--- a/calabash-cucumber/lib/calabash-cucumber/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device_agent.rb
@@ -126,7 +126,7 @@ module Calabash
       #
       # @raise [RuntimeError] if no view matches the uiquery after waiting.
       def query_for_coordinate(uiquery)
-        fail_with_screenshot { client.query_for_coordinate(uiquery) }
+        with_screenshot_on_failure { client.query_for_coordinate(uiquery) }
       end
 
       # Perform a touch on the center of the first view matched the uiquery.
@@ -140,7 +140,7 @@ module Calabash
       #
       # @raise [RuntimeError] if no view matches the uiquery after waiting.
       def touch(uiquery)
-        fail_with_screenshot { client.touch(uiquery) }
+        with_screenshot_on_failure { client.touch(uiquery) }
       end
 
       # Perform a touch at a coordinate.
@@ -173,7 +173,7 @@ module Calabash
       #
       # @raise [RuntimeError] if no view matches the uiquery after waiting.
       def double_tap(uiquery)
-        fail_with_screenshot { client.double_tap(uiquery) }
+        with_screenshot_on_failure { client.double_tap(uiquery) }
       end
 
       # Perform a two finger tap on the center of the first view matched the uiquery.
@@ -187,7 +187,7 @@ module Calabash
       #
       # @raise [RuntimeError] if no view matches the uiquery after waiting.
       def two_finger_tap(uiquery)
-        fail_with_screenshot { client.two_finger_tap(uiquery) }
+        with_screenshot_on_failure { client.two_finger_tap(uiquery) }
       end
 
       # Perform a long press on the center of the first view matched the uiquery.
@@ -202,7 +202,7 @@ module Calabash
       #
       # @raise [RuntimeError] if no view matches the uiquery after waiting.
       def long_press(uiquery, duration)
-        fail_with_screenshot { client.long_press(uiquery, {:duration => duration}) }
+        with_screenshot_on_failure { client.long_press(uiquery, {:duration => duration}) }
       end
 
       # Returns true if there is a keyboard visible.
@@ -228,7 +228,7 @@ module Calabash
       # @raise [RuntimeError] if there is no visible keyboard.
       # @deprecated 0.21.0 Use Core#enter_text
       def enter_text(text)
-        fail_with_screenshot { client.enter_text(text) }
+        with_screenshot_on_failure { client.enter_text(text) }
       end
 
       # Enter text into the first view matched by uiquery.
@@ -244,7 +244,7 @@ module Calabash
       #
       # @deprecated 0.21.0 Use Core#enter_text
       def enter_text_in(uiquery, text)
-        fail_with_screenshot do
+        with_screenshot_on_failure do
           client.touch(uiquery)
           client.wait_for_keyboard
           client.enter_text(text)
@@ -320,7 +320,7 @@ PRIVATE
       attr_reader :client, :world
 
       # @!visibility private
-      def fail_with_screenshot(&block)
+      def with_screenshot_on_failure(&block)
         begin
           block.call
         rescue => e

--- a/calabash-cucumber/test/cucumber/features/device_agent_api.feature
+++ b/calabash-cucumber/test/cucumber/features/device_agent_api.feature
@@ -1,0 +1,17 @@
+@device_agent
+Feature: DeviceAgent API
+  In order to interact with views that are outside of my application
+  As a UI tester
+  I want a DeviceAgent API
+
+Background: Application is launched
+Given the app has launched
+
+Scenario: Screenshot on failure
+When device_agent.query_for_coordinate fails, it generates a screenshot
+When device_agent.touch fails, it generates a screenshot
+When device_agent.double_tap fails, it generates a screenshot
+When device_agent.two_finger_tap fails, it generates a screenshot
+When device_agent.long_press fails, it generates a screenshot
+When device_agent.enter_text fails, it generates a screenshot
+When device_agent.enter_text_in fails, it generates a screenshot

--- a/calabash-cucumber/test/cucumber/features/steps/device_agent_api.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/device_agent_api.rb
@@ -1,0 +1,85 @@
+
+module TestApp
+  module DeviceAgent
+
+    def screenshot_count
+      begin
+        Calabash::Cucumber::FailureHelpers.class_variable_get(:@@screenshot_count)
+      rescue NameError => _
+        0
+      end
+    end
+
+    def expect_device_agent_to_screenshot(method, uiquery=nil)
+      if !uia_available?
+        original_wait = RunLoop::DeviceAgent::Client::WAIT_DEFAULTS[:timeout]
+
+        hash = uiquery || {marked: "no matching mark"}
+        before = screenshot_count
+        raised_error = false
+
+        begin
+          RunLoop::DeviceAgent::Client::WAIT_DEFAULTS[:timeout] = 0.1
+
+          # BasicObject does not respond to #send
+          case method
+            when :query_for_coordinate
+              device_agent.query_for_coordinate(hash)
+            when :touch
+              device_agent.touch(hash)
+            when :double_tap
+              device_agent.double_tap(hash)
+            when :two_finger_tap
+              device_agent.two_finger_tap(hash)
+            when :long_press
+              device_agent.long_press(hash, 1.0)
+            when :enter_text
+              device_agent.enter_text("Some text")
+            when :enter_text_in
+              device_agent.enter_text_in(hash, "Some text")
+            else
+              raise ArgumentError, "Unrecognized method: #{method}"
+          end
+        rescue RuntimeError => _
+          raised_error = true
+        ensure
+          RunLoop::DeviceAgent::Client::WAIT_DEFAULTS[:timeout] = original_wait
+        end
+
+        after = screenshot_count
+        expect(raised_error).to be_truthy
+        expect(before + 1).to be == after
+      end
+    end
+  end
+end
+
+World(TestApp::DeviceAgent)
+
+When(/^device_agent\.query_for_coordinate fails, it generates a screenshot$/) do
+  expect_device_agent_to_screenshot(:query_for_coordinate)
+end
+
+When(/^device_agent\.touch fails, it generates a screenshot$/) do
+  expect_device_agent_to_screenshot(:touch)
+end
+
+When(/^device_agent\.double_tap fails, it generates a screenshot$/) do
+  expect_device_agent_to_screenshot(:double_tap)
+end
+
+When(/^device_agent\.two_finger_tap fails, it generates a screenshot$/) do
+  expect_device_agent_to_screenshot(:two_finger_tap)
+end
+
+When(/^device_agent\.long_press fails, it generates a screenshot$/) do
+  expect_device_agent_to_screenshot(:long_press)
+end
+
+When(/^device_agent\.enter_text fails, it generates a screenshot$/) do
+  expect_device_agent_to_screenshot(:enter_text)
+end
+
+When(/^device_agent\.enter_text_in fails, it generates a screenshot$/) do
+  expect_device_agent_to_screenshot(:enter_text_in)
+end


### PR DESCRIPTION
### Motivation

Resolves:

* DeviceAgent public API with_screenshot_on_failure or screenshot_on_failure #1161
* DeviceAgent public API should not call method missing. #1167

This is a breaking change.

This call:

```
device_agent.send(:client).send(:tree)
```

will no longer work because BasicObject does not respond to `send`.

I will add a DeviceAgent equivalent to `query("*")` in the next version of run-loop (which will be available to Calabash iOS 0.20.1).

ATTN @JoeSSS ^