### PR TITLE
Today/Notification and Control Panel tests

### DIFF
--- a/calabash-cucumber/test/cucumber/features/device_agent_api.feature
+++ b/calabash-cucumber/test/cucumber/features/device_agent_api.feature
@@ -15,3 +15,7 @@ When device_agent.two_finger_tap fails, it generates a screenshot
 When device_agent.long_press fails, it generates a screenshot
 When device_agent.enter_text fails, it generates a screenshot
 When device_agent.enter_text_in fails, it generates a screenshot
+
+Scenario: Check that Today/Notification and Control Panel elements are visible for DeviceAgent
+Then I can open Notifications tab in Today and Notifications page
+And I can see Control Panel page elements

--- a/calabash-cucumber/test/cucumber/features/steps/device_agent_api.rb
+++ b/calabash-cucumber/test/cucumber/features/steps/device_agent_api.rb
@@ -83,3 +83,92 @@ end
 When(/^device_agent\.enter_text_in fails, it generates a screenshot$/) do
   expect_device_agent_to_screenshot(:enter_text_in)
 end
+
+Then(/^I can open Notifications tab in Today and Notifications page$/) do
+  if ipad?
+    puts "Test is not stable on iPad; skipping"
+  end
+
+  element = wait_for_view("*")
+  x = element["rect"]["center_x"]
+  final_y = element["rect"]["center_y"] + (element["rect"]["height"]/2)
+  pan_coordinates({:x => x, :y => 0},
+                  {:x => x, :y => final_y},
+                  {duration: 0.5})
+
+  # Waiting for animations is not good enough - the animation is outside of
+  # the AUT's view hierarchy
+  wait_for_external_animations
+
+  # Screenshots will not show the Control Panel page.
+  if ios9?
+    if uia_available?
+      if uia_call_windows([:button, {marked: 'Notifications'}], :isVisible) != 1
+        fail("Expected to see 'Notifications' element.")
+      end
+
+      uia_tap :button, marked: 'Notifications'
+      wait_for_external_animations
+
+      if uia_call_windows([:element, {marked: 'No Notifications'}], :isVisible) != 1
+        fail("Expected to see 'No Notifications' element")
+      end
+    else
+      wait_for(options_or_timeout=3) do
+        !device_agent.query({marked: 'Notifications'}).empty?
+      end
+
+      device_agent.touch({:marked => 'Notifications'})
+
+      wait_for(options_or_timeout=3) do
+        !device_agent.query({marked: 'No Notifications'}).empty?
+      end
+    end
+  elsif ios10?
+    wait_for(options_or_timeout=3) do
+      !device_agent.query({marked: 'No Notifications'}).empty?
+    end
+  end
+end
+
+Then(/^I can see Control Panel page elements$/) do
+  if ipad?
+    puts "Test is not stable on iPad; skipping"
+  end
+
+  element = wait_for_view("*")
+  x = element["rect"]["center_x"]
+  start_y = element["rect"]["height"] - 10
+  final_y = element["rect"]["center_y"] + (element["rect"]["height"]/4)
+  pan_coordinates({:x => x, :y => start_y},
+                  {:x => x, :y => final_y},
+                  {duration: 0.5})
+
+  # Waiting for animations is not good enough - the animation is outside of
+  # the AUT's view hierarchy
+  wait_for_external_animations
+
+  # Screenshots will not show the Control Panel page.
+  if ios9?
+    if uia_available?
+      if uia_call_windows([:element, {marked: 'Wi-Fi'}], :isVisible) != 1
+        fail("Expected to see 'Wi-Fi' element.")
+      end
+    else
+      wait_for(options_or_timeout=3) do
+        !device_agent.query({marked: 'Wi-Fi'}).empty?
+      end
+    end
+  elsif ios10?
+    # We have to swipe from Welcome view after sim reset.
+    if !device_agent.query({marked: 'Continue'}).empty?
+      swipe :left, {force: :strong}
+      wait_for_external_animations
+      swipe :right, {force: :strong}
+      wait_for_external_animations
+    end
+    wait_for(options_or_timeout=3) do
+      !device_agent.query({marked: 'Wi-Fi'}).empty?
+    end
+  end
+end


### PR DESCRIPTION
DeviceAgent should see Today/Notification and Control Panel elements. It is possible to run it on iOS9/iOS10 simulators, using DeviceAgent and instruments