### PR TITLE
Fix logic error in warning emitted by Launcher#calabash_no_launch? 

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -492,7 +492,7 @@ RunLoop.run returned:
         RunLoop.log_warn(%Q[
 Calabash::Cucumber::Launcher #calabash_no_launch? and support for the NO_LAUNCH
 environment variable has been removed from Calabash.  This always returns
-true.  Please remove this method call from your hooks.
+false.  Please remove this method call from your hooks.
 ])
         false
       end


### PR DESCRIPTION
Method Calabash::Cucumber::Launcher #calabash_no_launch? always returns false - not true. Fix typo in method description.