### PR TITLE
Numeric keyboard

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -204,21 +204,21 @@ module Calabash
       # UIKeyboardTypeWebSearch => :web_search
       #
       # @raise [RuntimeError] if there is no visible keyboard
-      def keyboard_type(query)
+      def keyboard_type(query = "* isFirstResponder:1")
         if !keyboard_visible?
           screenshot_and_raise "There must be a visible keyboard"
         end
 
-        if query.nil? || query.empty?
-          # Default to first responder
-          query = "* isFirstResponder:1"
+        query_result = _query_wrapper(query, :keyboardType).first
+        keyboard_type = KEYBOARD_TYPES[query_result]
+
+        if !keyboard_type 
+          RunLoop.log_debug("Found query_result:#{query_result}, but expected
+                            to match key in #{KEYBOARD_TYPES}")
+          keyboard_type = :unknown
         end
-        keyboard_type = _query_wrapper(query, :keyboardType).first
-        if keyboard_type.is_a?(Fixnum)
-          return KEYBOARD_TYPES[keyboard_type]
-        else
-          screenshot_and_raise "Invalid keyboard type"
-        end
+
+        keyboard_type
       end
 
       # @visibility private

--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -189,7 +189,7 @@ module Calabash
       end
 
       # @!visibility private
-      # Returns the keyboard type as a symbol
+      # Returns the keyboard type as a symbol from the specified query
       #
       # UIKeyboardTypeDefault => :default
       # UIKeyboardTypeASCIICapable => :ascii_capable
@@ -204,12 +204,12 @@ module Calabash
       # UIKeyboardTypeWebSearch => :web_search
       #
       # @raise [RuntimeError] if there is no visible keyboard
-      def keyboard_type
+      def keyboard_type(query = {})
         if !keyboard_visible?
           screenshot_and_raise "There must be a visible keyboard"
         end
 
-        keyboard_type = _query_for_keyboard
+        keyboard_type = _query_wrapper(query, :keyboardType).first
         if keyboard_type.is_a?(Fixnum)
           return KEYBOARD_TYPES[keyboard_type]
         else

--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -188,11 +188,56 @@ module Calabash
         text
       end
 
+      # @!visibility private
+      # Returns the keyboard type as a symbol
+      #
+      # UIKeyboardTypeDefault => :default
+      # UIKeyboardTypeASCIICapable => :ascii_capable
+      # UIKeyboardTypeNumbersAndPunctuation => :numbers_and_punctuation
+      # UIKeyboardTypeURL => :url
+      # UIKeyboardTypeNumberPad => :number_pad
+      # UIKeyboardTypePhonePad => :phone_pad
+      # UIKeyboardTypeNamePhonePad => :name_phone_pad
+      # UIKeyboardTypeEmailAddress => :email
+      # UIKeyboardTypeDecimalPad => :decimal
+      # UIKeyboardTypeTwitter => :twitter
+      # UIKeyboardTypeWebSearch => :web_search
+      #
+      # @raise [RuntimeError] if there is no visible keyboard
+      def keyboard_type
+        if !keyboard_visible?
+          screenshot_and_raise "There must be a visible keyboard"
+        end
+
+        keyboard_type = _query_for_keyboard
+        if keyboard_type.is_a?(Fixnum)
+          return KEYBOARD_TYPES[keyboard_type]
+        else
+          screenshot_and_raise "Invalid keyboard type"
+        end
+      end
+
       # @visibility private
       # TODO Remove in 0.21.0
       alias_method :_text_from_first_responder, :text_from_first_responder
 
       private
+
+      # @!visbility private
+      KEYBOARD_TYPES = {
+          0 => :default,
+          1 => :ascii_capable,
+          2 => :numbers_and_punctuation,
+          3 => :url,
+          4 => :number_pad,
+          5 => :phone_pad,
+          6 => :name_phone_pad,
+          7 => :email,
+          8 => :decimal,
+          9 => :twitter,
+          10 => :web_search
+        }
+
 
       # @!visibility private
       KEYBOARD_QUERY = "view:'UIKBKeyplaneView'"

--- a/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/keyboard_helpers.rb
@@ -204,11 +204,15 @@ module Calabash
       # UIKeyboardTypeWebSearch => :web_search
       #
       # @raise [RuntimeError] if there is no visible keyboard
-      def keyboard_type(query = {})
+      def keyboard_type(query)
         if !keyboard_visible?
           screenshot_and_raise "There must be a visible keyboard"
         end
 
+        if query.nil? || query.empty?
+          # Default to first responder
+          query = "* isFirstResponder:1"
+        end
         keyboard_type = _query_wrapper(query, :keyboardType).first
         if keyboard_type.is_a?(Fixnum)
           return KEYBOARD_TYPES[keyboard_type]


### PR DESCRIPTION
**Motivation**
Add ability to query keyboard type from a query or first responder. 

i.e. keyboard_type("UITextField") => :email
