### PR TITLE
Remove usage tracking to comply with EU GDPR 2018

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/launcher.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/launcher.rb
@@ -389,7 +389,13 @@ RunLoop.run returned:
           check_server_gem_compatibility
         end
 
-        usage_tracker.post_usage_async
+        # What was Calabash tracking? Read this post for information
+        # No private data (like ip addresses) were collected
+        # https://github.com/calabash/calabash-android/issues/655
+        #
+        # Removing usage tracking to avoid problems with EU General Data
+        # Protection Regulation which takes effect in 2018.
+        # usage_tracker.post_usage_async
 
         # :on_launch to the Cucumber World if:
         # * the Launcher is part of the World (it is not by default).


### PR DESCRIPTION
### Motivation

Read more about the EU GDPR here:

* http://www.europarl.europa.eu/pdfs/news/expert/background/20160413BKG22980/20160413BKG22980_en.pdf

Completes:

* Remove usage tracking from Calabash Calabash [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/12758)

Notes:

The MixPanel account that we used to track usage has been disabled for over a year.  