### PR TITLE
Coordinates: full-screen pans start and end closer to screen edge

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/automator/coordinates.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/automator/coordinates.rb
@@ -388,12 +388,12 @@ module Calabash
 
         # @!visibility private
         def min_x
-          10
+          2
         end
 
         # @!visibility private
         def max_x
-          @max_x ||= window[:width] - 10
+          @max_x ||= window[:width] - 2
         end
       end
     end

--- a/calabash-cucumber/spec/lib/automator/coordinates_spec.rb
+++ b/calabash-cucumber/spec/lib/automator/coordinates_spec.rb
@@ -430,7 +430,7 @@ describe Calabash::Cucumber::Automator::Coordinates do
       expect(coordinates).to receive(:window).and_return({:width => 100})
 
       actual = coordinates.send(:max_x)
-      expect(actual).to be == 90
+      expect(actual).to be == 98
       expect(coordinates.instance_variable_get(:@max_x)).to be == actual
     end
   end


### PR DESCRIPTION
### Motivation

* Full screen pans on iPads are flickering because start coordinate is not close enough to the edge [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/16894)

Sadly, this does not fix full screen pans on iPad Pro 12".

### Tests

* https://testcloud.xamarin.com/test/calsmoke-cal_8ed8aed5-a23f-4d80-86a9-c8b3455de55d/