### PR TITLE
Update the Core#scroll methods

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -886,23 +886,27 @@ Unable to scroll to mark '#{mark}' in UIScrollView matching #{uiquery}"
         views_touched
       end
 
-      # Scroll a table view to a section and row. Table view can have multiple sections.
+      # Scroll a table view to a section and row.
+      #
+      # Make sure your query matches exactly one UITableView.  If multiple views
+      # are matched, the results can be unpredictable.
       #
       # @todo should expose a non-option first argument query and required parameters `section`, `row`
       #
       # @see #scroll_to_row
       # @example
-      #   scroll_to_cell query:"UITableView", row:4, section:0, animate: false
-      # @note this is implemented by calling the Obj-C `scrollToRowAtIndexPath:atScrollPosition:animated:` method
-      #   and can do things users cant.
+      #   scroll_to_cell  row:4, section:0, animate: false
       #
       # @param {Hash} options specifies details of the scroll
-      # @option options {String} :query ('tableView') query specifying which table view to scroll
+      # @option options {String} :query ("UITableView index:0") query specifying
+      #   which table view to scroll
       # @option options {Fixnum} :section section to scroll to
       # @option options {Fixnum} :row row to scroll to
       # @option options {String} :scroll_position position to scroll to
       # @option options {Boolean} :animated (true) animate or not
-      def scroll_to_cell(options={:query => 'tableView',
+      # @raise [ArgumentError] If row or section is nil
+      # @raise [ArgumentError] If the :query value is nil, "", or "*".
+      def scroll_to_cell(options={:query => "UITableView index:0",
                                   :row => 0,
                                   :section => 0,
                                   :scroll_position => :top,
@@ -910,8 +914,8 @@ Unable to scroll to mark '#{mark}' in UIScrollView matching #{uiquery}"
         uiquery = options[:query] || 'tableView'
         row = options[:row]
         sec = options[:section]
-        if row.nil? or sec.nil?
-          raise 'You must supply both :row and :section keys to scroll_to_cell'
+        if row.nil? || sec.nil?
+          raise ArgumentError, 'You must supply both :row and :section keys to scroll_to_cell'
         end
 
         args = []

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -869,16 +869,19 @@ Unable to scroll to mark '#{mark}' in UIScrollView matching #{uiquery}"
       end
 
       # Scroll a table view to a row. Table view should have only one section.
-      # @see #scroll_to_cell
-      # @example
-      #   scroll_to_row "UITableView", 2
-      # @note this is implemented by calling the Obj-C `scrollToRowAtIndexPath:atScrollPosition:animated:` method
-      #   and can do things users cant.
       #
-      # @param {String} uiquery query describing view scroll (should be  UIScrollView or a web view).
+      # Make sure your query matches exactly one UITableView.  If multiple views
+      # are matched, the results can be unpredictable.
+      #
+      # @see #scroll_to_cell
+      #
+      # @example
+      #   scroll_to_row "UITableView index:0", 2
+      #
+      # @param {String} uiquery Should match a UITableView
       def scroll_to_row(uiquery, number)
         views_touched = Map.map(uiquery, :scrollToRow, number)
-        msg = "unable to scroll: '#{uiquery}' to: #{number}"
+        msg = "Unable to scroll to row #{number} in table view with '#{uiquery}'"
         Map.assert_map_results(views_touched, msg)
         views_touched
       end

--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -802,6 +802,72 @@ Use `ipad?` to branch in your test.
         views_touched
       end
 
+      # Scrolls to a mark in a UIScrollView.
+      #
+      # Make sure your query matches exactly one UIScrollView.  If multiple
+      # scroll views are matched, the results can be unpredictable.
+      #
+      # @example
+      #  scroll_to_mark("settings")
+      #  scroll_to_mark("Android", {:animated => false})
+      #  scroll_to_mark("Alarm", {:query => "UIScrollView marked:'Settings'"})
+      #
+      # @see #scroll_to_row_with_mark
+      # @see #scroll_to_collection_view_item_with_mark
+      #
+      # @param [String] mark an accessibility label or identifier or text
+      # @param [Hash] options controls the query and and scroll behavior
+      # @option options [String] :query ("UIScrollView index:0") A query to
+      #  uniquely identify the scroll view if there are multiple scroll views.
+      # @option options [Boolean] :animate (true) should the scrolling be animated
+      # @option options [String] :failure_message (nil) If nil, a default failure
+      #  message will be shown if this scroll scroll cannot be performed.
+      #
+      # @raise [RuntimeError] If the scroll cannot be performed
+      # @raise [RuntimeError] If the :query finds no scroll view
+      # @raise [ArgumentError] If the mark is nil
+      # @raise [ArgumentError] If the :query value is nil, "", or "*".
+      def scroll_to_mark(mark, options={})
+        if mark.nil?
+          raise ArgumentError, "The mark cannot be nil"
+        end
+
+        merged_options = {:query => "UIScrollView index:0",
+                          :animate => true,
+                          :failure_message => nil}.merge(options)
+
+        uiquery = merged_options[:query]
+
+        if uiquery.nil?
+          raise ArgumentError, "The :query option cannot be nil"
+        end
+
+        if uiquery == ""
+          raise ArgumentError, "The :query option cannot be the empty string"
+        end
+
+        if uiquery == "*"
+          raise ArgumentError, "The :query option cannot be the wildcard '*'"
+        end
+
+        args = [merged_options[:animate]]
+
+        views_touched = Map.map(uiquery, :scrollToMark, mark, *args)
+
+        message = merged_options[:failure_message]
+
+        if !message
+          message = %Q[
+
+Unable to scroll to mark '#{mark}' in UIScrollView matching #{uiquery}"
+
+]
+        end
+
+        Map.assert_map_results(views_touched, message)
+        views_touched
+      end
+
       # Scroll a table view to a row. Table view should have only one section.
       # @see #scroll_to_cell
       # @example

--- a/calabash-cucumber/lib/calabash-cucumber/map.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/map.rb
@@ -145,7 +145,7 @@ details: #{hash["details"]}
       def self.assert_map_results(map_results, msg)
         compact = map_results.compact
         if compact.empty? or compact.member? '<VOID>' or compact.member? '*****'
-          Map.new.screenshot_and_raise msg
+          self.map_factory.screenshot_and_raise msg
         end
       end
 

--- a/calabash-cucumber/spec/lib/core_spec.rb
+++ b/calabash-cucumber/spec/lib/core_spec.rb
@@ -1222,5 +1222,104 @@ describe Calabash::Cucumber::Core do
       end.to raise_error RuntimeError, /Unable to scroll to item/
     end
   end
-end
 
+  context "#scroll_to_collection_view_item_with_mark" do
+    let(:options) do
+      {
+        :query => "query",
+        :scroll_position => :bottom,
+        :animate => :animate,
+        :failure_message => "custom failure message"
+      }
+    end
+
+    let(:success) { ["a non nil result"] }
+    let(:failure) { [ nil ] }
+    let(:map) { Calabash::Cucumber::Map.new }
+
+    before do
+      allow(Calabash::Cucumber::Map).to receive(:map_factory).and_return(map)
+      allow(map).to receive(:screenshot).and_return("path/to/screenshot")
+    end
+
+    it "raises an ArgumentError if mark is nil" do
+      expect do
+        world.scroll_to_collection_view_item_with_mark(nil)
+      end.to raise_error ArgumentError, /The mark cannot be nil/
+    end
+
+    context "validates the :query option" do
+      it "raises an ArgumentError if query is nil" do
+        expect do
+          world.scroll_to_collection_view_item_with_mark(:mark, {:query => nil})
+        end.to raise_error ArgumentError, /query option cannot be nil/
+      end
+
+      it "raises an ArgumentError if query is nil" do
+        expect do
+          world.scroll_to_collection_view_item_with_mark(:mark, {:query => ""})
+        end.to raise_error ArgumentError, /query option cannot be the empty string/
+      end
+
+      it "raises an ArgumentError if query is *" do
+        expect do
+          world.scroll_to_collection_view_item_with_mark(:mark, {:query => "*"})
+        end.to raise_error ArgumentError, /query option cannot be the wildcard/
+      end
+    end
+
+    context "validates the scroll position" do
+      it "raises an error if :scroll_position is invalid" do
+        options[:scroll_position] = :invalid
+
+        expect do
+          world.scroll_to_collection_view_item_with_mark(:mark, options)
+        end.to raise_error ArgumentError, /Invalid :scroll_position option/
+      end
+    end
+
+    context "merges options correctly and asserts results" do
+      it "calls map with the correct variables" do
+        expect(Calabash::Cucumber::Map).to(
+          receive(:map).with("query", :collectionViewScrollToItemWithMark,
+                             :mark, :bottom, :animate).and_return(success)
+        )
+
+        actual = world.scroll_to_collection_view_item_with_mark(:mark, options)
+        expect(actual).to be == success
+      end
+
+      it "fails with the right error message" do
+        expect(Calabash::Cucumber::Map).to(
+          receive(:map).with("query", :collectionViewScrollToItemWithMark,
+                             :mark, :bottom, :animate).and_return(failure)
+        )
+
+        expect do
+          world.scroll_to_collection_view_item_with_mark(:mark, options)
+        end.to raise_error RuntimeError, /#{options[:failure_message]}/
+      end
+    end
+
+    it "calls Map with the correct defaults" do
+      expect(Calabash::Cucumber::Map).to(
+        receive(:map).with("UICollectionView index:0", :collectionViewScrollToItemWithMark,
+                           :mark, :top, true).and_return(success)
+      )
+
+      actual = world.scroll_to_collection_view_item_with_mark(:mark)
+      expect(actual).to be == success
+    end
+
+    it "fails with a good default message" do
+      expect(Calabash::Cucumber::Map).to(
+        receive(:map).with("UICollectionView index:0", :collectionViewScrollToItemWithMark,
+                           :mark, :top, true).and_return(failure)
+      )
+
+      expect do
+        world.scroll_to_collection_view_item_with_mark(:mark)
+      end.to raise_error RuntimeError, /Unable to scroll to item/
+    end
+  end
+end

--- a/calabash-cucumber/spec/lib/core_spec.rb
+++ b/calabash-cucumber/spec/lib/core_spec.rb
@@ -1028,5 +1028,91 @@ describe Calabash::Cucumber::Core do
       end.to raise_error RuntimeError, /Unable to scroll to mark/
     end
   end
+
+  context "#scroll_to_row_with_mark" do
+    let(:options) do
+      {
+        :query => "query",
+        :scroll_position => :top,
+        :animate => :animate,
+        :failure_message => "custom failure message"
+      }
+    end
+
+    let(:success) { ["a non nil result"] }
+    let(:failure) { [ nil ] }
+    let(:map) { Calabash::Cucumber::Map.new }
+
+    before do
+      allow(Calabash::Cucumber::Map).to receive(:map_factory).and_return(map)
+      allow(map).to receive(:screenshot).and_return("path/to/screenshot")
+    end
+
+    it "raises an ArgumentError if mark is nil" do
+      expect do
+        world.scroll_to_row_with_mark(nil)
+      end.to raise_error ArgumentError, /The mark cannot be nil/
+    end
+
+    context "validates the :query option" do
+      it "raises an ArgumentError if query is nil" do
+        expect do
+          world.scroll_to_row_with_mark(:mark, {:query => nil})
+        end.to raise_error ArgumentError, /query option cannot be nil/
+      end
+
+      it "raises an ArgumentError if query is nil" do
+        expect do
+          world.scroll_to_row_with_mark(:mark, {:query => ""})
+        end.to raise_error ArgumentError, /query option cannot be the empty string/
+      end
+
+      it "raises an ArgumentError if query is *" do
+        expect do
+          world.scroll_to_row_with_mark(:mark, {:query => "*"})
+        end.to raise_error ArgumentError, /query option cannot be the wildcard/
+      end
+    end
+
+    context "merges options correctly and asserts results" do
+      it "calls map with the correct variables" do
+        expect(Calabash::Cucumber::Map).to(
+          receive(:map).with("query", :scrollToRowWithMark, :mark, :top, :animate).and_return(success)
+        )
+
+        actual = world.scroll_to_row_with_mark(:mark, options)
+        expect(actual).to be == success
+      end
+
+      it "fails with the right error message" do
+        expect(Calabash::Cucumber::Map).to(
+          receive(:map).with("query", :scrollToRowWithMark, :mark, :top, :animate).and_return(failure)
+        )
+
+        expect do
+          world.scroll_to_row_with_mark(:mark, options)
+        end.to raise_error RuntimeError, /#{options[:failure_message]}/
+      end
+    end
+
+    it "calls Map with the correct defaults" do
+      expect(Calabash::Cucumber::Map).to(
+        receive(:map).with("UITableView index:0", :scrollToRowWithMark, :mark, :middle, true).and_return(success)
+      )
+
+      actual = world.scroll_to_row_with_mark(:mark)
+      expect(actual).to be == success
+    end
+
+    it "fails with a good default message" do
+      expect(Calabash::Cucumber::Map).to(
+        receive(:map).with("UITableView index:0", :scrollToRowWithMark, :mark, :middle, true).and_return(failure)
+      )
+
+      expect do
+        world.scroll_to_row_with_mark(:mark)
+      end.to raise_error RuntimeError, /Unable to scroll to mark/
+    end
+  end
 end
 

--- a/calabash-cucumber/spec/lib/core_spec.rb
+++ b/calabash-cucumber/spec/lib/core_spec.rb
@@ -1114,5 +1114,113 @@ describe Calabash::Cucumber::Core do
       end.to raise_error RuntimeError, /Unable to scroll to mark/
     end
   end
+
+  context "#scroll_to_collection_view_item" do
+    let(:options) do
+      {
+        :query => "query",
+        :scroll_position => :bottom,
+        :animate => :animate,
+        :failure_message => "custom failure message"
+      }
+    end
+
+    let(:success) { ["a non nil result"] }
+    let(:failure) { [ nil ] }
+    let(:map) { Calabash::Cucumber::Map.new }
+
+    before do
+      allow(Calabash::Cucumber::Map).to receive(:map_factory).and_return(map)
+      allow(map).to receive(:screenshot).and_return("path/to/screenshot")
+    end
+
+    context "validates the :query option" do
+      it "raises an ArgumentError if query is nil" do
+        expect do
+          world.scroll_to_collection_view_item(1, 1, {:query => nil})
+        end.to raise_error ArgumentError, /query option cannot be nil/
+      end
+
+      it "raises an ArgumentError if query is nil" do
+        expect do
+          world.scroll_to_collection_view_item(1, 1, {:query => ""})
+        end.to raise_error ArgumentError, /query option cannot be the empty string/
+      end
+
+      it "raises an ArgumentError if query is *" do
+        expect do
+          world.scroll_to_collection_view_item(1, 1, {:query => "*"})
+        end.to raise_error ArgumentError, /query option cannot be the wildcard/
+      end
+    end
+
+    context "validates item and section index arguments" do
+      it "raises an ArgumentError if item index < 0" do
+        expect do
+          world.scroll_to_collection_view_item(-1, 0)
+        end.to raise_error ArgumentError, /Invalid item index/
+      end
+
+      it "raises an ArgumentError if section index < 0" do
+        expect do
+          world.scroll_to_collection_view_item(0, -1)
+        end.to raise_error ArgumentError, /Invalid section index/
+      end
+    end
+
+    context "validates the scroll position" do
+      it "raises an error if :scroll_position is invalid" do
+        options[:scroll_position] = :invalid
+
+        expect do
+          world.scroll_to_collection_view_item(0, 1, options)
+        end.to raise_error ArgumentError, /Invalid :scroll_position option/
+      end
+    end
+
+    context "merges options correctly and asserts results" do
+      it "calls map with the correct variables" do
+        expect(Calabash::Cucumber::Map).to(
+          receive(:map).with("query", :collectionViewScroll,
+                             0, 1, :bottom, :animate).and_return(success)
+        )
+
+        actual = world.scroll_to_collection_view_item(0, 1, options)
+        expect(actual).to be == success
+      end
+
+      it "fails with the right error message" do
+        expect(Calabash::Cucumber::Map).to(
+          receive(:map).with("query", :collectionViewScroll,
+                             0, 1, :bottom, :animate).and_return(failure)
+        )
+
+        expect do
+          world.scroll_to_collection_view_item(0, 1, options)
+        end.to raise_error RuntimeError, /#{options[:failure_message]}/
+      end
+    end
+
+    it "calls Map with the correct defaults" do
+      expect(Calabash::Cucumber::Map).to(
+        receive(:map).with("UICollectionView index:0", :collectionViewScroll,
+                           0, 1, :top, true).and_return(success)
+      )
+
+      actual = world.scroll_to_collection_view_item(0, 1)
+      expect(actual).to be == success
+    end
+
+    it "fails with a good default message" do
+      expect(Calabash::Cucumber::Map).to(
+        receive(:map).with("UICollectionView index:0", :collectionViewScroll,
+                           0, 1, :top, true).and_return(failure)
+      )
+
+      expect do
+        world.scroll_to_collection_view_item(0, 1)
+      end.to raise_error RuntimeError, /Unable to scroll to item/
+    end
+  end
 end
 


### PR DESCRIPTION
### Motivation

The previous implementation of the `#scroll_to*` methods would, but default, try to scroll on every matching UIScrollView subclass.  This behavior was unpredictable and expensive (time).

The default to behavior is to scroll the _first_ matching scroll view.  This behavior is in line with the original documentation.  The documentation has been updated to stress that matching multiple scroll views will have unpredictable behavior.

This changeset also includes an interface to the new `scrollToMark` operation.

```
      # Scrolls to a mark in a UIScrollView.
      #
      # Make sure your query matches exactly one UIScrollView.  If multiple
      # scroll views are matched, the results can be unpredictable.
      #
      # @example
      #  scroll_to_mark("settings")
      #  scroll_to_mark("Android", {:animated => false})
      #  scroll_to_mark("Alarm", {:query => "UIScrollView marked:'Settings'"})
```

### Other changes

* improved client side argument checking
* specs for most of the scroll_to* API

[JIRA](https://jira.xamarin.com/browse/TCFW-664)