### PR TITLE
Use correct query for navigation bar with title on iOS 11

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/ibase.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/ibase.rb
@@ -74,7 +74,7 @@ class Calabash::IBase
   def trait
     raise "You should define a trait method or a title method" unless respond_to?(:title)
     if ios_gte_11?
-      "view:'_UINavigationItemView' label marked:'#{self.title}'"
+      "UINavigationBar marked:'#{self.title}'"
     else
       "navigationItemView marked:'#{self.title}'"
     end


### PR DESCRIPTION
The query changed after the iOS 11 GM. See the discussion on pull request for release 0.21.1 
https://github.com/calabash/calabash-ios/pull/1331#discussion_r140470253