### PR TITLE
DeviceAgent: automator skips keyboard visible checks

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/automator/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/automator/device_agent.rb
@@ -255,12 +255,12 @@ args[0] = #{args[0]}])
 
         # @!visibility private
         def enter_text_with_keyboard(string, options={})
-          client.enter_text(string)
+          client.enter_text_without_keyboard_check(string)
         end
 
         # @!visibility private
         def enter_char_with_keyboard(char)
-          client.enter_text(char)
+          client.enter_text_without_keyboard_check(char)
         end
 
         # @!visibility private
@@ -284,7 +284,7 @@ args[0] = #{args[0]}])
           end
 
           code = char_for_keyboard_action("Return")
-          client.enter_text(code)
+          client.enter_text_without_keyboard_check(code)
         end
 
         # @!visibility private
@@ -294,7 +294,7 @@ args[0] = #{args[0]}])
 
         # @!visibility private
         def fast_enter_text(text)
-          client.enter_text(text)
+          client.enter_text_without_keyboard_check(text)
         end
 
         # @!visibility private

--- a/calabash-cucumber/spec/lib/automator/device_agent_spec.rb
+++ b/calabash-cucumber/spec/lib/automator/device_agent_spec.rb
@@ -9,6 +9,7 @@ describe Calabash::Cucumber::Automator::DeviceAgent do
       def rotate_home_button_to(_); ; end
       def perform_coordinate_gesture(_, _, _, _={}); ; end
       def pan_between_coordinates(_, _, _={}); ; end
+      def enter_text_without_keyboard_check(_); ; end
     end.new
   end
 
@@ -489,7 +490,9 @@ describe Calabash::Cucumber::Automator::DeviceAgent do
     context "Text Entry" do
       context "#enter_text_with_keyboard" do
         it "types a string by calling out to enter_text" do
-          expect(device_agent.client).to receive(:enter_text).with("text").and_return({})
+          expect(device_agent.client).to(
+            receive(:enter_text_without_keyboard_check).with("text").and_return({})
+          )
 
           expect(device_agent.enter_text_with_keyboard("text")).to be == {}
         end
@@ -497,7 +500,9 @@ describe Calabash::Cucumber::Automator::DeviceAgent do
 
       context "#enter_char_with_keyboard" do
         it "types a char by calling out to enter_text" do
-          expect(device_agent.client).to receive(:enter_text).with("c").and_return({})
+          expect(device_agent.client).to(
+            receive(:enter_text_without_keyboard_check).with("c").and_return({})
+          )
 
           expect(device_agent.enter_text_with_keyboard("c")).to be == {}
         end
@@ -534,7 +539,9 @@ describe Calabash::Cucumber::Automator::DeviceAgent do
             receive(:mark_for_return_key_of_first_responder)
           ).and_return(nil)
           expect(device_agent).to receive(:char_for_keyboard_action).and_return("\n")
-          expect(device_agent.client).to receive(:enter_text).with("\n").and_return({})
+          expect(device_agent.client).to(
+            receive(:enter_text_without_keyboard_check).with("\n").and_return({})
+          )
 
           expect(device_agent.tap_keyboard_action_key).to be == {}
         end
@@ -550,7 +557,9 @@ describe Calabash::Cucumber::Automator::DeviceAgent do
           )
 
           expect(device_agent).to receive(:char_for_keyboard_action).and_return("\n")
-          expect(device_agent.client).to receive(:enter_text).with("\n").and_return({})
+          expect(device_agent.client).to(
+            receive(:enter_text_without_keyboard_check).with("\n").and_return({})
+          )
 
           expect(device_agent.tap_keyboard_action_key).to be == {}
         end
@@ -566,7 +575,9 @@ describe Calabash::Cucumber::Automator::DeviceAgent do
 
       context "#fast_enter_text" do
         it "calls 'enter_text'" do
-          expect(device_agent.client).to receive(:enter_text).with("text").and_return({})
+          expect(device_agent.client).to(
+            receive(:enter_text_without_keyboard_check).with("text").and_return({})
+          )
 
           expect(device_agent.fast_enter_text("text")).to be == {}
         end


### PR DESCRIPTION
### Motivation

Progress on:

* Can't type in one of the field of our APP #1155
* keyboard_enter_text times out typing long text #1158

Related to:

* DeviceAgent::Client: enter text without keyboard check [#548](https://github.com/calabash/run_loop/pull/548)

### Testing requires a run-loop release

Expect failures in CI until run-loop >= 2.2.2