### PR TITLE
Rename Calabash.keychain to TestCloudDev.keychain

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/dot_dir.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/dot_dir.rb
@@ -1,13 +1,13 @@
 module Calabash
   module Cucumber
-    # A module for managing the ~/.calabash directory.
+    # A module for managing the ~/.test-cloud-dev directory.
     module DotDir
       require "run_loop"
 
       # @!visibility private
       def self.directory
         home = RunLoop::Environment.user_home_directory
-        dir = File.join(home, ".calabash")
+        dir = File.join(home, ".test-cloud-dev")
         if !File.exist?(dir)
           FileUtils.mkdir_p(dir)
         end

--- a/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/store/preferences.rb
@@ -7,7 +7,7 @@ module Calabash
 
     # Users preferences persisted across runs:
     #
-    # ~/.calabash/preferences/preferences.json
+    # ~/.test-cloud-dev/preferences/preferences.json
     class Preferences
       require "calabash-cucumber/dot_dir"
 

--- a/calabash-cucumber/spec/lib/dot_dir_spec.rb
+++ b/calabash-cucumber/spec/lib/dot_dir_spec.rb
@@ -1,7 +1,7 @@
 describe Calabash::Cucumber::DotDir do
 
   let(:home_dir) { "./tmp/dot-calabash-examples" }
-  let(:dot_dir) { File.join(home_dir, ".calabash") }
+  let(:dot_dir) { File.join(home_dir, ".test-cloud-dev") }
 
   before do
     allow(RunLoop::Environment).to receive(:user_home_directory).and_return home_dir

--- a/calabash-cucumber/test/cucumber/config/cucumber.yml
+++ b/calabash-cucumber/test/cucumber/config/cucumber.yml
@@ -5,7 +5,7 @@ require "run_loop"
 SIM_APP = File.join("aut", "sim", "TestApp.app")
 DEVICE_APP = File.join("aut", "device", "TestApp.app")
 
-calabash_dir = File.expand_path(File.join(ENV["HOME"], ".calabash"))
+calabash_dir = File.expand_path(File.join(ENV["HOME"], ".test-cloud-dev"))
 
 devices = {}
 


### PR DESCRIPTION
[User Story 63322: rename calabash-codesign and Calabash.key to TestCloudDev.keychain](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/63322)