### PR TITLE
DeviceAgent:API: #to_s and #inspect

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device_agent.rb
@@ -24,6 +24,28 @@ module Calabash
         @world = world
       end
 
+      # @!visibility private
+      def to_s
+        if client.running?
+          version = client.server_version["bundle_short_version"]
+        else
+          version = "not connected!"
+        end
+        "#<DeviceAgent API: #{version}>"
+      end
+
+      # @!visibility private
+      def inspect
+        to_s
+      end
+
+      # @!visibility private
+      # https://github.com/awesome-print/awesome_print/pull/253
+      # Awesome print patch for BasicObject
+      def ai(_)
+        to_s
+      end
+
       # Query the UI for elements.
       #
       # @example


### PR DESCRIPTION
Also adds a patch for awesome print bug related to BasicObject

* https://github.com/awesome-print/awesome_print/pull/253
* https://github.com/calabash/calabash-ios/issues/1208

Requires run-loop patch:

https://github.com/calabash/run_loop/pull/559

Available in run_loop 2.2.3