### PR TITLE
Use environment 'WAIT_TIMEOUT' or DEFAULT_OPTS[:timeout] as default timeouts for wait_helpers.rb conditions

### DIFF
--- a/calabash-cucumber/lib/calabash-cucumber/wait_helpers.rb
+++ b/calabash-cucumber/lib/calabash-cucumber/wait_helpers.rb
@@ -132,7 +132,7 @@ module Calabash
         end
 
         begin
-          Timeout::timeout(timeout, WaitError) do
+          Timeout.timeout(timeout, WaitError) do
             sleep(retry_frequency) until yield
           end
           sleep(post_timeout) if post_timeout > 0
@@ -274,10 +274,9 @@ module Calabash
 
       # @!visibility private
       def wait_for_condition(options = {})
-        timeout = options[:timeout]
-        unless timeout && timeout > 0
-          timeout = 30
-        end
+        timeout = options[:timeout] || ENV['WAIT_TIMEOUT']
+        timeout = DEFAULT_OPTS[:timeout] unless timeout && timeout > 0
+
         options[:query] = options[:query] || '*'
         if options.has_key?(:condition)
           opt_condition = options[:condition]
@@ -299,7 +298,7 @@ module Calabash
         end
 
         begin
-          Timeout::timeout(timeout+CLIENT_TIMEOUT_ADDITION, WaitError) do
+          Timeout.timeout(timeout + CLIENT_TIMEOUT_ADDITION, WaitError) do
             res = http({:method => :post, :path => 'condition'},
                        options)
             res = JSON.parse(res)

--- a/calabash-cucumber/spec/lib/wait_helpers_spec.rb
+++ b/calabash-cucumber/spec/lib/wait_helpers_spec.rb
@@ -61,11 +61,32 @@ describe Calabash::Cucumber::WaitHelpers do
   end
 
   describe '.wait_for_condition' do
-    it 'rescues StandardError' do
-      expect(world).to receive(:http).and_raise(StandardError, 'I got raised!')
-      expect {
-        world.wait_for_condition({screenshot_on_error: false})
-      }.to raise_error(StandardError, 'I got raised!')
+    subject { world.wait_for_condition({ screenshot_on_error: false, timeout: }) }
+
+    context 'when no timeout parameter is provided' do
+      let(:timeout) { nil }
+
+      before do
+        expect(Timeout).to receive(:timeout).with(35, described_class::WaitError).and_call_original
+      end
+
+      it 'rescues StandardError' do
+        expect(world).to receive(:http).and_raise(StandardError, 'I got raised!')
+        expect { subject }.to raise_error(StandardError, 'I got raised!')
+      end
+    end
+
+    context 'when a timeout parameter is provided' do
+      let(:timeout) { 10 }
+
+      before do
+        expect(Timeout).to receive(:timeout).with(15, described_class::WaitError).and_call_original
+      end
+
+      it 'rescues StandardError' do
+        expect(world).to receive(:http).and_raise(StandardError, 'I got raised!')
+        expect { subject }.to raise_error(StandardError, 'I got raised!')
+      end
     end
   end
 


### PR DESCRIPTION
Start to use `WAIT_TIMEOUT` environment to decide how long to wait for `Calabash::Cucumber::WaitHelpers.wait_for_condition` (used from `wait_for_none_animating` / `wait_for_no_network_indicator` / `wait_for_transition`

It might be needed to clarify if a warning for whos already using such environment (already mentioned in https://github.com/calabash/calabash-ios/blob/master/calabash-cucumber/ENVIRONMENT_VARIABLES.md) is needed