### PR TITLE
Fix typo in contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ on how to make a good commit message.
 Xamarin has a two additional support channels for you.  If your question or bug report is UITest or Test Cloud related, your best chance of quick, accurate response will be on one of these channels.
 
 1. [Post your question on the Xamarin Forums](http://forums.xamarin.com/categories/xamarin-test-cloud).
-2. [mailto:support@example.org](Send and email to support@xamarin.com)
+2. [Send and email to support@xamarin.com](mailto:support@xamarin.com)
 
 ### CI Environments (Travis, Jenkins, Bamboo, Team City)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ on how to make a good commit message.
 Xamarin has a two additional support channels for you.  If your question or bug report is UITest or Test Cloud related, your best chance of quick, accurate response will be on one of these channels.
 
 1. [Post your question on the Xamarin Forums](http://forums.xamarin.com/categories/xamarin-test-cloud).
-2. [Send and email to support@xamarin.com](mailto:support@xamarin.com)
+2. [Send an email to support@xamarin.com](mailto:support@xamarin.com)
 
 ### CI Environments (Travis, Jenkins, Bamboo, Team City)
 


### PR DESCRIPTION
Fixes:
- Incorrectly formatted link for sending email to xamarin support in contributing doc
- Typo in link text for the above link

Please squash merge, I accidentally forgot to fix both of the issues in a single commit.