### PR TITLE
IRB: rescue LoadError on require 'irb/*'

### DIFF
--- a/calabash-cucumber/scripts/.irbrc
+++ b/calabash-cucumber/scripts/.irbrc
@@ -1,6 +1,17 @@
-require "irb/completion"
-require "irb/ext/save-history"
-require "benchmark"
+begin
+  require "irb/completion"
+  require "irb/ext/save-history"
+rescue LoadError => e
+  puts %Q[
+Caught a LoadError while requiring an irb module.
+
+#{e}
+
+An error like this usually means your ruby installation is corrupt.
+
+]
+  exit(1)
+end
 
 begin
   require "awesome_print"
@@ -24,6 +35,8 @@ $ gem install calabash-cucumber
 ]
   exit(1)
 end
+
+require "benchmark"
 
 AwesomePrint.irb!
 


### PR DESCRIPTION
### Motivation

Progress on:

* Unable to run queries in console since upgrade: NoMethodError #1262

This does not correct the "corrupt ruby install" problem, but it gives the user more information about the problem.

Completes:

* .irbrc should raise load errors to detect invalid/incomplete ruby installs [3463](https://msmobilecenter.visualstudio.com/Test/_workitems/edit/3463)


