### PR TITLE
Do not bind Calabash to any versions of Cucumber

### DIFF
--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency("cucumber", "~> 2.0")
+  s.add_dependency('cucumber')
   # Avoid 1.0.5 release; has an errant 'binding.pry'.
   s.add_dependency('edn', '>= 1.0.6', '< 2.0')
   s.add_dependency('slowhandcuke', '~> 0.0.3')


### PR DESCRIPTION
The version is quite outdated, in this way users are able to decide which version they want to use.