### PR TITLE
Automator::DeviceAgent: search for any first responder for return key type

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/automator/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/automator/device_agent.rb
@@ -453,17 +453,25 @@ Make sure your query returns at least one view.
         # @!visibility private
         def return_key_type_of_first_responder
 
-          ['textField', 'textView'].each do |ui_class|
-            query = "#{ui_class} isFirstResponder:1"
-            raw = Calabash::Cucumber::Map.raw_map(query, :query, :returnKeyType)
-            results = raw["results"]
-            if !results.empty?
-              return results.first
-            end
+          query = "* isFirstResponder:1"
+          raw = Calabash::Cucumber::Map.raw_map(query, :query, :returnKeyType)
+          elements = raw["results"]
+          return nil if elements.count == 0
+
+          return_key_type = elements[0]
+
+          # first responder did not respond to :text selector
+          if return_key_type == "*****"
+            RunLoop.log_debug("First responder does not respond to :returnKeyType")
+            return nil
           end
 
-          RunLoop.log_debug("Cannot find keyboard first responder to ask for its returnKeyType")
-          nil
+          if return_key_type.nil?
+            RunLoop.log_debug("First responder has nil :returnKeyType")
+            return nil
+          end
+
+          return_key_type
         end
 
         # @!visibility private

--- a/calabash-cucumber/spec/lib/automator/device_agent_spec.rb
+++ b/calabash-cucumber/spec/lib/automator/device_agent_spec.rb
@@ -622,8 +622,9 @@ describe Calabash::Cucumber::Automator::DeviceAgent do
       end
 
       context "#return_key_type_of_first_responder" do
-        it "returns the returnKeyType of text field when it is the first responder" do
-          query = "textField isFirstResponder:1"
+        let(:query) { "* isFirstResponder:1" }
+
+        it "returns the returnKeyType of the first responder" do
           expect(Calabash::Cucumber::Map).to(
             receive(:raw_map).with(query, :query, :returnKeyType)
           ).and_return({"results" => [1]})
@@ -632,31 +633,28 @@ describe Calabash::Cucumber::Automator::DeviceAgent do
           expect(actual).to be == 1
         end
 
-        it "returns the returnKeyType of text view when it is the first responder" do
-          query = "textField isFirstResponder:1"
+        it "returns nil if returnKeyType result is empty" do
           expect(Calabash::Cucumber::Map).to(
             receive(:raw_map).with(query, :query, :returnKeyType)
           ).and_return({"results" => []})
-
-          query = "textView isFirstResponder:1"
-          expect(Calabash::Cucumber::Map).to(
-            receive(:raw_map).with(query, :query, :returnKeyType)
-          ).and_return({"results" => [2]})
 
           actual = device_agent.send(:return_key_type_of_first_responder)
-          expect(actual).to be == 2
+          expect(actual).to be == nil
         end
 
-        it "returns nil when no first responder can be found" do
-          query = "textField isFirstResponder:1"
+        it "returns nil if first responder does not respond to :returnKeyType" do
           expect(Calabash::Cucumber::Map).to(
             receive(:raw_map).with(query, :query, :returnKeyType)
-          ).and_return({"results" => []})
+          ).and_return({"results" => ["*****"]})
 
-          query = "textView isFirstResponder:1"
+          actual = device_agent.send(:return_key_type_of_first_responder)
+          expect(actual).to be == nil
+        end
+
+        it "returns nil if first responder :returnKeyType is nil" do
           expect(Calabash::Cucumber::Map).to(
             receive(:raw_map).with(query, :query, :returnKeyType)
-          ).and_return({"results" => []})
+          ).and_return({"results" => [nil]})
 
           actual = device_agent.send(:return_key_type_of_first_responder)
           expect(actual).to be == nil


### PR DESCRIPTION
### Motivation

Related to:

* Xcode 8: tap_keyboard_action_key on the keyboard doesn't work in all cases e.g. Search button #1198 

Fixes the case where the first responder is not a UITextField or UITextView.

### Limitations

If the first responder (the view keyboard focus) does not respond to `:returnKeyType` this method will fail. 