### PR TITLE
Removes keyboard check on enter text

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device_agent.rb
@@ -228,7 +228,7 @@ module Calabash
       # @raise [RuntimeError] if there is no visible keyboard.
       # @deprecated 0.21.0 Use Core#enter_text
       def enter_text(text)
-        with_screenshot_on_failure { client.enter_text(text) }
+        with_screenshot_on_failure { client.enter_text_without_keyboard_check(text) }
       end
 
       # Enter text into the first view matched by uiquery.
@@ -246,8 +246,7 @@ module Calabash
       def enter_text_in(uiquery, text)
         with_screenshot_on_failure do
           client.touch(uiquery)
-          client.wait_for_keyboard
-          client.enter_text(text)
+          client.enter_text_without_keyboard_check(text)
         end
       end
 


### PR DESCRIPTION
I was able to successfully use `enter_text` on more fields - should I be removing the keyboard check also at `keyboard_enter_text`?