### PR TITLE
HTTP: dismiss SpringBoard alerts before and after http calls

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/http_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/http_helpers.rb
@@ -19,6 +19,8 @@ module Calabash
 
       # @!visibility private
       def http(options, data=nil)
+        _private_dismiss_springboard_alerts
+
         options[:uri] = url_for(options[:path])
         options[:method] = options[:method] || :get
         if data
@@ -30,6 +32,9 @@ module Calabash
         end
         res = make_http_request(options)
         res.force_encoding("UTF-8") if res.respond_to?(:force_encoding)
+
+        _private_dismiss_springboard_alerts
+
         res
       end
 
@@ -101,6 +106,18 @@ module Calabash
         http
       end
 
+      private
+
+      # @!visibility private
+      #
+      # Do not call this method.
+      def _private_dismiss_springboard_alerts
+        require "calabash-cucumber/launcher"
+        launcher = Calabash::Cucumber::Launcher.launcher_if_used
+        if launcher && launcher.automator && launcher.automator.name == :device_agent
+          launcher.automator.client.send(:_dismiss_springboard_alerts)
+        end
+      end
     end
   end
 end

--- a/calabash-cucumber/lib/calabash-cucumber/map.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/map.rb
@@ -55,12 +55,6 @@ module Calabash
       #
       # @todo Calabash LPOperations should return 'views touched' in JSON format
       def self.map(query, method_name, *method_args)
-        require "calabash-cucumber/launcher"
-        launcher = Calabash::Cucumber::Launcher.launcher_if_used
-        if launcher && launcher.automator && launcher.automator.name == :device_agent
-          launcher.automator.client.send(:_dismiss_springboard_alerts)
-        end
-
         self.raw_map(query, method_name, *method_args)['results']
       end
 


### PR DESCRIPTION
### Motivation

With UIAutomation, the alerts were dismissed asynchronously. UIAutomation had a method `onAlert` that was called whenever an alert was detected. We implemented `onAlert` to detect privacy alerts and dismiss them automatically.

DeviceAgent is based on XCUITest. XCUITest also has an equivalent method to `onAlert`. Sadly it does not work reliably so we cannot use it. There are several Apple Developer Forum posts and radars about problems with the XCUITest alert handling.

To dismiss alerts with DeviceAgent, the clients (Calabash or UITest) need to explicitly tell DeviceAgent to detect and dismiss alerts.  Every call to query, touch, etc. triggers an HTTP call to DeviceAgent detect and dismiss alerts.

This strategy breaks down if a test causes and alert to be triggered and then the test stops - no other query or gesture is performed. The alert will remain because nothing has asked the DeviceAgent to detect and dismiss the alert.  Further, once a privacy alert is showing, the DeviceAgent cannot launch your application again.

We've decided be more aggressive about detecting and dismissing SpringBoard alerts.

Calabash will ask DeviceAgent to detect and dismiss SpringBoard alerts before and after http calls to the LPServer.  This comes at the cost of speed.  We are investigating how we can optimize the SpringBoard alert detection.
