### PR TITLE
Cucumber 6.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.23.0
+
+* Support for Cucumber 6
+
 ### 0.21.10
 
 Remove bundler as a dependency.

--- a/calabash-cucumber/lib/calabash-cucumber/failure_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/failure_helpers.rb
@@ -52,7 +52,11 @@ module Calabash
         path = screenshot(options)
         filename = options[:label] || File.basename(path)
         if self.respond_to?(:embed)
-          embed(path, 'image/png', filename)
+          begin
+            embed(path, 'image/png', filename)
+          rescue NoMethodError
+            attach(path, 'image/png')
+          end
         else
           RunLoop.log_info2("Embed is not available in this context. Will not embed.")
         end

--- a/calabash-cucumber/lib/calabash-cucumber/wait_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/wait_helpers.rb
@@ -433,7 +433,12 @@ module Calabash
           FileUtils.rm_f(path)
           return res
         else
-          embed(path, 'image/png', msg)
+          begin
+            embed(path, 'image/png', msg)
+          rescue NoMethodError
+            attach(path, 'image/png')
+          end
+
           raise wait_error(msg)
         end
       end


### PR DESCRIPTION
`embed` is not available since cucumber 5, this PR will make sure the attach is called in cases embed is not available