### PR TITLE
Add compatibility with the latest irb

### DIFF
--- a/calabash-cucumber/.irbrc
+++ b/calabash-cucumber/.irbrc
@@ -29,8 +29,8 @@ IRB.conf[:PROMPT_MODE] = :CALABASH_IOS
 
 begin
   require 'pry'
-  Pry.config.history.should_save = false
-  Pry.config.history.should_load = false
+  Pry.config.history_save = true
+  Pry.config.history_load = true
   require 'pry-nav'
 rescue LoadError => _
 

--- a/calabash-cucumber/.irbrc
+++ b/calabash-cucumber/.irbrc
@@ -29,8 +29,8 @@ IRB.conf[:PROMPT_MODE] = :CALABASH_IOS
 
 begin
   require 'pry'
-  Pry.config.history_save = true
-  Pry.config.history_load = true
+  Pry.config.history_save = false
+  Pry.config.history_load = false
   require 'pry-nav'
 rescue LoadError => _
 

--- a/calabash-cucumber/scripts/.irbrc
+++ b/calabash-cucumber/scripts/.irbrc
@@ -34,9 +34,9 @@ IRB.conf[:HISTORY_FILE] = ".irb-history"
 
 begin
   require "pry"
-  Pry.config.history.should_save = true
-  Pry.config.history.should_load = true
-  Pry.config.history.file = ".pry-history"
+  Pry.config.history_save = true
+  Pry.config.history_load = true
+  Pry.config.history_file = ".pry-history"
   require "pry-nav"
 rescue LoadError => _
 


### PR DESCRIPTION
As per documentation, the configuration of history has changed, and now we should use Pry.config.history_save https://github.com/pry/pry/wiki/Customization-and-configuration#history 