### PR TITLE
Release/0.21.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 0.21.9
+
+Remove bundler as a dependency.
+
+The embedded LPServer was build with Xcode 10.2 on macOS Mojave.
+
+The server version is 0.21.8 (not a typo), it is just trailing behind
+the gem version.
+
 ### 0.21.8
 
 * gem: calabash-ios binary does not need CFPropertyList #1400

--- a/Calabash.podspec
+++ b/Calabash.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'Calabash'
-  s.version      = '0.21.7'
+  s.version      = '0.21.8'
   s.license      = { :type => 'Eclipse Public License 1.0', :text => <<-LICENSE
     Calabash-ios Copyright (2016) Xamarin. All rights reserved.
     The use and distribution terms for this software are covered by the

--- a/calabash-cucumber/calabash-cucumber.gemspec
+++ b/calabash-cucumber/calabash-cucumber.gemspec
@@ -56,10 +56,8 @@ Gem::Specification.new do |s|
   s.add_dependency('slowhandcuke', '~> 0.0.3')
   s.add_dependency('geocoder', '>= 1.1.8', '< 2.0')
   s.add_dependency('httpclient', '>= 2.7.1', '< 3.0')
-  # Match the xamarin-test-cloud dependency.
-  s.add_dependency('bundler', '~> 1.3')
   s.add_dependency("clipboard", "~> 1.0")
-  s.add_dependency("run_loop", ">= 4.1", "< 5.0")
+  s.add_dependency("run_loop", ">= 4.2", "< 5.0")
 
   # Shared with run-loop.
   s.add_dependency('json')

--- a/calabash-cucumber/lib/calabash-cucumber/version.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/version.rb
@@ -3,7 +3,7 @@ module Calabash
 
     # @!visibility public
     # The Calabash iOS gem version.
-    VERSION = "0.21.8"
+    VERSION = "0.21.9"
 
     # @!visibility public
     # The minimum required version of the Calabash embedded server.


### PR DESCRIPTION
### 0.21.9

Remove bundler as a dependency.

The embedded LPServer was build with Xcode 10.2 on macOS Mojave.

The server version is 0.21.8 (not a typo), it is just trailing behind the gem version.
