### PR TITLE
Workaround for cases when simulator stuck on boot

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/core.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/core.rb
@@ -1861,7 +1861,7 @@ this method.
           # quitting the simulator will make the next test stable
           if simulator?
             require "run_loop"
-            calabash_warn('Simulator seems to be stuck. Quitting the somulator app..')
+            calabash_warn('Simulator seems to be stuck. Quitting the simulator app..')
             RunLoop::CoreSimulator.quit_simulator
           end
 


### PR DESCRIPTION
We've noticed that sometimes iOS simulators stuck on boot (either progress bar or the Apple logo). 

These cases are quite expensive when you run several tests in a row (especially for CI), as Calabash seems to not being able to detect this state and it takes a lot of time to start a new test. 

The workaround is that Simulator will quit as soon as this situation happens, so the next test will not try to use "broken" simulator blindly but start the Simulator process again.