### PR TITLE
Keyboard: text from first responders should check out views

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -173,14 +173,19 @@ module Calabash
           screenshot_and_raise "There must be a visible keyboard"
         end
 
-        ['textField', 'textView'].each do |ui_class|
-          query = "#{ui_class} isFirstResponder:1"
-          result = _query_wrapper(query, :text)
-          if !result.empty?
-            return result.first
-          end
-        end
-        ""
+        query = "* isFirstResponder:1"
+        elements = _query_wrapper(query, :text)
+
+        return "" if elements.count == 0
+
+        text = elements[0]
+
+        # first responder did not respond to :text selector
+        return "" if text == "*****"
+
+        return "" if text.nil?
+
+        text
       end
 
       # @visibility private

--- a/calabash-cucumber/spec/lib/keyboard_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/keyboard_helpers_spec.rb
@@ -288,13 +288,13 @@ describe Calabash::Cucumber::KeyboardHelpers do
     end
 
     context "visible keyboard" do
+      let(:query) { "* isFirstResponder:1" }
 
       before do
         expect(world).to receive(:keyboard_visible?).and_return(true)
       end
 
-      it "returns the text of a text field when it is the first responder" do
-        query = "textField isFirstResponder:1"
+      it "returns the text of the first responder" do
         expect(world).to(
           receive(:_query_wrapper).with(query, :text)
         ).and_return(["text field text"])
@@ -303,28 +303,25 @@ describe Calabash::Cucumber::KeyboardHelpers do
         expect(actual).to be == "text field text"
       end
 
-      it "returns the test of text view when it is the first responder" do
-        query = "textField isFirstResponder:1"
+      it "returns the empty string when the query has no results" do
         expect(world).to(
           receive(:_query_wrapper).with(query, :text)
         ).and_return([])
-
-        query = "textView isFirstResponder:1"
-        expect(world).to(
-          receive(:_query_wrapper).with(query, :text)
-        ).and_return(["text view text"])
 
         actual = world.text_from_first_responder
-        expect(actual).to be == "text view text"
+        expect(actual).to be == ""
       end
 
-      it "returns an empty string when no first responder can be found" do
-        query = "textField isFirstResponder:1"
+      it "returns an empty string when the first responder does not respond to :text" do
         expect(world).to(
           receive(:_query_wrapper).with(query, :text)
-        ).and_return([])
+        ).and_return(["*****"])
 
-        query = "textView isFirstResponder:1"
+        actual = world.text_from_first_responder
+        expect(actual).to be == ""
+      end
+
+      it "returns the empty string when the first responder text is nil" do
         expect(world).to(
           receive(:_query_wrapper).with(query, :text)
         ).and_return([])


### PR DESCRIPTION
### Motivation

Resolves:

* text_from_first_responder needs to handle other TextInput fields [JIRA](https://jira.xamarin.com/browse/TCFW-673)

### Test

Tested against the feature/update-to-0.20.3 CalSmokeApp branch.

```
 Scenario: Interacting with non-UITextInput responders 
    Then I touch the CalTextField                                  
    And I ask for the first responder text                       
    And I can append the text of the CalTextField                
    And I dismiss the keyboard that is attached to the CalTextField
```

[Test Cloud Run](https://testcloud.xamarin.com/test/calsmoke-cal_424ccfcd-10ee-4c62-bf27-ec0c0e8a143f/)