### PR TITLE
Updated XCUIElementType documentation

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/device_agent.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/device_agent.rb
@@ -130,7 +130,7 @@ module Calabash
       # ]
       # ```
       #
-      # @see http://masilotti.com/xctest-documentation/Constants/XCUIElementType.html
+      # @see https://developer.apple.com/documentation/xctest/xcuielementtype
       # @param [Hash] uiquery A hash describing the query.
       # @return [Array<Hash>] An array of elements matching the `uiquery`.
       def query(uiquery)


### PR DESCRIPTION
The previous URL is 404ing now as the owner got a cease and desist from Apple. Apple now have official documentation on XCTest.