### PR TITLE
gem: calabash-ios binary does not need CFPropertyList

### DIFF
--- a/calabash-cucumber/bin/calabash-ios
+++ b/calabash-cucumber/bin/calabash-ios
@@ -1,9 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'fileutils'
-require 'cfpropertylist'
 require 'rexml/document'
-
 
 require File.join(File.dirname(__FILE__),"calabash-ios-helpers")
 require File.join(File.dirname(__FILE__),"calabash-ios-generate")

--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |s|
   # Match the xamarin-test-cloud dependency.
   s.add_dependency('bundler', '~> 1.3')
   s.add_dependency("clipboard", "~> 1.0")
-  s.add_dependency("run_loop", ">= 4.0", "< 5.0")
+  s.add_dependency("run_loop", ">= 4.1", "< 5.0")
 
   # Shared with run-loop.
   s.add_dependency('json')


### PR DESCRIPTION
### Motivation

run-loop 4.1.0 removed the CFPropertyList dependency.

calabash-ios had a hidden dependency on CFPropertyList in its bin/calabash-ios file.

This causes the calabash-ios binary to raise an LoadError.

