### PR TITLE
Feature/pin cucumber to 2.x

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |s|
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
   s.add_dependency("clipboard", "~> 1.0")
-  s.add_dependency("run_loop", ">= 2.6.1", "< 3.0")
+  s.add_dependency("run_loop", ">= 2.6.2", "< 3.0")
 
   # Shared with run-loop.
   s.add_dependency('json')

--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency("cucumber")
+  s.add_dependency("cucumber", "~> 2.0")
   # Avoid 1.0.5 release; has an errant 'binding.pry'.
   s.add_dependency('edn', '>= 1.0.6', '< 2.0')
   s.add_dependency('slowhandcuke', '~> 0.0.3')


### PR DESCRIPTION
### Motivation

Test Cloud is not ready for cucumber 3.0.

Completes:

* Calabash iOS: pin cucumber to 2.x [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/29370)
