### PR TITLE
Gem: never require 'rubygems'

### DIFF
--- a/calabash-cucumber/bin/calabash-ios
+++ b/calabash-cucumber/bin/calabash-ios
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'rubygems'
 require 'fileutils'
 require 'cfpropertylist'
 require 'rexml/document'

--- a/calabash-cucumber/bin/frank-calabash
+++ b/calabash-cucumber/bin/frank-calabash
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'rubygems'
 require 'fileutils'
 
 def print_usage


### PR DESCRIPTION
### Motivation

Progress on:

* Cannot install calabash sandbox on macOS: cannot load such file -- rubygems.rb [#65
](https://github.com/calabash/install/issues/65)

